### PR TITLE
Store data in /var/lib/waydroid rather than /home/.waydroid

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -38,7 +38,7 @@ session_config_keys = ["user_name",
 # overridden on the commandline)
 defaults = {
     "arch": "arm64",
-    "work": "/home/.waydroid",
+    "work": "/var/lib/waydroid",
     "vendor_type": "MAINLINE",
     "system_datetime": "0",
     "vendor_datetime": "0",


### PR DESCRIPTION
There should be nothing in `/home` other than user home directories. `.waydroid` is not a user home directory, so shouldn't be there.

The right location for system services to write and read data from is `/var/lib/<application name>`. Waydroid is (partially) a system service, so it should write it's stuff there. As far as I understand Ubuntu Touch has various directories in `/var/lib` writeable, and if they want Waydroid they should make `/var/lib/waydroid` writeable too.

This way Waydroid works like it should on _all_ distros and it isn't weird everywhere just because of Ubuntu Touch :stuck_out_tongue_winking_eye: 