### PR TITLE
support for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+.envrc
+.direnv
 .env
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ The Android runtime environment ships with a minimal customized Android system
 image based on the [LineageOS](https://lineageos.org/).
 The used image is currently based on Android 10
 
+## Development
+
+On Ubuntu:
+
+```sh
+sudo apt install gcc libgirepository1.0-dev libcairo-dev python3-venv
+python3 -m venv <path-to-venv>
+<path-to-venv>/bin/activate
+pip install -e .
+```
+
+
 ## Install and Run Android Applications
 
 You can install Android applications from the command line.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,105 @@
+[metadata]
+name = waydroid
+version = attr: tools.config.__init__.version
+description="Container-based approach to boot a full Android system"
+long_description = file: README.md
+url = https://github.com/waydroid/waydroid
+project_urls =
+    Documentation = https://link.to.documentation.missing
+    Source = https://github.com/waydroid/waydroid.git
+    Issues = https://github.com/waydroid/waydroid/issues
+author = Oliver Smith
+author_email = noreply@oliver.smith.placeholder
+license = GNU General Public License v3 or later (GPLv3)
+license_file = LICENSE
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3)
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+python_requires = >= 3.8
+include_package_data = True
+packages = find:
+zip_safe = False
+install_requires =
+    requests
+    PyGObject
+
+[options.entry_points]
+console_scripts =
+    waydroid = tools:main
+
+[options.package_data]
+tools = py.typed
+
+[options.extras_require]
+release =
+    twine
+    wheel
+test =
+    coverage
+    black
+    codespell
+    flake8
+    isort
+    mypy
+    pydocstyle
+    pylint
+    pylint-fixme-info
+    pylint-pytest
+    pytest
+    pytest-mock
+    pytest-subprocess
+    tox
+    types-requests
+    types-setuptools
+dev =
+    autoflake
+    %(release)s
+    %(test)s
+
+[options.packages.find]
+exclude =
+    tests
+    tests.*
+
+[bdist_wheel]
+universal = 1
+
+[codespell]
+quiet-level = 3
+skip = ./docs/_build,.direnv,.git,.mypy_cache,.pytest_cache,.venv,__pycache__,venv
+
+[flake8]
+exclude = .direnv .git .mypy_cache .pytest_cache .venv __pycache__ venv
+max-line-length = 88
+# E501 line too long
+extend-ignore = E501
+
+[mypy]
+python_version = 3.8
+plugins = pydantic.mypy
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True
+
+[pydocstyle]
+# D105 Missing docstring in magic method (reason: magic methods already have definitions)
+# D107 Missing docstring in __init__ (reason: documented in class docstring)
+# D203 1 blank line required before class docstring (reason: pep257 default)
+# D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
+# D215 Section underline is over-indented (reason: pep257 default)
+ignore = D105, D107, D203, D213, D215
+
+[aliases]
+test = pytest
+
+[tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+"""The setup script."""
+
+from setuptools import setup
+
+
+setup()


### PR DESCRIPTION
Minimal setup.py and batteries included setup.cfg provided (with
linting and type checks ready for use). The "waydroid" executable is
created through an entry point (this could replace what is done in the
debian package).

Some information in setup.cfg is stubbed, I thought I would leave it
there for review, there might be proper emails or documentation links
to use in a follow up commit.

The README.md has been updated to include minimal setup instructions
for development.

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>