### PR TITLE
debian: Add LXC as dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Package: waydroid
 Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
+         lxc,
          python3-gbinder,
          python3-gi
 Description: Android™ application support


### PR DESCRIPTION
Otherwise an error appears:

`[14:49:51] Extracting to /var/lib/waydroid/images
[14:49:54] ERROR: LXC is not installed
[14:49:54] See also: <https://github.com/waydroid>`