### PR TITLE
lxc: do prepend colon to Android PATHs in shell

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -277,7 +277,7 @@ def shell(args):
         command.append(args.COMMAND)
     else:
         command.append("/system/bin/sh")
-    subprocess.run(command, env={"PATH": os.environ['PATH'] + "/system/bin:/vendor/bin"})
+    subprocess.run(command, env={"PATH": os.environ['PATH'] + ":/system/bin:/vendor/bin"})
 
 def logcat(args):
     if status(args) != "RUNNING":


### PR DESCRIPTION
There is no guarantee that `PATH` ends with a colon, so we need to add one between the old `$PATH` and the parts we want to append.