### PR TITLE
upgrade: log that no we will not upgrade if a preinstalled image exists

### DIFF
--- a/tools/actions/upgrader.py
+++ b/tools/actions/upgrader.py
@@ -25,8 +25,11 @@ def upgrade(args):
     helpers.images.umount_rootfs(args)
     helpers.drivers.loadBinderNodes(args)
     if not args.offline:
-        if args.images_path != tools.config.defaults["preinstalled_images_path"]:
+        preinstalled_images_path = tools.config.defaults["preinstalled_images_path"]
+        if args.images_path != preinstalled_images_path:
             helpers.images.get(args)
+        else:
+            logging.info("Upgrade refused because a pre-installed image is detected at {}.".format(preinstalled_images_path))
     helpers.lxc.setup_host_perms(args)
     helpers.lxc.set_lxc_config(args)
     helpers.lxc.make_base_props(args)


### PR DESCRIPTION
Currently if a user have a custom image (like from aur) and runs waydroid upgrade he will get no output and think that there is no new version.

This pr add a friendly message to inform him.