### PR TITLE
Count tries of get_service and let user prematurely interrupt

### DIFF
--- a/tools/interfaces/IPlatform.py
+++ b/tools/interfaces/IPlatform.py
@@ -283,7 +283,7 @@ def get_service(args):
     while(not remote):
         if tries > 0:
             logging.warning(
-                "Failed to get service {}, trying again (try #{})...".format(SERVICE_NAME, timestoattempt - tries + 1))
+                "Failed to get service {}, trying again (try #{}/{})...".format(SERVICE_NAME, timestoattempt - tries + 1, timestoattempt))
             try:
                 time.sleep(1)
             except KeyboardInterrupt:

--- a/tools/interfaces/IPlatform.py
+++ b/tools/interfaces/IPlatform.py
@@ -277,13 +277,17 @@ def get_service(args):
     helpers.drivers.loadBinderNodes(args)
     serviceManager = gbinder.ServiceManager("/dev/" + args.BINDER_DRIVER)
     tries = 1000
+    timestoattempt = tries
 
     remote, status = serviceManager.get_service_sync(SERVICE_NAME)
     while(not remote):
         if tries > 0:
             logging.warning(
-                "Failed to get service {}, trying again...".format(SERVICE_NAME))
-            time.sleep(1)
+                "Failed to get service {}, trying again (try #{})...".format(SERVICE_NAME, timestoattempt - tries + 1))
+            try:
+                time.sleep(1)
+            except KeyboardInterrupt:
+                return None
             remote, status = serviceManager.get_service_sync(SERVICE_NAME)
             tries = tries - 1
         else:


### PR DESCRIPTION
I'm not familiar with waydroid's code so please excuse me if this is a sucky contribution.

I'm having an issue where the `Failed to get service {}, trying again...` message keeps re-appearing, but when I CTRL+C I get a long traceback so it makes it hard to see the original error message. It'd be nice to be able to cancel that retry loop because a thousand tries is a long time to wait for it to fail.

It'd also be nice to see how many times it's tried.

I have not tested this code.