### PR TITLE
Container: strip possible trailing newline from pid

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -206,7 +206,7 @@ def stop(args):
         # Sensors
         if which("waydroid-sensord"):
             command = ["pidof", "waydroid-sensord"]
-            pid = tools.helpers.run.user(args, command, check=False, output_return=True)
+            pid = tools.helpers.run.user(args, command, check=False, output_return=True).strip()
             if pid:
                 command = ["kill", "-9", pid]
                 tools.helpers.run.user(args, command, check=False)


### PR DESCRIPTION
Turned out that PID as returned by `tools.helpers.run.user` running `pidof` has a newline in the end of the string. As a result, 

```python
        if which("waydroid-sensord"):
            command = ["pidof", "waydroid-sensord"]
            pid = tools.helpers.run.user(args, command, check=False, output_return=True)
            if pid:
                command = ["kill", "-9", pid]
                tools.helpers.run.user(args, command, check=False)
```

was failing (from https://github.com/waydroid/waydroid/blob/bullseye/tools/actions/container_manager.py#L207) and leaving sensord behind. This PR fixes it.

Fixes #185