### PR TITLE
lxc.py: Detect usage of VM and set correct gralloc value

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -9,6 +9,7 @@ import shutil
 import platform
 import tools.config
 import tools.helpers.run
+from py_vmdetect import VMDetect
 
 
 def get_lxc_version(args):
@@ -168,11 +169,15 @@ def make_base_props(args):
     props = []
     egl = tools.helpers.props.host_get(args, "ro.hardware.egl")
 
+    vmd = VMDetect()
     gralloc = find_hal("gralloc")
     if gralloc == "":
         if os.path.exists("/dev/dri"):
-            gralloc = "gbm"
             egl = "mesa"
+            if vmd.is_vm():
+                gralloc = "default"
+            else:
+                gralloc = "gbm"
         else:
             gralloc = "default"
             egl = "swiftshader"


### PR DESCRIPTION
When using Qemu/VirtualBox, gralloc is set to "gbm" while it should be "default". Add py_vmdetect to detect if we're running in a virtual machine and set gralloc accordingly.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>