### PR TITLE
Add an optional [properties] in waydroid.cfg

### DIFF
--- a/tools/config/load.py
+++ b/tools/config/load.py
@@ -26,6 +26,10 @@ def load(args):
                           " default value from config: {}".format(cfg['waydroid'][key]))
             del cfg["waydroid"][key]
 
+    if "properties" not in cfg:
+        cfg["properties"] = {}
+    # no default values for property override
+
     return cfg
 
 def load_session():

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -240,6 +240,14 @@ def make_base_props(args):
     if prop_fp != "":
         props.append("ro.build.fingerprint=" + prop_fp)
 
+    # now append/override with values in [properties] section of waydroid.cfg
+    cfg = tools.config.load(args)
+    for k, v in cfg["properties"].items():
+        for idx, elem in enumerate(props):
+            if (k+"=") in elem:
+                props.pop(idx)
+        props.append(k+"="+v)
+
     base_props = open(args.work + "/waydroid_base.prop", "w")
     for prop in props:
         base_props.write(prop + "\n")


### PR DESCRIPTION
On some platforms, like a VM, we don't have the "getprop" android
utility available. It could be, also, that the default values
for some properties don't match the target device.

With this PR, one can add a [properties] section in waydroid.cfg,
that will act as an override for the values put by waydroid.

Example, on our LuneOS x86 VM:
[properties]
ro.hardware.gralloc=default
ro.hardware.egl=mesa

A minimal waydroid.cfg could even be shipped with waydroid, and
the rest of the configuration will be filled with "waydroid init".

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>