### PR TITLE
lxc: Optionally bind-mount NFC config

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -118,6 +118,9 @@ def generate_nodes_lxc_config(args):
     for n in glob.glob("/tmp/run-*"):
         make_entry(n, options="rbind,create=dir,optional 0 0")
 
+    # NFC config
+    make_entry("/system/etc/libnfc-nci.conf", options="bind,optional 0 0")
+
     return nodes
 
 


### PR DESCRIPTION
- Devices with libnfc-nci might have their NFC HAL crash when
  the config doesn't exist or contains invalid data. Fix it.

Fixes NFC HAL crashing on UT on the Pixel 3a.