### PR TITLE
Create .desktop files for system apps with "NoDisplay=true"

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -34,11 +34,13 @@ def start(args, unlocked_cb=None):
         packageName = appInfo["packageName"]
 
         desktop_file_path = args.apps_dir + "/waydroid." + packageName + ".desktop"
-        if not os.path.exists(desktop_file_path) and not packageName in system_apps:
+        if not os.path.exists(desktop_file_path):
             lines = ["[Desktop Entry]", "Type=Application"]
             lines.append("Name=" + appInfo["name"])
             lines.append("Exec=waydroid app launch " + packageName)
             lines.append("Icon=" + args.waydroid_data + "/icons/" + packageName + ".png")
+            if packageName in system_apps:
+                lines.append("NoDisplay=true")
             desktop_file = open(desktop_file_path, "w")
             for line in lines:
                 desktop_file.write(line + "\n")

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -9,6 +9,19 @@ from tools.interfaces import IPlatform
 
 
 def start(args, unlocked_cb=None):
+    system_apps = [
+        "com.android.calculator2",
+        "com.android.documentsui",
+        "com.android.settings",
+        "org.lineageos.jelly",
+        "com.android.contacts",
+        "com.android.email",
+        "org.lineageos.eleven",
+        "org.lineageos.recorder",
+        "com.android.deskclock",
+        "com.android.gallery3d",
+        "org.lineageos.etar"
+    ]
 
     def makeDesktopFile(appInfo):
         showApp = False
@@ -21,7 +34,7 @@ def start(args, unlocked_cb=None):
         packageName = appInfo["packageName"]
 
         desktop_file_path = args.apps_dir + "/waydroid." + packageName + ".desktop"
-        if not os.path.exists(desktop_file_path):
+        if not os.path.exists(desktop_file_path) and not packageName in system_apps:
             lines = ["[Desktop Entry]", "Type=Application"]
             lines.append("Name=" + appInfo["name"])
             lines.append("Exec=waydroid app launch " + packageName)

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -20,7 +20,10 @@ def start(args, unlocked_cb=None):
         "org.lineageos.recorder",
         "com.android.deskclock",
         "com.android.gallery3d",
-        "org.lineageos.etar"
+        "org.lineageos.etar",
+        "com.android.camera2",
+        "com.android.inputmethod.latin",
+        "com.google.android.gms"
     ]
 
     def makeDesktopFile(appInfo):

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -11,19 +11,19 @@ from tools.interfaces import IPlatform
 def start(args, unlocked_cb=None):
     system_apps = [
         "com.android.calculator2",
-        "com.android.documentsui",
-        "com.android.settings",
-        "org.lineageos.jelly",
-        "com.android.contacts",
-        "com.android.email",
-        "org.lineageos.eleven",
-        "org.lineageos.recorder",
-        "com.android.deskclock",
-        "com.android.gallery3d",
-        "org.lineageos.etar",
         "com.android.camera2",
+        "com.android.contacts",
+        "com.android.deskclock",
+        "com.android.documentsui",
+        "com.android.email",
+        "com.android.gallery3d",
         "com.android.inputmethod.latin",
-        "com.google.android.gms"
+        "com.android.settings",
+        "com.google.android.gms",
+        "org.lineageos.eleven",
+        "org.lineageos.etar",
+        "org.lineageos.jelly",
+        "org.lineageos.recorder"
     ]
 
     def makeDesktopFile(appInfo):


### PR DESCRIPTION
see #46

This approach blacklists the default system apps which should be sufficient for the vast majority of use cases. If required, it can be extended in future PRs to have a configurable blacklist.