### PR TITLE
Allows waydroid to create PTY

### DIFF
--- a/data/configs/config_1
+++ b/data/configs/config_1
@@ -19,6 +19,7 @@ lxc.network.hwaddr = 00:16:3e:f9:d3:03
 lxc.network.mtu = 1500
 
 lxc.console.path = none
+lxc.pty.max = 10
 
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_nodes
 

--- a/data/configs/config_2
+++ b/data/configs/config_2
@@ -19,7 +19,7 @@ lxc.net.0.hwaddr = 00:16:3e:f9:d3:03
 lxc.net.0.mtu = 1500
 
 lxc.console.path = none
-xc.pty.max = 10
+lxc.pty.max = 10
 
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_nodes
 

--- a/data/configs/config_2
+++ b/data/configs/config_2
@@ -19,6 +19,7 @@ lxc.net.0.hwaddr = 00:16:3e:f9:d3:03
 lxc.net.0.mtu = 1500
 
 lxc.console.path = none
+xc.pty.max = 10
 
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_nodes
 


### PR DESCRIPTION
doing this will allows LXC to create their own PTY instead of mounting host, this should be more secure then mounting /dev/pty 

addresses 

#145 #238 