### PR TITLE
Wait for init

### DIFF
--- a/debian/waydroid-container.service
+++ b/debian/waydroid-container.service
@@ -2,7 +2,7 @@
 Description=Waydroid Container
 
 [Service]
-ExecStart=/usr/bin/waydroid container start
+ExecStart=/usr/bin/waydroid -w container start
 ExecStop=/usr/bin/waydroid container stop
 ExecStopPost=/usr/bin/waydroid session stop
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -31,10 +31,16 @@ def main():
         args.sudo_timer = True
         args.timeout = 1800
 
-        if not os.path.isfile(args.config):
+        if not actions.initializer.is_initialized(args):
             if args.action and (args.action != "init" and args.action != "log"):
-                print('ERROR: WayDroid is not initialized, run "waydroid init"')
-                return 0
+                if not args.wait_for_init:
+                    print('ERROR: WayDroid is not initialized, run "waydroid init"')
+                    return 0
+
+                print('WayDroid waiting for initialization...')
+                while helpers.ipc.listen(channel="init") != "done":
+                    pass
+
             elif os.geteuid() == 0 and args.action == "init":
                 if not os.path.exists(args.work):
                     os.mkdir(args.work)

--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -5,6 +5,8 @@ import os
 from tools import helpers
 import tools.config
 
+def is_initialized(args):
+    return os.path.isfile(args.config) and os.path.isdir(tools.config.defaults["rootfs"])
 
 def get_vendor_type(args):
     vndk_str = helpers.props.host_get(args, "ro.vndk.version")
@@ -81,7 +83,7 @@ def setup_config(args):
     tools.config.save(args, cfg)
 
 def init(args):
-    if not os.path.isfile(args.config) or not os.path.isdir(tools.config.defaults["rootfs"]) or args.force:
+    if not is_initialized(args) or args.force:
         setup_config(args)
         status = "STOPPED"
         if os.path.exists(tools.config.defaults["lxc"] + "/waydroid"):
@@ -101,5 +103,7 @@ def init(args):
             logging.info("Starting container")
             helpers.images.mount_rootfs(args, args.images_path)
             helpers.lxc.start(args)
+
+        helpers.ipc.notify(channel="init", msg="done")
     else:
         logging.info("Already initialized")

--- a/tools/helpers/__init__.py
+++ b/tools/helpers/__init__.py
@@ -8,3 +8,4 @@ import tools.helpers.images
 import tools.helpers.drivers
 import tools.helpers.mount
 import tools.helpers.http
+import tools.helpers.ipc

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -129,6 +129,8 @@ def arguments():
                         " logfiles (this may reduce performance)")
     parser.add_argument("-q", "--quiet", dest="quiet", action="store_true",
                         help="do not output any log messages")
+    parser.add_argument("-w", "--wait", dest="wait_for_init", action="store_true",
+                        help="wait for init before running")
 
     # Actions
     sub = parser.add_subparsers(title="action", dest="action")

--- a/tools/helpers/ipc.py
+++ b/tools/helpers/ipc.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Alessandro Astone
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Currently implemented as FIFO
+import os
+
+BASE_DIR = "/var/run/"
+
+def listen(channel):
+    pipe = BASE_DIR + "waydroid-" + channel
+    if not os.path.exists(pipe):
+        os.mkfifo(pipe)
+    with open(pipe) as fifo:
+        while True:
+            data = fifo.read()
+            if len(data) != 0:
+                return data
+
+def notify(channel, msg):
+    pipe = BASE_DIR + "waydroid-" + channel
+    try:
+        fd = os.open(pipe, os.O_WRONLY | os.O_NONBLOCK)
+        with os.fdopen(fd, "w") as fifo:
+            fifo.write(msg)
+    except Exception:
+        pass


### PR DESCRIPTION
In the interest of simplifying the installation of waydroid, make it possible to start the container manager before running init.
The intended usecase is to have waydroid-container automatically enabled and started on install. This was previously impossible because the service would immediatly stop because waydroid was not initialized.