### PR TITLE
add checklist to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,13 @@ assignees: ''
 
 ---
 
+**Please check steps before reporting a bug**
+Put an `x` in all that apply like this `[x]`
+
+- [ ] I have verified I am running wayland
+- [ ] I have read the docs before creating this issue at https://docs.waydro.id/
+- [ ] My issue is unique enough for it's own bug report even if duplicates seem to exist
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
This should allow anyone helping with an issue assume that the person creating the issue has checked for duplicates, has read the docs, and is infact using wayland. any issues created missing one of these checks should have a good reason for doing so, or just close the ticket