### PR TITLE
Update Matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ If you have found an issue with Waydroid, please [file a bug](https://github.com
 ## Get in Touch
 
 If you want to get in contact with the developers please feel free to join the
-*Waydroid* groups in [Matrix](https://matrix.to/#/#waydroid:connolly.tech) or [Telegram](https://t.me/WayDroid).
+*Waydroid* groups in [Matrix](https://matrix.to/#/#waydroid:mrcyjanek.net) or [Telegram](https://t.me/WayDroid).


### PR DESCRIPTION
The old room address no longer works. Use new one as listed in waydro.id