### PR TITLE
Add Android Market Protocol Handler

### DIFF
--- a/data/waydroid.market.desktop
+++ b/data/waydroid.market.desktop
@@ -1,9 +1,12 @@
 [Desktop Entry]
-Name=Waydroid - Android Market Protocol Handler
+Name=Waydroid Market
+Comment=Android Market Protocol Handler
 Exec=echo "am start -a android.intent.action.VIEW -d %u" | pkexec waydroid shell
 Icon=/usr/lib/waydroid/data/AppIcon.png
 Type=Application
+Encoding=UTF-8
 Terminal=false
 NoDisplay=true
 Categories=Utility;
 MimeType=x-scheme-handler/market;
+X-KDE-Protocols=market;

--- a/data/waydroid.market.desktop
+++ b/data/waydroid.market.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Waydroid - Android Market Protocol Handler
+Exec=echo "am start -a android.intent.action.VIEW -d %u" | pkexec waydroid shell
+Icon=/usr/lib/waydroid/data/AppIcon.png
+Type=Application
+Terminal=false
+NoDisplay=true
+Categories=Utility;
+MimeType=x-scheme-handler/market;

--- a/data/waydroid.market.desktop
+++ b/data/waydroid.market.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Waydroid Market
 Comment=Android Market Protocol Handler
-Exec=echo "am start -a android.intent.action.VIEW -d %u" | pkexec waydroid shell
+Exec=waydroid app intent android.intent.action.VIEW -d %u
 Icon=/usr/lib/waydroid/data/AppIcon.png
 Type=Application
 Encoding=UTF-8

--- a/debian/waydroid.links
+++ b/debian/waydroid.links
@@ -1,2 +1,3 @@
 /usr/lib/waydroid/waydroid.py /usr/bin/waydroid
 /usr/lib/waydroid/data/Waydroid.desktop /usr/share/applications/Waydroid.desktop
+/usr/lib/waydroid/data/waydroid.market.desktop /usr/share/applications/waydroid.market.desktop


### PR DESCRIPTION
When clicking market:// protocol on Linux distro host, then open it on Waydroid.

Related: https://github.com/waydroid/waydroid/issues/412