### PR TITLE
lxc: Remove empty post-stop script

### DIFF
--- a/data/configs/config_1
+++ b/data/configs/config_1
@@ -21,5 +21,3 @@ lxc.network.mtu = 1500
 lxc.console.path = none
 
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_nodes
-
-lxc.hook.post-stop = /dev/null

--- a/data/configs/config_2
+++ b/data/configs/config_2
@@ -21,5 +21,3 @@ lxc.net.0.mtu = 1500
 lxc.console.path = none
 
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_nodes
-
-lxc.hook.post-stop = /dev/null


### PR DESCRIPTION
Every time the session stops this causes an error message on the log
that many users point at when debugging issues.
I don't see a reason for having post-stop = /dev/null