### PR TITLE
container: Only umount /sys/fs/cgroup/schedtune if needed

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -172,8 +172,9 @@ def start(args):
         if which("start"):
             command = ["start", "cgroup-lite"]
             tools.helpers.run.user(args, command, check=False)
-        command = ["umount", "-l", "/sys/fs/cgroup/schedtune"]
-        tools.helpers.run.user(args, command, check=False)
+        if os.path.ismount("/sys/fs/cgroup/schedtune"):
+            command = ["umount", "-l", "/sys/fs/cgroup/schedtune"]
+            tools.helpers.run.user(args, command, check=False)
 
         #TODO: remove NFC hacks
         if which("stop"):


### PR DESCRIPTION
Silences the following useless log from `waydroid log` outputs when the directory either doesn't exist at all (mainline Linux devices), or when it's not mounted on Halium:
```
(027693) [15:21:39] % umount -l /sys/fs/cgroup/schedtune
umount: /sys/fs/cgroup/schedtune: not mounted
```
Reference: https://docs.python.org/3/library/os.path.html#os.path.ismount