### PR TITLE
Support upgrading major android versions

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -82,33 +82,6 @@ def start(args):
         for path in perm_list:
             chmod(path, mode)
 
-    def set_aidl_version():
-        cfg = tools.config.load(args)
-        android_api = 0
-        try:
-            android_api = int(helpers.props.file_get(args,
-                    tools.config.defaults["rootfs"] + "/system/build.prop",
-                    "ro.build.version.sdk"))
-        except:
-            logging.error("Failed to parse android version from system.img")
-
-        if android_api < 28:
-            binder_protocol = "aidl"
-            sm_protocol =     "aidl"
-        elif android_api < 30:
-            binder_protocol = "aidl2"
-            sm_protocol =     "aidl2"
-        elif android_api < 31:
-            binder_protocol = "aidl3"
-            sm_protocol =     "aidl3"
-        else:
-            binder_protocol = "aidl3"
-            sm_protocol =     "aidl4"
-
-        cfg["waydroid"]["binder_protocol"] = binder_protocol
-        cfg["waydroid"]["service_manager_protocol"] = sm_protocol
-        tools.config.save(args, cfg)
-
     def signal_handler(sig, frame):
         services.hardware_manager.stop(args)
         stop(args)
@@ -159,7 +132,7 @@ def start(args):
         # Mount rootfs
         helpers.images.mount_rootfs(args, cfg["waydroid"]["images_path"])
 
-        set_aidl_version()
+        helpers.protocol.set_aidl_version(args)
 
         # Mount data
         helpers.mount.bind(args, session_cfg["session"]["waydroid_data"],

--- a/tools/actions/upgrader.py
+++ b/tools/actions/upgrader.py
@@ -36,4 +36,5 @@ def upgrade(args):
     if status != "STOPPED":
         logging.info("Starting container")
         helpers.images.mount_rootfs(args, args.images_path)
+        helpers.protocol.set_aidl_version(args)
         helpers.lxc.start(args)

--- a/tools/helpers/__init__.py
+++ b/tools/helpers/__init__.py
@@ -10,3 +10,4 @@ import tools.helpers.mount
 import tools.helpers.http
 import tools.helpers.ipc
 import tools.helpers.gpu
+import tools.helpers.protocol

--- a/tools/helpers/protocol.py
+++ b/tools/helpers/protocol.py
@@ -1,0 +1,31 @@
+from tools import helpers
+import tools.config
+import logging
+
+# Call me with rootfs mounted!
+def set_aidl_version(args):
+    cfg = tools.config.load(args)
+    android_api = 0
+    try:
+        android_api = int(helpers.props.file_get(args,
+                tools.config.defaults["rootfs"] + "/system/build.prop",
+                "ro.build.version.sdk"))
+    except:
+        logging.error("Failed to parse android version from system.img")
+
+    if android_api < 28:
+        binder_protocol = "aidl"
+        sm_protocol =     "aidl"
+    elif android_api < 30:
+        binder_protocol = "aidl2"
+        sm_protocol =     "aidl2"
+    elif android_api < 31:
+        binder_protocol = "aidl3"
+        sm_protocol =     "aidl3"
+    else:
+        binder_protocol = "aidl3"
+        sm_protocol =     "aidl4"
+
+    cfg["waydroid"]["binder_protocol"] = binder_protocol
+    cfg["waydroid"]["service_manager_protocol"] = sm_protocol
+    tools.config.save(args, cfg)

--- a/tools/services/clipboard_manager.py
+++ b/tools/services/clipboard_manager.py
@@ -11,6 +11,8 @@ except Exception as e:
     logging.debug(str(e))
     canClip = False
 
+stopping = False
+
 def start(args):
     def sendClipboardData(value):
         try:
@@ -25,15 +27,20 @@ def start(args):
             logging.debug(str(e))
 
     def service_thread():
-        IClipboard.add_service(args, sendClipboardData, getClipboardData)
+        while not stopping:
+            IClipboard.add_service(args, sendClipboardData, getClipboardData)
 
     if canClip:
+        global stopping
+        stopping = False
         args.clipboard_manager = threading.Thread(target=service_thread)
         args.clipboard_manager.start()
     else:
         logging.warning("Failed to start Clipboard manager service, check logs")
 
 def stop(args):
+    global stopping
+    stopping = True
     try:
         if args.clipboardLoop:
             args.clipboardLoop.quit()

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -7,6 +7,7 @@ import tools.config
 from tools.interfaces import IUserMonitor
 from tools.interfaces import IPlatform
 
+stopping = False
 
 def start(args, unlocked_cb=None):
 
@@ -89,12 +90,17 @@ def start(args, unlocked_cb=None):
                         os.remove(desktop_file_path)
 
     def service_thread():
-        IUserMonitor.add_service(args, userUnlocked, packageStateChanged)
+        while not stopping:
+            IUserMonitor.add_service(args, userUnlocked, packageStateChanged)
 
+    global stopping
+    stopping = False
     args.user_manager = threading.Thread(target=service_thread)
     args.user_manager.start()
 
 def stop(args):
+    global stopping
+    stopping = True
     try:
         if args.userMonitorLoop:
             args.userMonitorLoop.quit()


### PR DESCRIPTION
When restarting the lxc container our binder services will receive a
binder_presence event and will try to re-register on the service manager.
If the service manager was created with aidl2 and the new android version
uses aidl3 this will fail with:
  Failed to add service waydroidusermonitor: -2147483647

When that happens, try to restart the service by getting a new service
manager that can handle the new aidl protocol version.