### PR TITLE
Makefile: Add prefix for systemd directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ USE_NFTABLES ?= 0
 WAYDROID_DIR := $(DESTDIR)$(PREFIX)/lib/waydroid
 BIN_DIR := $(DESTDIR)$(PREFIX)/bin
 APPS_DIR := $(DESTDIR)$(PREFIX)/share/applications
-SYSD_DIR := $(DESTDIR)/lib/systemd/system
+SYSD_DIR := $(DESTDIR)$(PREFIX)/lib/systemd/system
 
 build:
 	@echo "Nothing to build, run 'make install' to copy the files!"


### PR DESCRIPTION
```
❯ sudo pacman -U --noconfirm waydroid-git-1.2.1.r32.g*-1-any.pkg.tar.zst
...
error: failed to commit transaction (conflicting files)
waydroid-git: /lib exists in filesystem (owned by filesystem)
waydroid-git: /lib/systemd/system/waydroid-container.service exists in filesystem
Errors occurred, no packages were upgraded.
```

We can't install that file under `/lib` because it just a symbolic link.

```
❯ file /lib
/lib: symbolic link to usr/lib
```

Note: Distro: Arch Linux