### PR TITLE
Updated desktop entry to run first-launch on icon click

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -40,7 +40,7 @@ def start(args, unlocked_cb=None):
             os.remove(desktop_file_path)
         lines = ["[Desktop Entry]", "Type=Application"]
         lines.append("Name=Waydroid")
-        lines.append("Exec=waydroid show-full-ui")
+        lines.append("Exec=waydroid first-launch")
         if hide:
             lines.append("NoDisplay=true")
         lines.append("Icon=" + tools.config.tools_src + "/data/AppIcon.png")


### PR DESCRIPTION
When creating the Waydroid desktop entry file using `makeWaydroidDesktopFile()`, the `Exec` key should execute `waydroid first-launch` instead of `waydroid show-full-ui`.

Currently, there is no indication whether anything has happened when clicking the Waydroid icon, not even an error pop-up stating that, for example, the Waydroid container service isn't running. 

This change would make the whole UX more accessible for new users, who would expect something to happen when clicking the icon in their launcher/menu after installation, and since `first-launch` displays a GTK GUI with a setup process, it should just make the whole experience more streamline.