### PR TITLE
Enable the "No New Privileges" restriction for the container

### DIFF
--- a/data/configs/config_2
+++ b/data/configs/config_2
@@ -7,6 +7,8 @@ lxc.autodev = 0
 # lxc.autodev.tmpfs.size = 25000000
 lxc.apparmor.profile = unconfined
 
+lxc.no_new_privs = 1
+
 lxc.init.cmd = /init
 
 lxc.mount.auto = cgroup:ro sys:ro proc


### PR DESCRIPTION
Hello everyone! I propose enabling the "No New Privileges" restriction for the container. 

**Explanation**:

"No New Privileges" is a restrictive flag on a process that prevents changing the effective UID, GID or capability set during an **execve**. It also restricts MAC domain transition, and allows a process to enable seccomp and Landlock self-restriction without CAP_SYS_ADMIN.

**Possible benefits**:

* Preventing unwanted AppArmor domain transition
* Preventing SUID flag and other "privileged file" flag based security risks.

**Possible problems**:

* I don't know how NNP affects SELinux domain transitions. AppArmor has a guaranteed restrictive domain transition feature (profile stacking) that works with NNP enabled, but I don't know whether the same exists in SELinux.
* I don't know how NNP affects root in the container. If an application relies on a **su** binary with a SUID flag to get root, then NNP may break it. (UPD: Magisk root works with container-wide NNP enabled)
* I also don't know how NNP affects Google Play Services.