### PR TITLE
Add a container-wide seccomp filter

### DIFF
--- a/data/configs/config_1
+++ b/data/configs/config_1
@@ -6,6 +6,7 @@ lxc.arch = LXCARCH
 lxc.autodev = 0
 # lxc.autodev.tmpfs.size = 25000000
 lxc.aa_profile = unconfined
+lxc.seccomp = /var/lib/waydroid/lxc/waydroid/waydroid.seccomp
 
 lxc.cap.keep = audit_control sys_nice wake_alarm setpcap setgid setuid sys_ptrace sys_admin wake_alarm block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner sys_module ipc_lock sys_chroot
 

--- a/data/configs/config_2
+++ b/data/configs/config_2
@@ -6,6 +6,8 @@ lxc.arch = LXCARCH
 lxc.autodev = 0
 # lxc.autodev.tmpfs.size = 25000000
 lxc.apparmor.profile = unconfined
+lxc.seccomp.profile = /var/lib/waydroid/lxc/waydroid/waydroid.seccomp
+lxc.seccomp.allow_nesting = 1
 
 lxc.cap.keep = audit_control sys_nice wake_alarm setpcap setgid setuid sys_ptrace sys_admin wake_alarm block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner sys_module ipc_lock sys_chroot
 lxc.no_new_privs = 1

--- a/data/configs/waydroid.seccomp
+++ b/data/configs/waydroid.seccomp
@@ -1,0 +1,21 @@
+2
+blacklist
+init_module
+finit_module
+delete_module
+_sysctl
+kexec_file_load
+kexec_load
+reboot
+adjtimex errno 0
+clock_adjtime errno 0
+clock_adjtime64 errno 0
+clock_settime errno 0
+clock_settime64 errno 0
+settimeofday errno 0
+stime errno 0
+add_key errno 0
+keyctl errno 0
+request_key errno 0
+swapoff errno 0
+swapon errno 0

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -137,12 +137,15 @@ def set_lxc_config(args):
     elif lxc_ver <= 2:
         config_file = "config_1"
     config_path = tools.config.tools_src + "/data/configs/" + config_file
+    seccomp_profile = tools.config.tools_src + "/data/configs/waydroid.seccomp"
 
     command = ["mkdir", "-p", lxc_path]
     tools.helpers.run.user(args, command)
     command = ["cp", "-fpr", config_path, lxc_path + "/config"]
     tools.helpers.run.user(args, command)
     command = ["sed", "-i", "s/LXCARCH/{}/".format(platform.machine()), lxc_path + "/config"]
+    tools.helpers.run.user(args, command)
+    command = ["cp", "-fpr", seccomp_profile, lxc_path + "/waydroid.seccomp"]
     tools.helpers.run.user(args, command)
 
     nodes = generate_nodes_lxc_config(args)


### PR DESCRIPTION
Hello everyone! I propose enabling a container-wide seccomp filter.

**Explanation**:

Seccomp is a Linux kernel system call access self-restriction feature. A process can load a seccomp filter to the kernel that will check the system calls and block unwanted ones (or terminate the process). I propose a deny list filter that blocks system calls related to loading kernel modules, rebooting the computer, changing system time, kernel key management facility and swap. Seccomp filter will block these syscalls, and the most dangerous ones will lead to termination of the process.

**Possible benefits**:

Mitigating the most dangerous security risks (such as kernel modification) for example, in case of vulnerabilities in root processes in the container.

**Possible problems**:

This will prevent the Settings app from changing the system time. Will not affect ordinary apps since the zygote loads an even more restrictive seccomp filter for them. I think it won't affect privileged apps since this filter only blocks the most dangerous system calls that are not needed in the Android container anyway (even by root apps).