### PR TITLE
Mount proc with the hidepid=2 option

### DIFF
--- a/data/configs/config_base
+++ b/data/configs/config_base
@@ -7,7 +7,8 @@ lxc.autodev = 0
 
 lxc.cap.keep = audit_control sys_nice wake_alarm setpcap setgid setuid sys_ptrace sys_admin wake_alarm block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner sys_module ipc_lock sys_chroot
 
-lxc.mount.auto = cgroup:ro sys:ro proc
+lxc.mount.auto = cgroup:ro sys:ro 
+lxc.mount.entry = proc proc proc nodev,nosuid,noexec,hidepid=2 0 0
 
 lxc.console.path = none
 lxc.pty.max = 10


### PR DESCRIPTION
Hello everyone! I propose mounting the /proc directory inside the container with **hidepid=2** option.

**Explanation**:

The **hidepid** option of the **proc** filesystem restricts access to information about process status. It takes one of the [three possible values](https://man7.org/linux/man-pages/man5/proc.5.html):

* **0**-- no restriction, any process can access information about any other process
* **1** -- an unprivileged user can only access information about their own processes -- only root and users from the group passed as **gid** option of **proc** filesystem mounting can see information about other users' processes
* **2** -- like **1**, but the directories of the processes that can't be read by the user, are now hidden from them.

**Possible benefits**:

* Restrict the app's ability to gather information about other apps' processes and system processes

**Possible problems**:

I don't see any. (btw, it's already implemented for Android on smartphones, so I don't see why it's going to be a problem for Waydroid)