### PR TITLE
Configure multiple preinstalled images paths

### DIFF
--- a/tools/actions/upgrader.py
+++ b/tools/actions/upgrader.py
@@ -25,11 +25,10 @@ def upgrade(args):
     helpers.images.umount_rootfs(args)
     helpers.drivers.loadBinderNodes(args)
     if not args.offline:
-        preinstalled_images_path = tools.config.defaults["preinstalled_images_path"]
-        if args.images_path != preinstalled_images_path:
+        if args.images_path not in tools.config.defaults["preinstalled_images_paths"]:
             helpers.images.get(args)
         else:
-            logging.info("Upgrade refused because a pre-installed image is detected at {}.".format(preinstalled_images_path))
+            logging.info("Upgrade refused because a pre-installed image is detected at {}.".format(args.images_path))
     helpers.lxc.setup_host_perms(args)
     helpers.lxc.set_lxc_config(args)
     helpers.lxc.make_base_props(args)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -43,7 +43,10 @@ defaults = {
     "vendor_type": "MAINLINE",
     "system_datetime": "0",
     "vendor_datetime": "0",
-    "preinstalled_images_path": "/usr/share/waydroid-extra/images"
+    "preinstalled_images_paths": [
+        "/etc/waydroid-extra/images",
+        "/usr/share/waydroid-extra/images",
+    ]
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -253,7 +253,7 @@ def make_base_props(args):
         opengles = "196608"
     props.append("ro.opengles.version=" + opengles)
 
-    if args.images_path != tools.config.defaults["preinstalled_images_path"]:
+    if args.images_path not in tools.config.defaults["preinstalled_images_paths"]:
         props.append("waydroid.system_ota=" + args.system_ota)
         props.append("waydroid.vendor_ota=" + args.vendor_ota)
     else:


### PR DESCRIPTION
Precedence:
  /etc/waydroid-extra/images
  /usr/share/waydroid-extra/images