### PR TITLE
Remove CAP_SYS_MODULE from the capability bounding set

### DIFF
--- a/data/configs/config_base
+++ b/data/configs/config_base
@@ -5,7 +5,7 @@ lxc.arch = LXCARCH
 lxc.autodev = 0
 # lxc.autodev.tmpfs.size = 25000000
 
-lxc.cap.keep = audit_control sys_nice wake_alarm setpcap setgid setuid sys_ptrace sys_admin wake_alarm block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner sys_module ipc_lock sys_chroot
+lxc.cap.keep = audit_control sys_nice wake_alarm setpcap setgid setuid sys_ptrace sys_admin wake_alarm block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner ipc_lock sys_chroot
 
 lxc.mount.auto = cgroup:ro sys:ro proc
 


### PR DESCRIPTION
Hello everyone! I propose removing CAP_SYS_MODULE from the capability bounding set.

**Explanation**:

POSIX capabilities are a way for granular management of superuser privileges in GNU/Linux systems. They allow granting some superuser privileges to a non-root process and restricting superuser privileges for a root process. CAP_SYS_MODULE is a capability that allows a process to load and unload kernel modules. Removing it would prevent root processes from modifying the kernel.

**Possible benefits**:

Protect the kernel from compromised root processes and root apps.

**Possible problems**:

I don't see any -- kernel module loading is already blocked by a [container-wide seccomp filter](https://github.com/waydroid/waydroid/pull/505).