### PR TITLE
hardware-manager: Optionally stop the session on suspend

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -20,7 +20,8 @@ config_keys = ["arch",
                "images_path",
                "vendor_type",
                "system_datetime",
-               "vendor_datetime"]
+               "vendor_datetime",
+               "suspend_action"]
 
 session_config_keys = ["user_name",
                        "user_id",
@@ -46,7 +47,8 @@ defaults = {
     "preinstalled_images_paths": [
         "/etc/waydroid-extra/images",
         "/usr/share/waydroid-extra/images",
-    ]
+    ],
+    "suspend_action": "freeze"
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/services/hardware_manager.py
+++ b/tools/services/hardware_manager.py
@@ -3,6 +3,8 @@
 import logging
 import threading
 import tools.actions.container_manager
+import tools.actions.session_manager
+import tools.config
 from tools import helpers
 from tools.interfaces import IHardware
 
@@ -16,7 +18,11 @@ def start(args):
         logging.debug("Function enableBluetooth not implemented")
 
     def suspend():
-        tools.actions.container_manager.freeze(args)
+        cfg = tools.config.load(args)
+        if cfg["waydroid"]["suspend_action"] == "stop":
+            tools.actions.session_manager.stop(args)
+        else:
+            tools.actions.container_manager.freeze(args)
 
     def reboot():
         helpers.lxc.stop(args)


### PR DESCRIPTION
This allows to use persist.waydroid.suspend as a way to automatically stop the session after an inactivity timeout, as opposed to merely freezing the container. Freeze still remains the default action.

To use it this way, add to waydroid.cfg:
```
suspend_action = stop
```