### PR TITLE
Mount overlays on top of image mount points

### DIFF
--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -119,6 +119,13 @@ def init(args):
             helpers.images.get(args)
         if not os.path.isdir(tools.config.defaults["rootfs"]):
             os.mkdir(tools.config.defaults["rootfs"])
+        if not os.path.isdir(tools.config.defaults["overlay"]):
+            os.mkdir(tools.config.defaults["overlay"])
+            os.mkdir(tools.config.defaults["overlay"]+"/vendor")
+        if not os.path.isdir(tools.config.defaults["overlay_rw"]):
+            os.mkdir(tools.config.defaults["overlay_rw"])
+            os.mkdir(tools.config.defaults["overlay_rw"]+"/system")
+            os.mkdir(tools.config.defaults["overlay_rw"]+"/vendor")
         helpers.lxc.setup_host_perms(args)
         helpers.lxc.set_lxc_config(args)
         helpers.lxc.make_base_props(args)

--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -117,6 +117,8 @@ def init(args):
         helpers.images.umount_rootfs(args)
         if args.images_path not in tools.config.defaults["preinstalled_images_paths"]:
             helpers.images.get(args)
+        else:
+            helpers.images.remove_overlay(args)
         if not os.path.isdir(tools.config.defaults["rootfs"]):
             os.mkdir(tools.config.defaults["rootfs"])
         if not os.path.isdir(tools.config.defaults["overlay"]):

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -40,6 +40,9 @@ defaults = {
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"
+defaults["overlay"] = defaults["work"] + "/overlay"
+defaults["overlay_rw"] = defaults["work"] + "/overlay_rw"
+defaults["overlay_work"] = defaults["work"] + "/overlay_work"
 defaults["data"] = defaults["work"] + "/data"
 defaults["lxc"] = defaults["work"] + "/lxc"
 defaults["host_perms"] = defaults["work"] + "/host-permissions"

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -21,7 +21,8 @@ config_keys = ["arch",
                "vendor_type",
                "system_datetime",
                "vendor_datetime",
-               "suspend_action"]
+               "suspend_action",
+               "mount_overlays"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -36,7 +37,8 @@ defaults = {
         "/etc/waydroid-extra/images",
         "/usr/share/waydroid-extra/images",
     ],
-    "suspend_action": "freeze"
+    "suspend_action": "freeze",
+    "mount_overlays": "True",
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/helpers/images.py
+++ b/tools/helpers/images.py
@@ -128,8 +128,19 @@ def make_prop(args, cfg, full_props_path):
 def mount_rootfs(args, images_dir, session):
     helpers.mount.mount(args, images_dir + "/system.img",
                         tools.config.defaults["rootfs"], umount=True)
+    helpers.mount.mount_overlay(args, [tools.config.defaults["overlay"],
+                                       tools.config.defaults["rootfs"]],
+                                tools.config.defaults["rootfs"],
+                                upper_dir=tools.config.defaults["overlay_rw"] + "/system",
+                                work_dir=tools.config.defaults["overlay_work"] + "/system")
     helpers.mount.mount(args, images_dir + "/vendor.img",
                            tools.config.defaults["rootfs"] + "/vendor")
+    helpers.mount.mount_overlay(args, [tools.config.defaults["overlay"] + "/vendor",
+                                       tools.config.defaults["rootfs"] + "/vendor"],
+                                tools.config.defaults["rootfs"] + "/vendor",
+                                upper_dir=tools.config.defaults["overlay_rw"] + "/vendor",
+                                work_dir=tools.config.defaults["overlay_work"] + "/vendor")
+
     for egl_path in ["/vendor/lib/egl", "/vendor/lib64/egl"]:
         if os.path.isdir(egl_path):
             helpers.mount.bind(

--- a/tools/helpers/images.py
+++ b/tools/helpers/images.py
@@ -4,6 +4,7 @@ import logging
 import zipfile
 import json
 import hashlib
+import shutil
 import os
 import tools.config
 from tools import helpers
@@ -78,6 +79,7 @@ def get(args):
             tools.config.save(args, cfg)
             os.remove(images_zip)
             break
+    remove_overlay(args)
 
 def replace(args, system_zip, system_time, vendor_zip, vendor_time):
     cfg = tools.config.load(args)
@@ -92,6 +94,13 @@ def replace(args, system_zip, system_time, vendor_zip, vendor_time):
             zip_ref.extractall(args.images_path)
         cfg["waydroid"]["vendor_datetime"] = str(vendor_time)
         tools.config.save(args, cfg)
+    remove_overlay(args)
+
+def remove_overlay(args):
+    if os.path.isdir(tools.config.defaults["overlay_rw"]):
+        shutil.rmtree(tools.config.defaults["overlay_rw"])
+    if os.path.isdir(tools.config.defaults["overlay_work"]):
+        shutil.rmtree(tools.config.defaults["overlay_work"])
 
 def make_prop(args, cfg, full_props_path):
     if not os.path.isfile(args.work + "/waydroid_base.prop"):

--- a/tools/helpers/images.py
+++ b/tools/helpers/images.py
@@ -135,20 +135,23 @@ def make_prop(args, cfg, full_props_path):
     os.chmod(full_props_path, 0o644)
 
 def mount_rootfs(args, images_dir, session):
+    cfg = tools.config.load(args)
     helpers.mount.mount(args, images_dir + "/system.img",
                         tools.config.defaults["rootfs"], umount=True)
-    helpers.mount.mount_overlay(args, [tools.config.defaults["overlay"],
-                                       tools.config.defaults["rootfs"]],
-                                tools.config.defaults["rootfs"],
-                                upper_dir=tools.config.defaults["overlay_rw"] + "/system",
-                                work_dir=tools.config.defaults["overlay_work"] + "/system")
+    if cfg["waydroid"]["mount_overlays"] == "True":
+        helpers.mount.mount_overlay(args, [tools.config.defaults["overlay"],
+                                           tools.config.defaults["rootfs"]],
+                                    tools.config.defaults["rootfs"],
+                                    upper_dir=tools.config.defaults["overlay_rw"] + "/system",
+                                    work_dir=tools.config.defaults["overlay_work"] + "/system")
     helpers.mount.mount(args, images_dir + "/vendor.img",
                            tools.config.defaults["rootfs"] + "/vendor")
-    helpers.mount.mount_overlay(args, [tools.config.defaults["overlay"] + "/vendor",
-                                       tools.config.defaults["rootfs"] + "/vendor"],
-                                tools.config.defaults["rootfs"] + "/vendor",
-                                upper_dir=tools.config.defaults["overlay_rw"] + "/vendor",
-                                work_dir=tools.config.defaults["overlay_work"] + "/vendor")
+    if cfg["waydroid"]["mount_overlays"] == "True":
+        helpers.mount.mount_overlay(args, [tools.config.defaults["overlay"] + "/vendor",
+                                           tools.config.defaults["rootfs"] + "/vendor"],
+                                    tools.config.defaults["rootfs"] + "/vendor",
+                                    upper_dir=tools.config.defaults["overlay_rw"] + "/vendor",
+                                    work_dir=tools.config.defaults["overlay_work"] + "/vendor")
 
     for egl_path in ["/vendor/lib/egl", "/vendor/lib64/egl"]:
         if os.path.isdir(egl_path):

--- a/tools/helpers/mount.py
+++ b/tools/helpers/mount.py
@@ -109,7 +109,7 @@ def umount_all(args, folder):
         if ismount(mountpoint):
             raise RuntimeError("Failed to umount: " + mountpoint)
 
-def mount(args, source, destination, create_folders=True, umount=False, readonly=True):
+def mount(args, source, destination, create_folders=True, umount=False, readonly=True, mount_type=None, options=None):
     """
     Mount and create necessary directory structure.
     :param umount: when destination is already a mount point, umount it first.
@@ -129,10 +129,19 @@ def mount(args, source, destination, create_folders=True, umount=False, readonly
             raise RuntimeError("Mount failed, folder does not exist: " +
                             destination)
 
-    # Actually mount the folder
-    tools.helpers.run.user(args, ["mount", source, destination])
+    extra_args = []
+    opt_args = []
+    if mount_type:
+        extra_args.extend(["-t", mount_type])
     if readonly:
-        tools.helpers.run.user(args, ["mount", "-o", "remount,ro", source, destination])
+        opt_args.append("ro")
+    if options:
+        opt_args.extend(options)
+    if opt_args:
+        extra_args.extend(["-o", ",".join(opt_args)])
+
+    # Actually mount the folder
+    tools.helpers.run.user(args, ["mount", *extra_args, source, destination])
 
     # Verify, that it has worked
     if not ismount(destination):

--- a/tools/helpers/mount.py
+++ b/tools/helpers/mount.py
@@ -149,3 +149,28 @@ def mount(args, source, destination, create_folders=True, umount=False,
     # Verify, that it has worked
     if not ismount(destination):
         raise RuntimeError("Mount failed: " + source + " -> " + destination)
+
+def mount_overlay(args, lower_dirs, destination, upper_dir=None, work_dir=None,
+                  create_folders=True, readonly=True):
+    """
+    Mount an overlay.
+    """
+    dirs = [*lower_dirs]
+    options = ["xino=off", "lowerdir=" + (":".join(lower_dirs))]
+
+    if upper_dir:
+        dirs.append(upper_dir)
+        dirs.append(work_dir)
+        options.append("upperdir=" + upper_dir)
+        options.append("workdir=" + work_dir)
+
+    for dir_path in dirs:
+        if not os.path.exists(dir_path):
+            if create_folders:
+                tools.helpers.run.user(args, ["mkdir", "-p", dir_path])
+            else:
+                raise RuntimeError("Mount failed, folder does not exist: " +
+                                   dir_path)
+
+    mount(args, "overlay", destination, mount_type="overlay", options=options,
+          readonly=readonly, create_folders=create_folders, force=True)

--- a/tools/helpers/mount.py
+++ b/tools/helpers/mount.py
@@ -109,17 +109,20 @@ def umount_all(args, folder):
         if ismount(mountpoint):
             raise RuntimeError("Failed to umount: " + mountpoint)
 
-def mount(args, source, destination, create_folders=True, umount=False, readonly=True, mount_type=None, options=None):
+def mount(args, source, destination, create_folders=True, umount=False,
+          readonly=True, mount_type=None, options=None, force=True):
     """
     Mount and create necessary directory structure.
     :param umount: when destination is already a mount point, umount it first.
+    :param force: attempt mounting even if the mount point already exists.
     """
     # Check/umount destination
     if ismount(destination):
         if umount:
             umount_all(args, destination)
         else:
-            return
+            if not force:
+                return
 
     # Check/create folders
     if not os.path.exists(destination):

--- a/tools/helpers/mount.py
+++ b/tools/helpers/mount.py
@@ -102,8 +102,10 @@ def umount_all(args, folder):
     """
     Umount all folders, that are mounted inside a given folder.
     """
-    for mountpoint in umount_all_list(folder):
+    all_list = umount_all_list(folder)
+    for mountpoint in all_list:
         tools.helpers.run.user(args, ["umount", mountpoint])
+    for mountpoint in all_list:
         if ismount(mountpoint):
             raise RuntimeError("Failed to umount: " + mountpoint)
 


### PR DESCRIPTION
This allows the user to make modifications to the images that may persist between image upgrades.

For both the system and vendor image there's a set of two overlays:

- one, specified in config as "overlay", is a read-only persistent overlay meant for stuff like installing privileged apps that should persist between updates
- second one, specified as "overlay_rw", is a read-write overlay that stores the changes made by the user when they remount the mount point in read-write mode. This one is cleaned up when performing image upgrade to not carry potentially incompatible changes on between images