### PR TITLE
desktop: Mark as compatible with mobile form factor

### DIFF
--- a/data/Waydroid.desktop
+++ b/data/Waydroid.desktop
@@ -3,3 +3,4 @@ Type=Application
 Name=Waydroid
 Exec=waydroid first-launch
 Icon=/usr/lib/waydroid/data/AppIcon.png
+X-Purism-FormFactor=Workstation;Mobile;

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -27,6 +27,7 @@ def start(args, unlocked_cb=None):
             lines.append("Name=" + appInfo["name"])
             lines.append("Exec=waydroid app launch " + packageName)
             lines.append("Icon=" + args.waydroid_data + "/icons/" + packageName + ".png")
+            lines.append("X-Purism-FormFactor=Workstation;Mobile;")
             desktop_file = open(desktop_file_path, "w")
             for line in lines:
                 desktop_file.write(line + "\n")
@@ -41,6 +42,7 @@ def start(args, unlocked_cb=None):
         lines = ["[Desktop Entry]", "Type=Application"]
         lines.append("Name=Waydroid")
         lines.append("Exec=waydroid show-full-ui")
+        lines.append("X-Purism-FormFactor=Workstation;Mobile;")
         if hide:
             lines.append("NoDisplay=true")
         lines.append("Icon=" + tools.config.tools_src + "/data/AppIcon.png")


### PR DESCRIPTION
This allows environments like Phosh to consider Waydroid launchers as mobile-compatible, so they get displayed in default app list when undocked.