### PR TITLE
net: Fix vnic name selection for LXC <=2

### DIFF
--- a/data/scripts/waydroid-net.sh
+++ b/data/scripts/waydroid-net.sh
@@ -2,7 +2,10 @@
 
 varrun="/run/waydroid-lxc"
 varlib="/var/lib"
-vnic=$(awk '$1 == "lxc.net.0.link" {print $3}' /var/lib/waydroid/lxc/waydroid/config || echo "waydroid0")
+net_link_key="lxc.net.0.link"
+case "$(lxc-info --version)" in [012].*) net_link_key="lxc.network.link" ;; esac
+vnic=$(awk "\$1 == \"$net_link_key\" {print \$3}" /var/lib/waydroid/lxc/waydroid/config)
+: ${vnic:=waydroid0}
 
 if [ "$vnic" != "waydroid0" ]; then
     echo "vnic is $vnic, bailing out"


### PR DESCRIPTION
The "default to `waydroid0`" was broken as `awk` never returned a non-zero exit code if the file exists but no match was found.

Also account for the key being named `lxc.network.link` on older LXC versions so one still has the ability to have a flexible Waydroid network configuration.

Cc: @aleasto @Quackdoc 