### PR TITLE
fix(shell): allow command to have arguments

### DIFF
--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -110,7 +110,7 @@ def arguments_firstLaunch(subparser):
 
 def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
-    ret.add_argument('COMMAND', nargs='?', help="command to run")
+    ret.add_argument('COMMAND', nargs='*', help="command to run")
     return ret
 
 def arguments_logcat(subparser):

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -373,7 +373,7 @@ def shell(args):
     command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
                "-n", "waydroid", "--"]
     if args.COMMAND:
-        command.append(args.COMMAND)
+        command.extend(args.COMMAND)
     else:
         command.append("/system/bin/sh")
     subprocess.run(command, env={"PATH": os.environ['PATH'] + ":/system/bin:/vendor/bin"})


### PR DESCRIPTION
Hello! :wave:

Before:

```console
$ waydroid shell --help
usage: waydroid shell [-h] [COMMAND]

positional arguments:
  COMMAND     command to run

options:
  -h, --help  show this help message and exit

$ waydroid shell pm disable com.android.inputmethod.latin
usage: waydroid [-h] [-V] [-l LOG] [--details-to-stdout] [-v] [-q] [-w] {status,log,init,upgrade,session,container,app,prop,show-full-ui,first-launch,shell,logcat} ...
waydroid: error: unrecognized arguments: disable com.android.inputmethod.latin
```

After:

```console
$ waydroid shell --help
usage: waydroid shell [-h] [COMMAND ...]

positional arguments:
  COMMAND     command to run

options:
  -h, --help  show this help message and exit

$ waydroid shell pm disable com.android.inputmethod.latin
Package com.android.inputmethod.latin new state: disabled
```

Adding `--` also works:

```console
$ waydroid shell -- pm disable com.android.inputmethod.latin
Package com.android.inputmethod.latin new state: disabled
```