### PR TITLE
session: warn about unset WAYLAND_DISPLAY instead of XDG_SESSION_TYPE

### DIFF
--- a/tools/actions/session_manager.py
+++ b/tools/actions/session_manager.py
@@ -15,11 +15,10 @@ def start(args, unlocked_cb=None):
         stop(args)
         sys.exit(0)
 
-    xdg_session = os.getenv("XDG_SESSION_TYPE")
-    if xdg_session != "wayland":
-        logging.warning('XDG Session is not "wayland"')
-
     cfg = tools.config.load_session()
+    wayland_display = cfg["session"]["wayland_display"]
+    if wayland_display == "None" or not wayland_display:
+        logging.warning('WAYLAND_DISPLAY is not set, defaulting to "wayland-0"')
     waydroid_data = cfg["session"]["waydroid_data"]
     if not os.path.isdir(waydroid_data):
         os.makedirs(waydroid_data)


### PR DESCRIPTION
`XDG_SESSION_TYPE` isn't a reliable check for Wayland being present (e.g. on Ubuntu Touch currently `XDG_SESSION_TYPE` is `mir` with `WAYLAND_DISPLAY` set to `wayland-0` as it also provides Wayland windowing.

Also mention the behavior of defaulting `WAYLAND_DISPLAY` to `wayland-0` in case it's not set.