### PR TITLE
lxc: Only add /dev/ashmem to config_nodes when it exists

### DIFF
--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -128,6 +128,7 @@ def init(args):
             os.mkdir(tools.config.defaults["overlay_rw"])
             os.mkdir(tools.config.defaults["overlay_rw"]+"/system")
             os.mkdir(tools.config.defaults["overlay_rw"]+"/vendor")
+        helpers.drivers.probeAshmemDriver(args)
         helpers.lxc.setup_host_perms(args)
         helpers.lxc.set_lxc_config(args)
         helpers.lxc.make_base_props(args)

--- a/tools/actions/upgrader.py
+++ b/tools/actions/upgrader.py
@@ -48,6 +48,7 @@ def upgrade(args):
             helpers.images.get(args)
         else:
             logging.info("Upgrade refused because a pre-installed image is detected at {}.".format(args.images_path))
+    helpers.drivers.probeAshmemDriver(args)
     helpers.lxc.setup_host_perms(args)
     helpers.lxc.set_lxc_config(args)
     helpers.lxc.make_base_props(args)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -42,7 +42,7 @@ def generate_nodes_lxc_config(args):
     make_entry("/dev/zero")
     make_entry("/dev/null")
     make_entry("/dev/full")
-    make_entry("/dev/ashmem", check=False)
+    make_entry("/dev/ashmem")
     make_entry("/dev/fuse")
     make_entry("/dev/ion")
     make_entry("/dev/char", options="bind,create=dir,optional 0 0")


### PR DESCRIPTION
This hasn't existed in mainline Linux kernels [since v5.18](https://cateee.net/lkddb/web-lkddb/ASHMEM.html) and trying to always mount it regardless just adds to the noise in `waydroid log` in most cases, so simply don't add it to `config_nodes` unless it actually exists.

Silences the following:
```
lxc-start: waydroid: ../src/lxc/utils.c: safe_mount: 1221 No such file or directory - Failed to mount "/dev/ashmem" onto "/usr/lib/lxc/rootfs/dev/ashmem"
```