### PR TITLE
configs: Drop CAP_WAKE_ALARM capability

### DIFF
--- a/data/configs/config_base
+++ b/data/configs/config_base
@@ -5,7 +5,7 @@ lxc.arch = LXCARCH
 lxc.autodev = 0
 # lxc.autodev.tmpfs.size = 25000000
 
-lxc.cap.keep = audit_control sys_nice wake_alarm setpcap setgid setuid sys_ptrace sys_admin wake_alarm block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner ipc_lock sys_chroot
+lxc.cap.keep = audit_control sys_nice setpcap setgid setuid sys_ptrace sys_admin block_suspend sys_time net_admin net_raw net_bind_service kill dac_override dac_read_search fsetid mknod syslog chown sys_resource fowner ipc_lock sys_chroot
 
 lxc.mount.auto = cgroup:ro sys:ro proc
 


### PR DESCRIPTION
Prevent the android userspace from continuously waking up the hardware