### PR TITLE
Fix prop set command

### DIFF
--- a/tools/actions/prop.py
+++ b/tools/actions/prop.py
@@ -30,7 +30,7 @@ def set(args):
         if session["state"] == "FROZEN":
             cm.Unfreeze()
 
-        helpers.props.set(args, args.key, args.value)
+        tools.helpers.props.set(args, args.key, args.value)
 
         if session["state"] == "FROZEN":
             cm.Freeze()


### PR DESCRIPTION
There is a small typo that misses `tools.` when calling `helpers`, which has issues with setting props.