### PR TITLE
add a dbus activated systemd user service for waydroid session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WAYDROID_DIR := $(PREFIX)/lib/waydroid
 BIN_DIR := $(PREFIX)/bin
 APPS_DIR := $(PREFIX)/share/applications
 METAINFO_DIR := $(PREFIX)/share/metainfo
-SYSD_DIR := $(PREFIX)/lib/systemd/system
+SYSD_DIR := $(PREFIX)/lib/systemd
 DBUS_DIR := $(PREFIX)/share/dbus-1
 POLKIT_DIR := $(PREFIX)/share/polkit-1
 APPARMOR_DIR := /etc/apparmor.d
@@ -35,11 +35,15 @@ install:
 	cp dbus/id.waydro.Container.policy $(INSTALL_POLKIT_DIR)/actions/
 	if [ $(USE_DBUS_ACTIVATION) = 1 ]; then \
 		install -d $(INSTALL_DBUS_DIR)/system-services; \
+		install -d $(INSTALL_DBUS_DIR)/services; \
 		cp dbus/id.waydro.Container.service $(INSTALL_DBUS_DIR)/system-services/; \
+		cp dbus/id.waydro.Session.service $(INSTALL_DBUS_DIR)/services/; \
 	fi
 	if [ $(USE_SYSTEMD) = 1 ]; then \
-		install -d $(INSTALL_SYSD_DIR); \
-		cp systemd/waydroid-container.service $(INSTALL_SYSD_DIR); \
+		install -d $(INSTALL_SYSD_DIR)/system; \
+		install -d $(INSTALL_SYSD_DIR)/user; \
+		cp systemd/waydroid-container.service $(INSTALL_SYSD_DIR)/system; \
+		cp systemd/waydroid-session.service $(INSTALL_SYSD_DIR)/user; \
 	fi
 	if [ $(USE_NFTABLES) = 1 ]; then \
 		sed '/LXC_USE_NFT=/ s/false/true/' -i $(INSTALL_WAYDROID_DIR)/data/scripts/waydroid-net.sh; \

--- a/dbus/id.waydro.Session.service
+++ b/dbus/id.waydro.Session.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=id.waydro.Session
+Exec=/usr/bin/waydroid session start
+SystemdService=waydroid-session.service

--- a/systemd/waydroid-session.service
+++ b/systemd/waydroid-session.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Waydroid Session
+
+[Service]
+BusName=id.waydro.Session
+ExecStart=waydroid session start
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
this will start waydroid session over dbus

currently it reaches https://github.com/waydroid/waydroid/blob/fb92d3a016a956e8520e938b59f55bd0fe9c2deb/tools/actions/app_manager.py#L65 too quickly causing it to return `Failed to get service waydroidplatform, trying again...` on the first run, it launches fine on the second

my current understanding is that it should  only call `launchNow` after this point has been reached https://github.com/waydroid/waydroid/blob/fb92d3a016a956e8520e938b59f55bd0fe9c2deb/tools/services/user_manager.py#L75