### PR TITLE
lxc: add selinuxfs mount entry

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -128,6 +128,10 @@ def generate_nodes_lxc_config(args):
     # NFC config
     make_entry("/system/etc/libnfc-nci.conf", options="bind,optional 0 0")
 
+    # selinuxfs
+    if os.path.exists("/sys/fs/selinux/enforce"):
+        make_entry("selinuxfs", "sys/fs/selinux", "selinuxfs", "nosuid,noexec 0 0", False)
+
     return nodes
 
 LXC_APPARMOR_PROFILE = "lxc-waydroid"


### PR DESCRIPTION
Mounts selinuxfs inside the lxc container.

While this mounts `selinuxfs` inside waydroid, context labels inside waydroid images differ from what Android usually is used to work with and policies need to be generated when building the imagest. Left some references at the end of this post.

Why do we need Selinux?
* SafetyNet mainly relies on selinux (enforced selinux to be more precise) to bypass properly, and enabling it in Waydroid will be a step closer in bypassing it, at least on distributions using selinux.

References for patching Selinux inside waydroid:

**Security-Enhanced Linux in Android**
* https://source.android.com/docs/security/features/selinux/

**Validating SELinux**
* https://source.android.com/docs/security/features/selinux/validate

**audit2allow-sepolicy-android (probably an useful note too**
* https://gist.github.com/Nihhaar/c39a1ca3429b12b75d4dac1a04fcb7cd

SELinux is usually needed for bypassing SafetyNet in android, beside some other props that could be set before waydroid starts, but this should be handled later.

Discussion in the __WayDroid on Ubuntu Touch__ telegram  group mentions implementing an kernel hack to enable selinux to work with apparmor. The biggest issue here is while it is possible, it's useless without having selinux properly working in Waydroid.