### PR TITLE
session: Add strict WAYLAND_DISPLAY validity checks

### DIFF
--- a/debian/waydroid.postinst
+++ b/debian/waydroid.postinst
@@ -3,7 +3,7 @@ set -e
 
 configure() {
 	# Update configs
-    waydroid upgrade -o
+	waydroid upgrade -o
 }
 
 case "$1" in

--- a/tools/helpers/props.py
+++ b/tools/helpers/props.py
@@ -42,5 +42,5 @@ def file_get(args, file, prop):
                 continue
             k,v = line.partition("=")[::2]
             if k == prop:
-                return v;
+                return v
     return ""


### PR DESCRIPTION
Enough with not checking we actually have a Wayland compositor around at all: start requiring the `WAYLAND_DISPLAY` socket actually exists as an absolute path or relatively under `XDG_RUNTIME_DIR`.

Additionally if `WAYLAND_DISPLAY` isn't an absolute path to the socket (most setups) ensure `XDG_RUNTIME_DIR` is set and error with a typically appropriate message.

Fixes https://github.com/waydroid/waydroid/issues/693, closes https://github.com/waydroid/waydroid/pull/246.

Also contains a few small irrelevant commits that shouldn't change runtime in any way.

Few questions though (@aleasto):
1. Should we support `WAYLAND_SOCKET` right now? [technically it's a part of the spec](https://wayland.freedesktop.org/docs/html/apb.html#Client-classwl__display_1af048371dfef7577bd39a3c04b78d0374) so I left it as a `TODO` for now
2. Should we add a default for `XDG_RUNTIME_DIR` (of e.g. `/run/user/$(id -u)`)? `sudo waydroid show-full-ui` currently produces this and I kinda like how obvious it makes that the user attempted to start a session as root without any `XDG_RUNTIME_DIR` configured (though perhaps that could be another check by itself? I do like that idea as well):
```
[06:19:14] Starting waydroid session
[06:19:14] WAYLAND_DISPLAY is not set, defaulting to "wayland-0"
[06:19:14] WAYLAND_DISPLAY socket 'None/wayland-0' doesn't exist; you're running a Wayland compositor right?
```