### PR TITLE
container: Make "waydroid-net.sh start" failure fatal

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -128,7 +128,7 @@ def do_start(args, session):
     # Networking
     command = [tools.config.tools_src +
                "/data/scripts/waydroid-net.sh", "start"]
-    tools.helpers.run.user(args, command, check=False)
+    tools.helpers.run.user(args, command)
 
     # Sensors
     if which("waydroid-sensord"):


### PR DESCRIPTION
Failing the network setup will in 99% of all cases cause the `lxc-start` to fail due to the `waydroid0` bridge not existing, so we might as well fail fast instead of polluting the `waydroid log` and doing a futile attempt at booting the LXC container.

Fixes https://github.com/waydroid/waydroid/issues/694.

<details>
  <summary>Click to show/hide logs BEFORE this patch with failing "waydroid-net.sh start"</summary>
  
  ```
$ waydroid show-full-ui
[20:51:18] Starting waydroid session
[20:51:29] OSError: container failed to start

# waydroid log
(030513) [20:51:18] Starting waydroid session
(030516) [20:51:19] % modprobe -q ashmem_linux
(030516) [20:51:19] % chmod 666 -R /dev/anbox-binder
(030516) [20:51:19] % chmod 666 -R /dev/anbox-vndbinder
(030516) [20:51:19] % chmod 666 -R /dev/anbox-hwbinder
(030516) [20:51:19] % /usr/lib/waydroid/data/scripts/waydroid-net.sh start
vnic is waydroid0
which: no iptables-legacy in ((null))
which: no iptables in ((null))
which: no ip6tables-legacy in ((null))
which: no ip6tables in ((null))
which: no nft in ((null))
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 91: -I: not found
Failed to setup waydroid-net.
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 213: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 214: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 215: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 216: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 217: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 218: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 219: -t: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 220: -t: not found
(030516) [20:51:19] % mount -o ro /var/lib/waydroid/images/system.img /var/lib/waydroid/rootfs
(030516) [20:51:19] % mount -t overlay -o ro,xino=off,lowerdir=/var/lib/waydroid/overlay:/var/lib/waydroid/rootfs,upperdir=/var/lib/waydroid/overlay_rw/system,workdir=/var/lib/waydroid/overlay_work/system overlay /var/lib/waydroid/rootfs
(030516) [20:51:19] % mount -o ro /var/lib/waydroid/images/vendor.img /var/lib/waydroid/rootfs/vendor
(030516) [20:51:19] % mount -t overlay -o ro,xino=off,lowerdir=/var/lib/waydroid/overlay/vendor:/var/lib/waydroid/rootfs/vendor,upperdir=/var/lib/waydroid/overlay_rw/vendor,workdir=/var/lib/waydroid/overlay_work/vendor overlay /var/lib/waydroid/rootfs/vendor
(030516) [20:51:19] % mount -o bind /var/lib/waydroid/waydroid.prop /var/lib/waydroid/rootfs/vendor/waydroid.prop
(030516) [20:51:19] Save config: /var/lib/waydroid/waydroid.cfg
(030516) [20:51:19] % mount -o bind /home/deathmist/.local/share/waydroid/data /var/lib/waydroid/data
(030516) [20:51:19] % chmod 777 -R /dev/dri
(030516) [20:51:19] % chmod 777 -R /dev/fb0
(030516) [20:51:19] % chmod 777 -R /dev/video1
(030516) [20:51:19] % chmod 777 -R /dev/video0
(030516) [20:51:19] % lxc-start -P /var/lib/waydroid/lxc -F -n waydroid -- /init
(030516) [20:51:19] New background process: pid=30559, output=background
lxc-start: waydroid: ../src/lxc/network.c: netdev_configure_server_veth: 711 No such file or directory - Failed to attach "vethejG1ZA" to bridge "waydroid0", bridge interface doesn't exist
lxc-start: waydroid: ../src/lxc/network.c: lxc_create_network_priv: 3427 No such file or directory - Failed to create network device
lxc-start: waydroid: ../src/lxc/start.c: lxc_spawn: 1840 Failed to create the network
lxc-start: waydroid: ../src/lxc/start.c: __lxc_start: 2107 Failed to spawn container "waydroid"
lxc-start: waydroid: ../src/lxc/conf.c: run_buffer: 321 Script exited with status 126
lxc-start: waydroid: ../src/lxc/start.c: lxc_end: 985 Failed to run lxc.hook.post-stop for container "waydroid"
lxc-start: waydroid: ../src/lxc/tools/lxc_start.c: main: 306 The container failed to start
lxc-start: waydroid: ../src/lxc/tools/lxc_start.c: main: 311 Additional information can be obtained by setting the --logfile and --logpriority options
(030516) [20:51:19] waiting 10 seconds for container to start...
(030516) [20:51:20] waiting 9 seconds for container to start...
(030516) [20:51:21] waiting 8 seconds for container to start...
(030516) [20:51:22] waiting 7 seconds for container to start...
(030516) [20:51:23] waiting 6 seconds for container to start...
(030516) [20:51:24] waiting 5 seconds for container to start...
(030516) [20:51:25] waiting 4 seconds for container to start...
(030516) [20:51:26] waiting 3 seconds for container to start...
(030516) [20:51:27] waiting 2 seconds for container to start...
(030516) [20:51:28] waiting 1 seconds for container to start...
(030513) [20:51:29] OSError: container failed to start
  ```
</details>

<details>
  <summary>Click to show/hide logs AFTER this patch with failing "waydroid-net.sh start"</summary>
  
  ```
$ waydroid show-full-ui
[20:52:12] Starting waydroid session
[20:52:12] RuntimeError: Command failed: % /usr/lib/waydroid/data/scripts/waydroid-net.sh start

# waydroid log
(030827) [20:52:12] Starting waydroid session
(030830) [20:52:12] % modprobe -q ashmem_linux
(030830) [20:52:12] % chmod 666 -R /dev/anbox-binder
(030830) [20:52:12] % chmod 666 -R /dev/anbox-vndbinder
(030830) [20:52:12] % chmod 666 -R /dev/anbox-hwbinder
(030830) [20:52:12] % /usr/lib/waydroid/data/scripts/waydroid-net.sh start
vnic is waydroid0
which: no iptables-legacy in ((null))
which: no iptables in ((null))
which: no ip6tables-legacy in ((null))
which: no ip6tables in ((null))
which: no nft in ((null))
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 91: -I: not found
Failed to setup waydroid-net.
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 213: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 214: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 215: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 216: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 217: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 218: -D: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 219: -t: not found
/usr/lib/waydroid/data/scripts/waydroid-net.sh: 220: -t: not found
(030830) [20:52:12] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(030830) [20:52:12] NOTE: The failed command's output is above the ^^^ line in the log file: /var/lib/waydroid/waydroid.log
(030827) [20:52:12] RuntimeError: Command failed: % /usr/lib/waydroid/data/scripts/waydroid-net.sh start
  ```
</details>

Cc. @quackdoc @aleasto 