### PR TITLE
version: Fix "NameError: name 're' is not defined"

### DIFF
--- a/tools/helpers/version.py
+++ b/tools/helpers/version.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 def versiontuple(v):
     return tuple(map(int, (v.split("."))))


### PR DESCRIPTION
Looks like the import was just forgotten in c0f595e.