### PR TITLE
container: Extend nfcd stop/start hacks to systemd

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -154,6 +154,9 @@ def do_start(args, session):
     if which("stop"):
         command = ["stop", "nfcd"]
         tools.helpers.run.user(args, command, check=False)
+    elif which("systemctl") and (tools.helpers.run.user(args, ["systemctl", "is-active", "-q", "nfcd"], check=False) == 0):
+        command = ["systemctl", "stop", "nfcd"]
+        tools.helpers.run.user(args, command, check=False)
 
     # Set permissions
     set_permissions(args)
@@ -194,6 +197,9 @@ def stop(args, quit_session=True):
         #TODO: remove NFC hacks
         if which("start"):
             command = ["start", "nfcd"]
+            tools.helpers.run.user(args, command, check=False)
+        elif which("systemctl") and (tools.helpers.run.user(args, ["systemctl", "is-enabled", "-q", "nfcd"], check=False) == 0):
+            command = ["systemctl", "start", "nfcd"]
             tools.helpers.run.user(args, command, check=False)
 
         # Sensors


### PR DESCRIPTION
Toggling NFC on Ubuntu Touch 20.04 System Settings while Waydroid is running breaks NFC for apps currently until another session is started.