### PR TITLE
arch: Fallback to arm on weird arm64 kernels with 32-bit userspace

### DIFF
--- a/tools/helpers/arch.py
+++ b/tools/helpers/arch.py
@@ -24,5 +24,7 @@ def maybe_remap(target):
             if "sse4_2" not in f.read():
                 logging.info("x86_64 CPU does not support SSE4.2, falling back to x86...")
                 return "x86"
+    elif target == "arm64" and platform.architecture()[0] == "32bit":
+        return "arm"
 
     return target


### PR DESCRIPTION
Typically `armv8l` should catch these, but it seems some Android downstream kernels at least cheat and don't report the correct thing.