### PR TITLE
Fix last hardcoded direct usages of AppIcon.png

### DIFF
--- a/data/waydroid.app.install.desktop
+++ b/data/waydroid.app.install.desktop
@@ -4,4 +4,4 @@ Name=Install in Waydroid
 NoDisplay=true
 MimeType=application/vnd.android.package-archive
 Exec=/usr/bin/waydroid app install %f
-Icon=/usr/lib/waydroid/data/AppIcon.png
+Icon=waydroid

--- a/data/waydroid.app.install.desktop
+++ b/data/waydroid.app.install.desktop
@@ -3,5 +3,5 @@ Type=Application
 Name=Install in Waydroid
 NoDisplay=true
 MimeType=application/vnd.android.package-archive
-Exec=/usr/bin/waydroid app install %f
+Exec=waydroid app install %f
 Icon=waydroid

--- a/data/waydroid.market.desktop
+++ b/data/waydroid.market.desktop
@@ -2,7 +2,7 @@
 Name=Waydroid Market
 Comment=Android Market Protocol Handler
 Exec=waydroid app intent android.intent.action.VIEW %u
-Icon=/usr/lib/waydroid/data/AppIcon.png
+Icon=waydroid
 Type=Application
 Encoding=UTF-8
 Terminal=false

--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -293,7 +293,7 @@ def remote_init_client(args):
             channels_cfg = tools.config.load_channels()
 
             self.set_default_size(600, 250)
-            self.set_icon_from_file(tools.config.tools_src + "/data/AppIcon.png")
+            self.set_icon_name("waydroid")
 
             grid = Gtk.Grid(row_spacing=6, column_spacing=6, margin=10, column_homogeneous=True)
             grid.set_hexpand(True)


### PR DESCRIPTION
Since 574405d it's additionally installed under a 512x512 XDG icon dir just looking it up by `waydroid` should work.

@aleasto Please confirm the `first-launch` GTK3 window icon works properly ideally under both KDE and GNOME; my typical test compositor `weston` has no window icons to speak of :)