### PR TITLE
Add App Settings to .desktop file

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -28,6 +28,10 @@ def start(args, session, unlocked_cb=None):
             lines.append("Exec=waydroid app launch " + packageName)
             lines.append("Icon=" + args.waydroid_data + "/icons/" + packageName + ".png")
             lines.append("X-Purism-FormFactor=Workstation;Mobile;")
+            lines.append("Actions=app_settings;")
+            lines.append("[Desktop Action app_settings]")
+            lines.append("Name=App Settings")
+            lines.append("Exec=waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:" + packageName)
             desktop_file = open(desktop_file_path, "w")
             for line in lines:
                 desktop_file.write(line + "\n")


### PR DESCRIPTION
This pull request adds an option to open the App's Settings page to easily manage the app's permissions or to uninstall the app, similar to GNOMES "Show Details"

![image](https://user-images.githubusercontent.com/71790678/226015951-76137c11-9a34-4cb0-a16c-4a41d6ac6cd1.png)

Closes #805