### PR TITLE
Add X-WayDroid-App category to auto-generated WayDroid desktop files

### DIFF
--- a/data/Waydroid.desktop
+++ b/data/Waydroid.desktop
@@ -3,4 +3,5 @@ Type=Application
 Name=Waydroid
 Exec=waydroid first-launch
 Icon=waydroid
+Categories=X-WayDroid-App;
 X-Purism-FormFactor=Workstation;Mobile;

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -27,6 +27,7 @@ def start(args, session, unlocked_cb=None):
             lines.append("Name=" + appInfo["name"])
             lines.append("Exec=waydroid app launch " + packageName)
             lines.append("Icon=" + args.waydroid_data + "/icons/" + packageName + ".png")
+            lines.append("Categories=X-WayDroid-App;")
             lines.append("X-Purism-FormFactor=Workstation;Mobile;")
             desktop_file = open(desktop_file_path, "w")
             for line in lines:
@@ -42,6 +43,7 @@ def start(args, session, unlocked_cb=None):
         lines = ["[Desktop Entry]", "Type=Application"]
         lines.append("Name=Waydroid")
         lines.append("Exec=waydroid show-full-ui")
+        lines.append("Categories=X-WayDroid-App;")
         lines.append("X-Purism-FormFactor=Workstation;Mobile;")
         if hide:
             lines.append("NoDisplay=true")


### PR DESCRIPTION
This pull request adds the 'X-WayDroid-App' category to the WayDroid desktop file and those for apps installed inside WayDroid, to allow for them to be grouped by the desktop environment.