### PR TITLE
.desktop files should not be executable

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -18,7 +18,7 @@ def start(args, session, unlocked_cb=None):
                 showApp = True
         if not showApp:
             return -1
-        
+
         packageName = appInfo["packageName"]
 
         desktop_file_path = args.apps_dir + "/waydroid." + packageName + ".desktop"
@@ -37,7 +37,7 @@ def start(args, session, unlocked_cb=None):
             for line in lines:
                 desktop_file.write(line + "\n")
             desktop_file.close()
-            os.chmod(desktop_file_path, 0o755)
+            os.chmod(desktop_file_path, 0o644)
             return 0
 
     def makeWaydroidDesktopFile(hide):

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -56,7 +56,7 @@ def start(args, session, unlocked_cb=None):
         for line in lines:
             desktop_file.write(line + "\n")
         desktop_file.close()
-        os.chmod(desktop_file_path, 0o755)
+        os.chmod(desktop_file_path, 0o644)
 
     def userUnlocked(uid):
         logging.info("Android with user {} is ready".format(uid))


### PR DESCRIPTION
waydroid create .desktop files in a user's ~/.local/share/applications folder with chmod 755 permissions. They should be 644. The permissions are properly set for the desktop file in /usr/share/applications