### PR TITLE
Add device IP address to status, auto adb connect

### DIFF
--- a/tools/actions/status.py
+++ b/tools/actions/status.py
@@ -3,6 +3,7 @@
 import os
 import tools.config
 import tools.helpers.ipc
+import tools.helpers.net
 import dbus
 
 def print_status(args):
@@ -17,6 +18,7 @@ def print_status(args):
             print("Session:\tRUNNING")
             print("Container:\t" + session["state"])
             print("Vendor type:\t" + cfg["waydroid"]["vendor_type"])
+            print("IP address:\t" + (tools.helpers.net.get_device_ip_address() or "UNKNOWN"))
             print("Session user:\t{}({})".format(session["user_name"], session["user_id"]))
             print("Wayland display:\t" + session["wayland_display"])
         else:

--- a/tools/helpers/net.py
+++ b/tools/helpers/net.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Maximilian Wende
+# SPDX-License-Identifier: GPL-3.0-or-later
+from shutil import which
+import tools.helpers.run
+import logging
+import re
+
+def adb_connect(args):
+    """
+    Creates an android debugging connection from the host system to the
+    Waydroid device, if ADB is found on the host system and the device
+    has booted.
+    """
+    # Check if adb exists on the system.
+    if not which("adb"):
+        return
+
+    # Start and 'warm up' the adb server
+    tools.helpers.run.user(args, ["adb", "start-server"])
+
+    ip = get_device_ip_address()
+    if not ip:
+        return
+
+    tools.helpers.run.user(args, ["adb", "connect", ip])
+    logging.info("Established ADB connection to Waydroid device at {}.".format(ip))
+
+def get_device_ip_address():
+    # The IP address is queried from the DHCP lease file.
+    lease_file = "/var/lib/misc/dnsmasq.waydroid0.leases"
+
+    try:
+        with open(lease_file) as f:
+            return re.search("(\d{1,3}\.){3}\d{1,3}\s", f.read()).group().strip()
+    except:
+        pass

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -4,6 +4,7 @@ import logging
 import os
 import threading
 import tools.config
+import tools.helpers.net
 from tools.interfaces import IUserMonitor
 from tools.interfaces import IPlatform
 
@@ -65,6 +66,8 @@ def start(args, session, unlocked_cb=None):
 
     def userUnlocked(uid):
         logging.info("Android with user {} is ready".format(uid))
+
+        tools.helpers.net.adb_connect(args)
 
         platformService = IPlatform.get_service(args)
         if platformService:


### PR DESCRIPTION
To make my workflow during android development easier, I implemented
- a display of Waydroid's local IP address to the status command
- an automatic call to ADB connect (if available on the host system) once the system is ready

The IP address is taken from the DHCP lease file for the default network configuration. Tested on cachyos with Waydroid installed from the AUR.

As I am not very familiar with Python or with the code structure, any feedback is very appreciated. Please let me know if this fits the project or if changes are necessary for issues or use cases that I didn't think of.

Possible alternatives:
- Just displaying the IP address in the status
- Adding a subcommand, such as `waydroid adb connect` instead of automatically connecting

Some related issues: #164 #845 