### PR TITLE
Switch AppArmor profiles into "enforce" mode with changes required by Google Play Services to work

### DIFF
--- a/data/configs/apparmor_profiles/adbd
+++ b/data/configs/apparmor_profiles/adbd
@@ -1,4 +1,4 @@
-profile adbd flags=(attach_disconnected,mediate_deleted,complain) {
+profile adbd flags=(attach_disconnected,mediate_deleted) {
   /** ix,
   /dev** rw,
   network,

--- a/data/configs/apparmor_profiles/android_app
+++ b/data/configs/apparmor_profiles/android_app
@@ -1,4 +1,4 @@
-profile android_app flags=(attach_disconnected, complain, mediate_deleted) {
+profile android_app flags=(attach_disconnected, mediate_deleted) {
   /** ix,
   /dev** rw,
   network,
@@ -49,6 +49,7 @@ profile android_app flags=(attach_disconnected, complain, mediate_deleted) {
   /data/dalvik-cache** r,
   /data/misc** r,
   /data/lineageos_updates** r,
+  /data/resource-cache** r,
   /apex** mr,
   /data/system_ce/** rw,
   /data/data/com.android** rw,

--- a/data/configs/apparmor_profiles/lxc-waydroid
+++ b/data/configs/apparmor_profiles/lxc-waydroid
@@ -1,4 +1,4 @@
-profile lxc-waydroid flags=(attach_disconnected, complain, mediate_deleted) {
+profile lxc-waydroid flags=(attach_disconnected, mediate_deleted) {
   /** ix,
   /system/bin/app_process Pix -> lxc-waydroid//&android_app,
   /system/bin/app_process32 Pix -> lxc-waydroid//&android_app,


### PR DESCRIPTION
Hello everyone!

During the last year, [a commit has been merged](https://github.com/waydroid/waydroid/pull/506) that enables AppArmor for the container. In order to avoid breaking any existing installations and work out policy mistakes, all profiles have been switched into the complain mode, in which AppArmor handles domain transitions, logs violations, but doesn't enforce rules (except for deny rules). If proposed AppArmor policies are somehow too restrictive for a container to work properly, it will show up in the audit log.

If you have AppArmor enabled on your system, you can help with AppArmor support in Waydroid:

* by reporting any policy violations by Android container processes in the audit log on your system (/var/log/audit/audit.log if auditd is installed and system log if it's not). They are reported in the AVC category, with "ALLOWED" label if the profile is in complain mode and "DENIED" label if it's in enforce mode
* by switching the profiles into enforce mode and reporting any problems in Waydroid container resulted from that

During [the latest attempt to switch them info *enforce* mode](https://github.com/waydroid/waydroid/pull/725), a problem has been detected that prevented GAPPS images from working. In order to fix that, additional allow rule has been added. I've tried, the official GAPPS image boots fine with that change.