### PR TITLE
I propose workarounds for restrictions built in the "run-as" utility

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -130,6 +130,9 @@ def main():
                 actions.app_manager.showFullUI(args)
         elif args.action == "status":
             actions.status.print_status(args)
+        elif args.action == "make-debuggable":
+            actionNeedRoot(args.action)
+            helpers.lxc.forcedebuggable(args)
         elif args.action == "log":
             if args.clear_log:
                 helpers.run.user(args, ["truncate", "-s", "0", args.log])

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -112,6 +112,12 @@ def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
     ret.add_argument('COMMAND', nargs='*', help="command to run")
     return ret
+    
+def arguments_force_debuggable(subparser):
+    ret = subparser.add_parser("make-debuggable", help="mark the given package as debuggable")
+    ret.add_argument("-D","--unsafe", action="store_true", help="disable the safety check that causes this command to exit if the package is not found (Not recommended!)")
+    ret.add_argument('PACKAGE', help="the package name of the app")
+    return ret
 
 def arguments_logcat(subparser):
     ret = subparser.add_parser("logcat", help="show android logcat")
@@ -153,6 +159,7 @@ def arguments():
     arguments_fullUI(sub)
     arguments_firstLaunch(sub)
     arguments_shell(sub)
+    arguments_force_debuggable(sub)
     arguments_logcat(sub)
 
     if argcomplete:


### PR DESCRIPTION
# Hello everyone!

Recently, I was researching the ```run-as``` utility pre-installed in the Android. It allows to run an arbitrary command in the context of an arbitrary package (kind of like ```sudo```, but with apps instead of users). However, it has restrictions which seriously limit it usefulness -- the one I have the problem with, is that it does not accept packages which are not marked as debuggable. In this pull request, I solve this problem by tampering with the Android package list and marking the requested package as debuggable. This is done in a manner similar to the ```waydroid shell``` command, however, instead of running an arbitrary command, it will execute ```sed``` with a custom script that lists the given package as debuggable. After that, ```run-as``` accepts this package name.

# Problems I've run into while making this PR

* ```sh``` may fail due to lack of controlling tty -- one of the possible solutions that worked for me was described in #145 
* ```run-as``` still conforms to other restrictions, for example, it will refuse to accept some system applications
* This workaround does not actually make the app debuggable -- it just tampers with the package list to make it appear as debuggable to ```libpackagelistparser``` (and to ```run-as```). Unlike true debuggability, this one is not preserved across reboot or package installations and uninstallations -- the user may have to run this command again after container reboots or any changes to the package list.
* Since Android is designed for use with SELinux, ```run-as``` is unaware of AppArmor and will not switch to the necessary profile. All commands run with ```run-as``` will run under ```lxc-waydroid``` profile, and ```run-as``` is not able to run with ```android_app``` profile. ~In this pull request, I solve this by AppArmor policy amendment that introduces the fourth profile, ```run-as```, designed specifically for this utility, in which ```execve``` on all binaries leads to transition to the ```android_app``` profile (it's just a modified copy of the ```lxc-waydroid``` profile~ (see below)