### PR TITLE
Allow running a shell command as an arbitrary user and group and with an arbitrary security context

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -119,6 +119,9 @@ def main():
         elif args.action == "shell":
             actionNeedRoot(args.action)
             helpers.lxc.shell(args)
+        elif args.action == "custom-shell":
+            actionNeedRoot(args.action)
+            helpers.lxc.custom_shell(args)
         elif args.action == "logcat":
             actionNeedRoot(args.action)
             helpers.lxc.logcat(args)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -119,9 +119,6 @@ def main():
         elif args.action == "shell":
             actionNeedRoot(args.action)
             helpers.lxc.shell(args)
-        elif args.action == "custom-shell":
-            actionNeedRoot(args.action)
-            helpers.lxc.custom_shell(args)
         elif args.action == "logcat":
             actionNeedRoot(args.action)
             helpers.lxc.logcat(args)

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -110,6 +110,12 @@ def arguments_firstLaunch(subparser):
 
 def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
+    ret.add_argument("-u", "--uid", help="the UID to run as (also sets GID to the same value if -g is not set)")
+    ret.add_argument("-g", "--gid", help="the GID to run as")
+    ret.add_argument("-s", "--context", help="transition to the specified SELinux or AppArmor security context. No-op if -L is supplied.")
+    ret.add_argument("-L", "--nolsm", action="store_true", help="tell LXC not to perform security domain transition related to mandatory access control (e.g. SELinux, AppArmor). If this option is supplied, LXC won't apply a container-wide seccomp filter to the executed program. This is a dangerous option that can result in leaking privileges to the container!!!")
+    ret.add_argument("-C", "--allcaps", action="store_true", help="tell LXC not to drop capabilities. This is a dangerous option that can result in leaking privileges to the container!!!")
+    ret.add_argument("-G", "--nocgroup", action="store_true", help="tell LXC not to switch to the container cgroup. This is a dangerous option that can result in leaking privileges to the container!!!")
     ret.add_argument('COMMAND', nargs='*', help="command to run")
     return ret
 

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -110,6 +110,11 @@ def arguments_firstLaunch(subparser):
 
 def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
+    ret.add_argument('COMMAND', nargs='*', help="command to run")
+    return ret
+    
+def arguments_shell2(subparser):
+    ret = subparser.add_parser("custom-shell", help="run remote shell command as an arbitrary user and group, and with arbitrary security context")
     ret.add_argument("-u", "--uid", help="the UID to run as (also sets GID to the same value if -g is not set)")
     ret.add_argument("-g", "--gid", help="the GID to run as")
     ret.add_argument("-s", "--context", help="transition to the specified SELinux or AppArmor security context. No-op if -L is supplied.")
@@ -159,6 +164,7 @@ def arguments():
     arguments_fullUI(sub)
     arguments_firstLaunch(sub)
     arguments_shell(sub)
+    arguments_shell2(sub)
     arguments_logcat(sub)
 
     if argcomplete:

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -110,11 +110,6 @@ def arguments_firstLaunch(subparser):
 
 def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
-    ret.add_argument('COMMAND', nargs='*', help="command to run")
-    return ret
-    
-def arguments_shell2(subparser):
-    ret = subparser.add_parser("custom-shell", help="run remote shell command as an arbitrary user and group, and with arbitrary security context")
     ret.add_argument("-u", "--uid", help="the UID to run as (also sets GID to the same value if -g is not set)")
     ret.add_argument("-g", "--gid", help="the GID to run as")
     ret.add_argument("-s", "--context", help="transition to the specified SELinux or AppArmor security context. No-op if -L is supplied.")
@@ -164,7 +159,6 @@ def arguments():
     arguments_fullUI(sub)
     arguments_firstLaunch(sub)
     arguments_shell(sub)
-    arguments_shell2(sub)
     arguments_logcat(sub)
 
     if argcomplete:

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -465,24 +465,24 @@ def custom_shell(args):
         command.append("--gid="+str(args.uid))
     if args.nolsm or args.allcaps or args.nocgroup:
         elevatedprivs = "--elevated-privileges="
-        addpipe = 0
+        addpipe = False
         if args.nolsm:
             if addpipe:
                 elevatedprivs+="|"
             elevatedprivs+="LSM"
-            addpipe = 1
+            addpipe = True
         if args.allcaps:
             if (addpipe == 1):
                 elevatedprivs+="|CAP"
             else:
                 elevatedprivs+="CAP"
-            addpipe = 1
+            addpipe = True
         if args.nocgroup:
             if (addpipe == 1):
                 elevatedprivs+="|CGROUP"
             else:
                 elevatedprivs+="CGROUP"
-            addpipe = 1
+            addpipe = True
         command.append(elevatedprivs)
     if args.context!=None and not args.nolsm:
         command.append("--context="+args.context)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -12,7 +12,6 @@ import gbinder
 import tools.config
 import tools.helpers.run
 
-
 def get_lxc_version(args):
     if shutil.which("lxc-info") is not None:
         command = ["lxc-info", "--version"]
@@ -439,6 +438,36 @@ def shell(args):
     command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
                "-n", "waydroid", "--clear-env"]
     command.extend(android_env_attach_options())
+    if args.uid!=None:
+        command.append("--uid="+str(args.uid))
+    if args.gid!=None:
+        command.append("--gid="+str(args.gid))
+    elif args.uid!=None:
+        command.append("--gid="+str(args.uid))
+    if args.nolsm or args.allcaps or args.nocgroup:
+        elevatedprivs = "--elevated-privileges="
+        addpipe = 0
+        if args.nolsm:
+            if (addpipe == 1):
+                elevatedprivs+="|LSM"
+            else:
+                elevatedprivs+="LSM"
+            addpipe = 1
+        if args.allcaps:
+            if (addpipe == 1):
+                elevatedprivs+="|CAP"
+            else:
+                elevatedprivs+="CAP"
+            addpipe = 1
+        if args.nocgroup:
+            if (addpipe == 1):
+                elevatedprivs+="|CGROUP"
+            else:
+                elevatedprivs+="CGROUP"
+            addpipe = 1
+        command.append(elevatedprivs)
+    if args.context!=None and not args.nolsm:
+        command.append("--context="+args.context)
     command.append("--")
     if args.COMMAND:
         command.extend(args.COMMAND)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -438,25 +438,6 @@ def shell(args):
     command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
                "-n", "waydroid", "--clear-env"]
     command.extend(android_env_attach_options())
-    command.append("--")
-    if args.COMMAND:
-        command.extend(args.COMMAND)
-    else:
-        command.append("/system/bin/sh")
-    subprocess.run(command)
-    if state == "FROZEN":
-        freeze(args)
-        
-def custom_shell(args):
-    state = status(args)
-    if state == "FROZEN":
-        unfreeze(args)
-    elif state != "RUNNING":
-        logging.error("WayDroid container is {}".format(state))
-        return
-    command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
-               "-n", "waydroid", "--clear-env"]
-    command.extend(android_env_attach_options())
     if args.uid!=None:
         command.append("--uid="+str(args.uid))
     if args.gid!=None:

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -453,16 +453,14 @@ def shell(args):
             elevatedprivs+="LSM"
             addpipe = True
         if args.allcaps:
-            if (addpipe == 1):
-                elevatedprivs+="|CAP"
-            else:
-                elevatedprivs+="CAP"
+            if addpipe:
+                elevatedprivs+="|"
+            elevatedprivs+="CAP"
             addpipe = True
         if args.nocgroup:
-            if (addpipe == 1):
-                elevatedprivs+="|CGROUP"
-            else:
-                elevatedprivs+="CGROUP"
+            if addpipe:
+                elevatedprivs+="|"
+            elevatedprivs+="CGROUP"
             addpipe = True
         command.append(elevatedprivs)
     if args.context!=None and not args.nolsm:

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -438,6 +438,25 @@ def shell(args):
     command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
                "-n", "waydroid", "--clear-env"]
     command.extend(android_env_attach_options())
+    command.append("--")
+    if args.COMMAND:
+        command.extend(args.COMMAND)
+    else:
+        command.append("/system/bin/sh")
+    subprocess.run(command)
+    if state == "FROZEN":
+        freeze(args)
+        
+def custom_shell(args):
+    state = status(args)
+    if state == "FROZEN":
+        unfreeze(args)
+    elif state != "RUNNING":
+        logging.error("WayDroid container is {}".format(state))
+        return
+    command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
+               "-n", "waydroid", "--clear-env"]
+    command.extend(android_env_attach_options())
     if args.uid!=None:
         command.append("--uid="+str(args.uid))
     if args.gid!=None:

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -467,10 +467,9 @@ def custom_shell(args):
         elevatedprivs = "--elevated-privileges="
         addpipe = 0
         if args.nolsm:
-            if (addpipe == 1):
-                elevatedprivs+="|LSM"
-            else:
-                elevatedprivs+="LSM"
+            if addpipe:
+                elevatedprivs+="|"
+            elevatedprivs+="LSM"
             addpipe = 1
         if args.allcaps:
             if (addpipe == 1):


### PR DESCRIPTION
# Hello everyone!

In this pull request, I propose a new subcommand, ```waydroid custom-shell```, that runs a shell command in the Android container as an arbitrary user, not just as root. It works in a way similar to ```waydroid shell```, by running ```lxc-launch```, but passes more command-line arguments to it. Currently, we have the ```waydroid shell``` subcommand that allows running a command inside the Android container as root. However, unlike the vast majority of other Linux distributions, Android doesn't have any utility similar to ```su``` or ```doas```, which makes running a command as an arbitrary user harder (and not all commands have to be run with the most privileged security context. In this PR, I add another subcommand that accepts more command-line arguments that alllow the user to set UID, GID, SELinux or AppArmor context, and also allow running without AppArmor/seccomp protection, with all capabilities and within the same cgroup (the last three are listed as dangerous as they can leak privileges inside the container, however, I don't think that it's going to be an issue since only the host root is allowed to call this command).

# Alternatives to this pull request

* ```su``` from Magisk -- works, but requires to install Magisk (and I don't like having rooting solutions in a privileged container)
* ```su``` from BusyBox -- works, but requires to have the ```/etc/passwd``` file to be filled with valid entries (can be solved through bind-mounting), not that convenient to use
* patched ```su``` inside the container -- a good idea, but requires writing or adapting an existing ```su``` implementation (it can also require linking with Android libraries, but we can just statically link it with desktop Linux libraries)
* call ```lxc-attach``` directly -- works, but not as convenient
* ```nsenter``` -- a very dangerous alternative, because it does not [clear the capability bounding set](https://github.com/waydroid/waydroid/pull/504), does not enable the ["No New Privileges" restriction](https://github.com/waydroid/waydroid/pull/503), does not [load the seccomp filter](https://github.com/waydroid/waydroid/pull/505) and does not transition to a more secure AppArmor profile. As a result, it can leak privileges inside the container.
* ```run-as``` -- not the same, because it runs a command from a context assigned to an installed app (and does not allow running the command as ```system``` or ```shell``` user, for example), and enforces its own nasty restrictions (that require [some dirty tricks](https://github.com/waydroid/waydroid/pull/994) in order to get it working on non-debuggable packages without patching Android)