### PR TITLE
clipboard: change warning message to be less misleading

### DIFF
--- a/tools/services/clipboard_manager.py
+++ b/tools/services/clipboard_manager.py
@@ -37,7 +37,7 @@ def start(args):
         args.clipboard_manager = threading.Thread(target=service_thread)
         args.clipboard_manager.start()
     else:
-        logging.warning("Failed to start Clipboard manager service, check logs")
+        logging.warning("Skipping clipboard manager service because of missing pyclip package")
 
 def stop(args):
     global stopping


### PR DESCRIPTION
Repeatedly, people have understood the current warning as indication of the actual problem they experience (#83, #117, #276…) so make it more informative & a little less dramatic.