### PR TITLE
container_manager: Keep schedtune cgroup around in case nesting is supported

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -146,9 +146,20 @@ def do_start(args, session):
     if which("start"):
         command = ["start", "cgroup-lite"]
         tools.helpers.run.user(args, command, check=False)
+
+    # Keep schedtune around in case nesting is supported
     if os.path.ismount("/sys/fs/cgroup/schedtune"):
-        command = ["umount", "-l", "/sys/fs/cgroup/schedtune"]
-        tools.helpers.run.user(args, command, check=False)
+        try:
+            os.mkdir("/sys/fs/cgroup/schedtune/probe0")
+            os.mkdir("/sys/fs/cgroup/schedtune/probe0/probe1")
+        except:
+            command = ["umount", "-l", "/sys/fs/cgroup/schedtune"]
+            tools.helpers.run.user(args, command, check=False)
+        finally:
+            if os.path.exists("/sys/fs/cgroup/schedtune/probe0/probe1"):
+                os.rmdir("/sys/fs/cgroup/schedtune/probe0/probe1")
+            if os.path.exists("/sys/fs/cgroup/schedtune/probe0"):
+                os.rmdir("/sys/fs/cgroup/schedtune/probe0")
 
     #TODO: remove NFC hacks
     if which("stop"):


### PR DESCRIPTION
Certain devices with Ubuntu Touch make use of the schedtune cgroup boosting mechanism, allowing for better performance system-wide with very little tweaking. Some devices have trouble using this cgroup in a regular GNU/Linux setting because their kernels are not carrying the necessary kernel patch for enabling nesting [here].

To please both those that want Waydroid to stop dropping their performance as well as those having unpatched kernels, probe the capability to nest schedtune cgroups before deciding to unmount it.

[here]: https://gitlab.com/ubports/porting/reference-device-ports/android9/google-pixel-3a/android_kernel_google_bonito/-/commit/6452429d1f1dbdc9e1e310e82cc18664f2d1b56d