### PR TITLE
Add an option to decide whether to create a desktop file

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -22,7 +22,8 @@ config_keys = ["arch",
                "system_datetime",
                "vendor_datetime",
                "suspend_action",
-               "mount_overlays"]
+               "mount_overlays",
+               "show_waydroid_apps"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -39,6 +40,7 @@ defaults = {
     ],
     "suspend_action": "freeze",
     "mount_overlays": "True",
+    "show_waydroid_apps": "True",
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -76,7 +76,7 @@ def start(args, session, unlocked_cb=None):
                 os.mkdir(apps_dir)
                 os.chmod(apps_dir, 0o700)
             
-            if cfg["waydroid"].get("show_waydroid_apps") == "True":
+            if cfg["waydroid"].get("show_waydroid_apps", "True") == "True":
                 appsList = platformService.getAppsInfo()
                 for app in appsList:
                     makeDesktopFile(app)
@@ -97,7 +97,7 @@ def start(args, session, unlocked_cb=None):
             desktop_file_path = apps_dir + "/waydroid." + packageName + ".desktop"
             if mode == 0:
                 # Package added
-                if cfg["waydroid"].get("show_waydroid_apps") == "True":
+                if cfg["waydroid"].get("show_waydroid_apps", "True") == "True":
                     makeDesktopFile(appInfo)
             elif mode == 1:
                 if os.path.isfile(desktop_file_path):

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -13,6 +13,7 @@ stopping = False
 def start(args, session, unlocked_cb=None):
     waydroid_data = session["waydroid_data"]
     apps_dir = session["xdg_data_home"] + "/applications/"
+    cfg = tools.config.load(args)
 
     def makeDesktopFile(appInfo):
         if appInfo is None:
@@ -74,12 +75,16 @@ def start(args, session, unlocked_cb=None):
             if not os.path.exists(apps_dir):
                 os.mkdir(apps_dir)
                 os.chmod(apps_dir, 0o700)
-            appsList = platformService.getAppsInfo()
-            for app in appsList:
-                makeDesktopFile(app)
-            multiwin = platformService.getprop("persist.waydroid.multi_windows", "false")
-            if multiwin == "false":
-                makeWaydroidDesktopFile(False)
+            
+            if cfg["waydroid"].get("show_waydroid_apps") == "True":
+                appsList = platformService.getAppsInfo()
+                for app in appsList:
+                    makeDesktopFile(app)
+                multiwin = platformService.getprop("persist.waydroid.multi_windows", "false")
+                if multiwin == "false":
+                    makeWaydroidDesktopFile(False)
+                else:
+                    makeWaydroidDesktopFile(True)
             else:
                 makeWaydroidDesktopFile(True)
         if unlocked_cb:
@@ -92,13 +97,17 @@ def start(args, session, unlocked_cb=None):
             desktop_file_path = apps_dir + "/waydroid." + packageName + ".desktop"
             if mode == 0:
                 # Package added
-                makeDesktopFile(appInfo)
+                if cfg["waydroid"].get("show_waydroid_apps") == "True":
+                    makeDesktopFile(appInfo)
             elif mode == 1:
                 if os.path.isfile(desktop_file_path):
                     os.remove(desktop_file_path)
             else:
                 if os.path.isfile(desktop_file_path):
-                    if makeDesktopFile(appInfo) == -1:
+                    if cfg["waydroid"].get("show_waydroid_apps", "True") == "True":
+                        if makeDesktopFile(appInfo) == -1:
+                            os.remove(desktop_file_path)
+                    else:
                         os.remove(desktop_file_path)
 
     def service_thread():


### PR DESCRIPTION
Add new options `show_waydroid_apps` in `waydroid.cfg` to decide whether to create a dot desktop file for all apps.