### PR TITLE
Allow local amendments to the AppArmor policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ install:
 
 install_apparmor:
 	install -d $(INSTALL_APPARMOR_DIR) $(INSTALL_APPARMOR_DIR)/lxc
+	mkdir -p $(INSTALL_APPARMOR_DIR)/local/
+	touch $(INSTALL_APPARMOR_DIR)/local/adbd
+	touch $(INSTALL_APPARMOR_DIR)/local/android_app
+	touch $(INSTALL_APPARMOR_DIR)/local/lxc-waydroid
 	cp -f data/configs/apparmor_profiles/adbd $(INSTALL_APPARMOR_DIR)/adbd
 	cp -f data/configs/apparmor_profiles/android_app $(INSTALL_APPARMOR_DIR)/android_app
 	cp -f data/configs/apparmor_profiles/lxc-waydroid $(INSTALL_APPARMOR_DIR)/lxc/lxc-waydroid

--- a/data/configs/apparmor_profiles/adbd
+++ b/data/configs/apparmor_profiles/adbd
@@ -1,4 +1,5 @@
 profile adbd flags=(attach_disconnected,mediate_deleted,complain) {
+  #include <local/adbd>
   /** ix,
   /dev** rw,
   network,

--- a/data/configs/apparmor_profiles/android_app
+++ b/data/configs/apparmor_profiles/android_app
@@ -1,4 +1,5 @@
 profile android_app flags=(attach_disconnected, complain, mediate_deleted) {
+  #include <local/android_app>
   /** ix,
   /dev** rw,
   network,

--- a/data/configs/apparmor_profiles/lxc-waydroid
+++ b/data/configs/apparmor_profiles/lxc-waydroid
@@ -1,4 +1,5 @@
 profile lxc-waydroid flags=(attach_disconnected, complain, mediate_deleted) {
+  #include <local/lxc-waydroid>
   /** ix,
   /system/bin/app_process Pix -> lxc-waydroid//&android_app,
   /system/bin/app_process32 Pix -> lxc-waydroid//&android_app,


### PR DESCRIPTION
Hello everyone! I propose adding an include to three AppArmor profiles currently supplied by the Waydroid project, in order to allow users to make their own amendments to the AppArmor policy. The reason for this is, when these changes are made in the main policy files, these changes can conflict with new versions of profiles during upgrades, and in some cases, get overwritten. In order to avoid this, we can store the Waydroid-supplied policy and user's changes separately, and update only Waydroid-supplied files.