### PR TITLE
debian: depend on iptables

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Depends: ${misc:Depends},
          gir1.2-gtk-3.0,
          python3-dbus,
          dbus,
-         policykit-1
+         policykit-1,
+         iptables
 Description: Android™ application support
  waydroid allows running a separate Android™ environment
  confined to a LXC container.


### PR DESCRIPTION
`USE_NFTABLES=0` is the default the package is built with, yet it doesn't depend on `iptables` which may be missing and breaks launching Waydroid due to networking script failing with `IP*TABLES_BIN` variables ending up empty.