### PR TITLE
Enable the "ro.adb.secure" property

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -244,6 +244,10 @@ def make_base_props(args):
     if not os.path.exists("/dev/ashmem"):
         props.append("sys.use_memfd=true")
 
+# Added for security reasons
+    props.append("ro.adb.secure=1")
+
+
     egl = tools.helpers.props.host_get(args, "ro.hardware.egl")
     dri, _ = tools.helpers.gpu.getDriNode(args)
 
@@ -260,6 +264,7 @@ def make_base_props(args):
             egl = "swiftshader"
         props.append("debug.stagefright.ccodec=0")
     props.append("ro.hardware.gralloc=" + gralloc)
+
 
     if egl != "":
         props.append("ro.hardware.egl=" + egl)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -244,11 +244,9 @@ def make_base_props(args):
     if not os.path.exists("/dev/ashmem"):
         props.append("sys.use_memfd=true")
 
-# Added for security reasons
+    # Added for security reasons
     props.append("ro.adb.secure=1")
     props.append("ro.debuggable=0")
-
-
     egl = tools.helpers.props.host_get(args, "ro.hardware.egl")
     dri, _ = tools.helpers.gpu.getDriNode(args)
 
@@ -265,7 +263,6 @@ def make_base_props(args):
             egl = "swiftshader"
         props.append("debug.stagefright.ccodec=0")
     props.append("ro.hardware.gralloc=" + gralloc)
-
 
     if egl != "":
         props.append("ro.hardware.egl=" + egl)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -246,6 +246,7 @@ def make_base_props(args):
 
 # Added for security reasons
     props.append("ro.adb.secure=1")
+    props.append("ro.debuggable=0")
 
 
     egl = tools.helpers.props.host_get(args, "ro.hardware.egl")


### PR DESCRIPTION
Hello everyone! I propose enabling the ```ro.adb.secure``` property.

**Explanation**:

Android Debug Bridge is a tools that allows remote communication with the Android system. On the Android system side, it's represented by the Android Debug Bridge Daemon, that runs as a special user (```shell```). ```ro.adb.secure``` is a property that allows ADBD to be managed by Android settings. If ```ro.adb.secure``` is set to ```0```, anyone that can connect to the Android system over network (including installed Android apps connecting to ```127.0.0.1```) can get access to the privileged shell with lots of irrevocable Android permissions, and remotely control the system through tools like ```scrcpy```. If it's set to ```1```, all such interactions have to be authorized by the user -- it cannot be done over network.

**Possible benefits**:

* ADB can be disabled in the settings (without re-enabling on container restart)
* ADB connections have to be authorized by user
* Such authorizations can be revoked

**Possible problems**:

I haven't found any.