### PR TITLE
Block the "open_by_handle_at" system call (part of anti-escape protection for rooted containers)

### DIFF
--- a/data/configs/waydroid.seccomp
+++ b/data/configs/waydroid.seccomp
@@ -7,6 +7,7 @@ _sysctl
 kexec_file_load
 kexec_load
 reboot
+open_by_handle_at errno 38
 adjtimex errno 0
 clock_adjtime errno 0
 clock_adjtime64 errno 0


### PR DESCRIPTION
Hello everyone! I propose blocking the ```open_by_handle_at``` system call container-wide.

**Explanation**:

Seccomp is a Linux kernel system call access self-restriction feature. A process can load a seccomp filter to the kernel that will check the system calls and block unwanted ones (or terminate the process).

```open_by_handle_at``` is a system call that allows a privileged process (for which ```CAP_DAC_READ_SEARCH``` is effective) to open a file referring it by a byte array known as file handle. The file handle can be obtained by any process using the ```name_to_handle_at``` system call. The reason why ```open_by_handle_at``` is dangerous is that a container may have some file systems mounted it with limited visibility using a bind mount (by which I mean, that a subdirectory of a file system is bind-mounted in a container, e.g., the ```/data``` partition is bind-mounted that way), so a file is only accessible by a path within a container if it has a hard link inside a bind-mounted directory (for example, ```/data``` is stored in a user's home directory, but a container process cannot access arbitrary files, only those in the ```~/.local/share/waydroid/data```). File handles do not behave this way, a file can be opened by its handle if it is located on a bind-mounted filesystem regardless of whether it has hard-links inside of bind-mounted directory or not. Which means, a process running as root (more correctly, any process that has ```CAP_DAC_READ_SEARCH``` capability) can theoretically open any file in a user's home directory if it knows its file handle. In fact, [```open_by_handle_at``` has been used in a container escape before](https://www.openwall.com/lists/oss-security/2014/06/24/16) and [some container solutions do block it](https://github.com/moby/moby/pull/45766).

**Possible benefits**:

* Preventing one of the most obvious container escape ways
* Protecting rooted (with Magisk, for example) containers from abuse by unprivileged users (since root in a container has both ```CAP_DAC_READ_SEARCH``` and ```CAP_DAC_OVERRIDE```, an unprivileged user can retrieve a file handle with ```name_to_handle_at```, then use it in a container root shell)

**Possible problems**:

I don't see any -- I don't recall ```open_by_handle_at``` being used outside of user-space NFS servers, and it's not like they are widely used in Waydroid -- meanwhile, mobile apps already cannot use ```open_by_handle_at``` due to lack of capabilities.