### PR TITLE
Don't change user-defined desktop files for Waydroid when they're set as read-only

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -49,10 +49,14 @@ Icon={waydroid_data}/icons/com.android.settings.png
 
     def makeWaydroidDesktopFile(hide):
         desktop_file_path = apps_dir + "/Waydroid.desktop"
-        if os.path.isfile(desktop_file_path):
-            os.remove(desktop_file_path)
-        with open(desktop_file_path, "w") as desktop_file:
-            desktop_file.write(f"""\
+        # If the user has set the desktop file as read-only, we won't replace it
+        if not os.access(desktop_file_path, os.W_OK):
+            logging.info(f"Desktop file '{desktop_file_path}' is not writeable, not updating it")
+        else:
+            if os.path.isfile(desktop_file_path):
+                os.remove(desktop_file_path)
+            with open(desktop_file_path, "w") as desktop_file:
+                desktop_file.write(f"""\
 [Desktop Entry]
 Type=Application
 Name=Waydroid


### PR DESCRIPTION
This PR is a proposal to solve PR https://github.com/waydroid/waydroid/pull/817.

- On usual installations, it won't change a thing to current behaviour.
- On installations where a user may want to preserve their changes to the `Waydroid.desktop` file, they now can by setting it as read-only (`chmod -r`, Windows readonly attribute, etc.).