### PR TITLE
update regex for deprecation warning

### DIFF
--- a/tools/helpers/net.py
+++ b/tools/helpers/net.py
@@ -31,6 +31,6 @@ def get_device_ip_address():
 
     try:
         with open(lease_file) as f:
-            return re.search("(\d{1,3}\.){3}\d{1,3}\s", f.read()).group().strip()
+            return re.search(r"(\d{1,3}\.){3}\d{1,3}\s", f.read()).group().strip()
     except:
         pass


### PR DESCRIPTION
Python interprets \d as invalid escape sequence.  In a future Python version there will be a SyntaxWarning and eventually a SyntaxError.

Fix this via declaring the RegEx pattern as a raw string instead by prepending r

![image](https://github.com/waydroid/waydroid/assets/9145965/e9077892-04c3-4a2d-aa86-005457f6edb1)
