### PR TITLE
Add SSSE3 CPU check for arch x86/x86_64

### DIFF
--- a/tools/helpers/arch.py
+++ b/tools/helpers/arch.py
@@ -19,11 +19,14 @@ def host():
                      " architecture is not supported")
 
 def maybe_remap(target):
-    if target == "x86_64":
+    if target.startswith("x86"):
         with open("/proc/cpuinfo") as f:
-            if "sse4_2" not in f.read():
-                logging.info("x86_64 CPU does not support SSE4.2, falling back to x86...")
-                return "x86"
+            cpuinfo = f.read()
+        if "ssse3" not in cpuinfo:
+            raise ValueError("x86/x86_64 CPU must support SSSE3!")
+        if target == "x86_64" and "sse4_2" not in cpuinfo:
+            logging.info("x86_64 CPU does not support SSE4.2, falling back to x86...")
+            return "x86"
     elif target == "arm64" and platform.architecture()[0] == "32bit":
         return "arm"
 


### PR DESCRIPTION
This patch adds a simple SSSE3 check for x86/x86_64 targets to provide log info and prevent container from simply crashing.

Fixes: (some) waydroid container/session "_fails to start_" issues

Greetings,

Waydroid installed on my CPU, initialized and downloaded images, but failed to start.

Only clue provided in waydroid.log was:
`lxc-start: waydroid: ../src/lxc/conf.c: run_buffer: 322 Script exited with status 126`
_(many unresolved issues present a similar line in their logs...)_

Debugging indicated it was actually crashing on an illegal instruction: `pshufb`.
...so it turns out **my CPU does not support SSSE3**.
related: [issue #617](https://github.com/waydroid/waydroid/issues/617#issuecomment-1725791124)

Yes, it's documented that `SSSE3` is required for all x86/x86_64 CPUs now:
[Android Supported Instruction Sets](https://developer.android.com/ndk/guides/abis#abi-table)

I think SSSE3 support implies MMX, SSE2 and SSE3 (pni) support, therefore those checks are not required.

Thanks!

(p.s. note related aborted [pr #132](https://github.com/waydroid/waydroid/pull/132))
