### PR TITLE
Add prefix to all install directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ WAYDROID_DIR := $(PREFIX)/lib/waydroid
 BIN_DIR := $(PREFIX)/bin
 APPS_DIR := $(PREFIX)/share/applications
 APPS_DIRECTORY_DIR := $(PREFIX)/share/desktop-directories
-APPS_MENU_DIR := /etc/xdg/menus/applications-merged
+APPS_MENU_DIR := $(PREFIX)/etc/xdg/menus/applications-merged
 METAINFO_DIR := $(PREFIX)/share/metainfo
 ICONS_DIR := $(PREFIX)/share/icons
 SYSD_DIR := $(PREFIX)/lib/systemd/system
 DBUS_DIR := $(PREFIX)/share/dbus-1
 POLKIT_DIR := $(PREFIX)/share/polkit-1
-APPARMOR_DIR := /etc/apparmor.d
+APPARMOR_DIR := $(PREFIX)/etc/apparmor.d
 
 INSTALL_WAYDROID_DIR := $(DESTDIR)$(WAYDROID_DIR)
 INSTALL_BIN_DIR := $(DESTDIR)$(BIN_DIR)


### PR DESCRIPTION
Otherwise the installs fail on NixOS for 1.4.2 because the application is not allowed to write there in the build sandbox.