### PR TITLE
Make ADB auto-connection opt-out

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -22,7 +22,8 @@ config_keys = ["arch",
                "system_datetime",
                "vendor_datetime",
                "suspend_action",
-               "mount_overlays"]
+               "mount_overlays",
+               "auto_adb"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -39,6 +40,7 @@ defaults = {
     ],
     "suspend_action": "freeze",
     "mount_overlays": "True",
+    "auto_adb": "True",
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -64,9 +64,11 @@ NoDisplay={str(hide).lower()}
 """)
 
     def userUnlocked(uid):
+        cfg = tools.config.load(args)
         logging.info("Android with user {} is ready".format(uid))
 
-        tools.helpers.net.adb_connect(args)
+        if cfg["waydroid"]["auto_adb"] == "True":
+            tools.helpers.net.adb_connect(args)
 
         platformService = IPlatform.get_service(args)
         if platformService:


### PR DESCRIPTION
Just because you have ADB installed (for e.g. physical Android device development) doesn't mean you necessarily want Waydroid to always also get automatically connected, allow disabling this functionality.

Also see #847 which originally made this mandatory by default (since v1.4.1)