### PR TITLE
Adds config support for overlays_readonly

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -23,7 +23,8 @@ config_keys = ["arch",
                "vendor_datetime",
                "suspend_action",
                "mount_overlays",
-               "auto_adb"]
+               "auto_adb",
+               "overlays_readonly"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -41,6 +42,7 @@ defaults = {
     "suspend_action": "freeze",
     "mount_overlays": "True",
     "auto_adb": "True",
+    "overlays_readonly": "True",
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/helpers/images.py
+++ b/tools/helpers/images.py
@@ -162,7 +162,8 @@ def mount_rootfs(args, images_dir, session):
                                                tools.config.defaults["rootfs"]],
                                     tools.config.defaults["rootfs"],
                                     upper_dir=tools.config.defaults["overlay_rw"] + "/system",
-                                    work_dir=tools.config.defaults["overlay_work"] + "/system")
+                                    work_dir=tools.config.defaults["overlay_work"] + "/system",
+                                    readonly=(cfg["waydroid"]["overlays_readonly"] == "True"))
         except RuntimeError:
             cfg["waydroid"]["mount_overlays"] = "False"
             tools.config.save(args, cfg)
@@ -175,7 +176,8 @@ def mount_rootfs(args, images_dir, session):
                                            tools.config.defaults["rootfs"] + "/vendor"],
                                     tools.config.defaults["rootfs"] + "/vendor",
                                     upper_dir=tools.config.defaults["overlay_rw"] + "/vendor",
-                                    work_dir=tools.config.defaults["overlay_work"] + "/vendor")
+                                    work_dir=tools.config.defaults["overlay_work"] + "/vendor",
+                                    readonly=(cfg["waydroid"]["overlays_readonly"] == "True"))
 
     for egl_path in ["/vendor/lib/egl", "/vendor/lib64/egl"]:
         if os.path.isdir(egl_path):


### PR DESCRIPTION
Some users workflows rely upon bind mounts for various filesystem paths, including beneath /vendor, and beneath /system. But assuming overlays to be readonly precludes such usage.  This commit exposes a configuration option, "overlays_readonly", for such users. The default behavior is unchanged.