### PR TITLE
Use synthetic paths for host sockets

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -41,6 +41,8 @@ defaults = {
     "suspend_action": "freeze",
     "mount_overlays": "True",
     "auto_adb": "True",
+    "container_xdg_runtime_dir": "/run/xdg",
+    "container_wayland_display": "wayland-0",
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"
@@ -50,6 +52,7 @@ defaults["overlay_work"] = defaults["work"] + "/overlay_work"
 defaults["data"] = defaults["work"] + "/data"
 defaults["lxc"] = defaults["work"] + "/lxc"
 defaults["host_perms"] = defaults["work"] + "/host-permissions"
+defaults["container_pulse_runtime_path"] = defaults["container_xdg_runtime_dir"] + "/pulse"
 
 session_defaults = {
     "user_name": pwd.getpwuid(os.getuid()).pw_name,

--- a/tools/helpers/images.py
+++ b/tools/helpers/images.py
@@ -136,10 +136,10 @@ def make_prop(args, cfg, full_props_path):
     add_prop("waydroid.host.uid", "user_id")
     add_prop("waydroid.host.gid", "group_id")
     add_prop("waydroid.host_data_path", "waydroid_data")
-    add_prop("waydroid.xdg_runtime_dir", "xdg_runtime_dir")
-    add_prop("waydroid.pulse_runtime_path", "pulse_runtime_path")
-    add_prop("waydroid.wayland_display", "wayland_display")
     add_prop("waydroid.background_start", "background_start")
+    props.append("waydroid.xdg_runtime_dir=" + tools.config.defaults["container_xdg_runtime_dir"])
+    props.append("waydroid.pulse_runtime_path=" + tools.config.defaults["container_pulse_runtime_path"])
+    props.append("waydroid.wayland_display=" + tools.config.defaults["container_wayland_display"])
     if which("waydroid-sensord") is None:
         props.append("waydroid.stub_sensors_hal=1")
     dpi = cfg["lcd_density"]

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -190,15 +190,18 @@ def generate_session_lxc_config(args, session):
         return add_node_entry(nodes, src, dist, mnt_type, options, check=False)
 
     # Make sure XDG_RUNTIME_DIR exists
-    if not make_entry("tmpfs", session["xdg_runtime_dir"], options="create=dir 0 0"):
+    if not make_entry("tmpfs", tools.config.defaults["container_xdg_runtime_dir"], options="create=dir 0 0"):
         raise OSError("Failed to create XDG_RUNTIME_DIR mount point")
 
-    wayland_socket = os.path.realpath(os.path.join(session["xdg_runtime_dir"], session["wayland_display"]))
-    if not make_entry(wayland_socket):
+    wayland_host_socket = os.path.realpath(os.path.join(session["xdg_runtime_dir"], session["wayland_display"]))
+    wayland_container_socket = os.path.realpath(os.path.join(tools.config.defaults["container_xdg_runtime_dir"], tools.config.defaults["container_wayland_display"]))
+    if not make_entry(wayland_host_socket, wayland_container_socket[1:]):
         raise OSError("Failed to bind Wayland socket")
 
-    pulse_socket = os.path.join(session["pulse_runtime_path"], "native")
-    make_entry(pulse_socket)
+    # Make sure PULSE_RUNTIME_DIR exists
+    pulse_host_socket = os.path.join(session["pulse_runtime_path"], "native")
+    pulse_container_socket = os.path.join(tools.config.defaults["container_pulse_runtime_path"], "native")
+    make_entry(pulse_host_socket, pulse_container_socket[1:])
 
     if not make_entry(session["waydroid_data"], "data", options="rbind 0 0"):
         raise OSError("Failed to bind userdata")


### PR DESCRIPTION
Mount XDG_RUNTIME_DIR, PULSE_RUNTIME_PATH and
WAYLAND_DISPLAY to our own synthetic paths in
/waydroid/xdg/...

That way, they can never clash with any of our
Android bindpoints.

Eg. /data/.../xdg/wayland-0 conflicts with /data