### PR TITLE
prevent recreate not mounted devtmpfs node by `mknod` & prevent access to kmsg

### DIFF
--- a/data/configs/waydroid.seccomp
+++ b/data/configs/waydroid.seccomp
@@ -20,3 +20,7 @@ keyctl errno 0
 request_key errno 0
 swapoff errno 0
 swapon errno 0
+mknod errno 0
+mknodat errno 0
+syslog
+klogctl


### PR DESCRIPTION
https://github.com/aosp-mirror/platform_system_core/blob/a8c6a92f4389604cdb400a4eb56ae98012625cf8/init/first_stage_init.cpp#L355-L366
https://android.googlesource.com/platform/system/core/+/master/init/README.md

on debuggable build. android init will try to create `/dev/kmsg`. and write init log to it. which polluted system log on host. and journald will slow down the whole system

i also dont think android container should have access to kernel log on host. which may contains sensitive info