### PR TITLE
initializer: Fix Halium version VNDK detection logic for 12L+

### DIFF
--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -23,6 +23,8 @@ def get_vendor_type(args):
     ret = "MAINLINE"
     if vndk_str != "":
         vndk = int(vndk_str)
+        if vndk > 31:
+            vndk -= 1 # 12L -> Halium 12
         if vndk > 19:
             ret = "HALIUM_" + str(vndk - 19)
 


### PR DESCRIPTION
API 32 (12L) vendor was getting detected as `HALIUM_13` which wouldn't work on devices when official images ship with support for these newer versions.