### PR TITLE
require WM on `bug_report` template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,6 +52,13 @@ body:
 
   - type: input
     attributes:
+      label: Window Manager / Windowing System
+      placeholder: "Example: Xorg 21.1.13 / X11"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
       label: GPU
       placeholder: "Example: AMD Radeon™ RX 5700"
     validations:


### PR DESCRIPTION
Many distros and DEs support multiple Window Managers/Systems. So it seems like a good idea to disambiguate which is running