### PR TITLE
Add msm_dpu driver for freedreno

### DIFF
--- a/tools/helpers/gpu.py
+++ b/tools/helpers/gpu.py
@@ -27,6 +27,7 @@ def getVulkanDriver(args, dev):
         "radeon": "radeon",
         "panfrost": "panfrost",
         "msm": "freedreno",
+        "msm_dpu": "freedreno",
         "vc4": "broadcom",
     }
     kernel_driver = getKernelDriver(args, dev)


### PR DESCRIPTION
I am using a chromebook (trogdor model) which uses a Qualcomm turnip gpu. The driver name should be "msm_dpu" on my machine.