### PR TITLE
net: Match IPv6 address in IPv6 nftables rule

### DIFF
--- a/data/scripts/waydroid-net.sh
+++ b/data/scripts/waydroid-net.sh
@@ -106,7 +106,7 @@ start_nftables() {
 add table ip6 lxc;
 flush table ip6 lxc;
 add chain ip6 lxc postrouting { type nat hook postrouting priority 100; };
-add rule ip6 lxc postrouting ip saddr ${LXC_IPV6_NETWORK} ip daddr != ${LXC_IPV6_NETWORK} counter masquerade;
+add rule ip6 lxc postrouting ip6 saddr ${LXC_IPV6_NETWORK} ip6 daddr != ${LXC_IPV6_NETWORK} counter masquerade;
 "
     fi
     NFT_RULESET="${NFT_RULESET};


### PR DESCRIPTION
Syntax for nftables considers `ip saddr` and `ip daddr` as strictly IPv4. Use the `ip6 saddr` and `ip6 daddr` to match IPv6 addresses in an IPv6 rule.