### PR TITLE
support for user config from XDG_CONFIG_HOME

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -25,6 +25,14 @@ config_keys = ["arch",
                "mount_overlays",
                "auto_adb"]
 
+property_keys = [
+        "create_desktop_entry",
+        ]
+
+property_defaults = {
+        "create_desktop_entry": "True",
+        }
+
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
 # overridden on the commandline)
@@ -61,6 +69,7 @@ session_defaults = {
     "host_user": os.path.expanduser("~"),
     "pid": str(os.getpid()),
     "xdg_data_home": str(os.environ.get('XDG_DATA_HOME', os.path.expanduser("~") + "/.local/share")),
+    "xdg_config_home": str(os.environ.get('XDG_CONFIG_HOME', os.path.expanduser("~") + "/.config")),
     "xdg_runtime_dir": str(os.environ.get('XDG_RUNTIME_DIR')),
     "wayland_display": str(os.environ.get('WAYLAND_DISPLAY')),
     "pulse_runtime_path": str(os.environ.get('PULSE_RUNTIME_PATH')),

--- a/tools/config/load.py
+++ b/tools/config/load.py
@@ -6,10 +6,10 @@ import os
 import tools.config
 
 
-def load(args):
+def load(config_file):
     cfg = configparser.ConfigParser()
-    if os.path.isfile(args.config):
-        cfg.read(args.config)
+    if os.path.isfile(config_file):
+        cfg.read(config_file)
 
     if "waydroid" not in cfg:
         cfg["waydroid"] = {}
@@ -28,7 +28,9 @@ def load(args):
 
     if "properties" not in cfg:
         cfg["properties"] = {}
-    # no default values for property override
+    for key in tools.config.property_defaults:
+        if key in tools.config.property_keys and key not in cfg["properties"]:
+            cfg["properties"][key] = str(tools.config.property_defaults[key])
 
     return cfg
 

--- a/tools/helpers/drivers.py
+++ b/tools/helpers/drivers.py
@@ -169,7 +169,7 @@ def setupBinderNodes(args):
             raise OSError('Binder node "hwbinder" for waydroid not found')
 
 def loadBinderNodes(args):
-    cfg = tools.config.load(args)
+    cfg = tools.config.load(args.config)
     args.BINDER_DRIVER = cfg["waydroid"]["binder"]
     args.VNDBINDER_DRIVER = cfg["waydroid"]["vndbinder"]
     args.HWBINDER_DRIVER = cfg["waydroid"]["hwbinder"]

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -68,7 +68,11 @@ NoDisplay={str(hide).lower()}
 """)
 
     def userUnlocked(uid):
-        cfg = tools.config.load(args)
+        cfg = tools.config.load(args.config)
+        user_config_file = str(tools.config.session_defaults["xdg_config_home"] + "/waydroid/waydroid.cfg")
+        if os.path.exists(user_config_file):
+            cfg.update(tools.config.load(user_config_file))
+
         logging.info("Android with user {} is ready".format(uid))
 
         if cfg["waydroid"]["auto_adb"] == "True":
@@ -79,8 +83,9 @@ NoDisplay={str(hide).lower()}
             if not os.path.exists(apps_dir):
                 os.mkdir(apps_dir, 0o700)
             appsList = platformService.getAppsInfo()
-            for app in appsList:
-                makeDesktopFile(app)
+            if cfg["properties"]["create_desktop_entry"] == "True":
+                for app in appsList:
+                    makeDesktopFile(app)
             multiwin = platformService.getprop("persist.waydroid.multi_windows", "false")
             makeWaydroidDesktopFile(multiwin == "true")
         if unlocked_cb:
@@ -93,7 +98,8 @@ NoDisplay={str(hide).lower()}
             desktop_file_path = apps_dir + "/waydroid." + packageName + ".desktop"
             if mode == 0:
                 # Package added
-                makeDesktopFile(appInfo)
+                if cfg["properties"]["create_desktop_entry"] == "True":
+                    makeDesktopFile(appInfo)
             elif mode == 1:
                 if os.path.isfile(desktop_file_path):
                     os.remove(desktop_file_path)


### PR DESCRIPTION
Added support for user config from XDG_CONFIG_HOME
Added property 'create_desktop_entry': only create desktop entries of True.
The function tools.config.load(args) has been changed to accept a file path.