### PR TITLE
gpu: Check i915_capabilities for the card node

### DIFF
--- a/tools/helpers/gpu.py
+++ b/tools/helpers/gpu.py
@@ -38,6 +38,7 @@ def getVulkanDriver(args, dev):
 
     if kernel_driver == "i915":
         try:
+            dev = os.path.basename(getCardFromRender(args, dev))
             gen = tools.helpers.run.user(args,["awk", "/^graphics version:|^gen:/ {print $NF}",
                 "/sys/kernel/debug/dri/{}/i915_capabilities".format(getMinor(args, dev))], output_return=True, check=False)
             if int(gen) < 9:


### PR DESCRIPTION
In some kernels the i915_capabilities file is not present for the render node, but it is for the card node.