### PR TITLE
Fix bug report link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Our documentation site can be found at [docs.waydro.id](https://docs.waydro.id)
 
 ## Reporting bugs
 
-If you have found an issue with Waydroid, please [file a bug](https://github.com/Waydroid/waydroid/issues/new).
+If you have found an issue with Waydroid, please [file a bug](https://github.com/Waydroid/waydroid/issues/new/choose).
 
 ## Get in Touch
 


### PR DESCRIPTION
Previously, the link to file a bug report in the `README` pointed to `/issues/new`, but it is probably better for it to point to `/issues/new/choose`. This should encourage people to use the issue templates.