### PR TITLE
Remove underscores from .desktop action names

### DIFF
--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -90,13 +90,13 @@ def start(args, session, unlocked_cb=None):
         desktop_file.set_string("Desktop Entry", "Icon", f"{waydroid_data}/icons/{packageName}.png")
         glib_key_file_prepend_string_list(desktop_file, "Desktop Entry", "Categories", ["X-WayDroid-App"])
         desktop_file.set_string_list("Desktop Entry", "X-Purism-FormFactor", ["Workstation", "Mobile"])
-        glib_key_file_prepend_string_list(desktop_file, "Desktop Entry", "Actions", ["app_settings"])
+        glib_key_file_prepend_string_list(desktop_file, "Desktop Entry", "Actions", ["app-settings"])
         if packageName in system_apps and not glib_key_file_has_value(desktop_file, "Desktop Entry", "NoDisplay"):
             desktop_file.set_boolean("Desktop Entry", "NoDisplay", True)
 
-        desktop_file.set_string("Desktop Action app_settings", "Name", "App Settings")
-        desktop_file.set_string("Desktop Action app_settings", "Exec", f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:{packageName}")
-        desktop_file.set_string("Desktop Action app_settings", "Icon", f"{waydroid_data}/icons/com.android.settings.png")
+        desktop_file.set_string("Desktop Action app-settings", "Name", "App Settings")
+        desktop_file.set_string("Desktop Action app-settings", "Exec", f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:{packageName}")
+        desktop_file.set_string("Desktop Action app-settings", "Icon", f"{waydroid_data}/icons/com.android.settings.png")
 
         desktop_file.save_to_file(desktop_file_path)
 


### PR DESCRIPTION
According to the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/1.2/extra-actions.html#extra-actions-identifier), identifiers for additional actions in desktop files must follow the same format as key names — only the characters `A–Z`, `a–z`, `0–9`, and `-` are allowed.

Currently, the generated desktop files use underscores in the action identifiers, which causes `desktop-file-utils` validation to fail. Replacing underscores with hyphens resolves the issue.