### PR TITLE
Fix: replace '"' that may cause SyntaxErrors for some Python versions

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -165,7 +165,7 @@ def main():
         log_hint = "Run 'waydroid log' for details."
         if not args or not os.path.exists(args.log) or not args.action == "container":
             log_hint = ("Use '--details-to-stdout' to get more details:\n"
-                         f"  {sys.argv[0]} --details-to-stdout {" ".join(sys.argv[1:])}")
+                         f"  {sys.argv[0]} --details-to-stdout {' '.join(sys.argv[1:])}")
         print(log_hint)
         return 1
 


### PR DESCRIPTION
Hello there,

As mentioned in [this issue](https://github.com/waydroid/waydroid/issues/2120), some installs or updates are suddenly failing.

This patch replaces the ambiguous `"` at the `.join(` part of line 168 causing install failures for a.e. some Ubuntu versions with specific Python versions which fail to interpret the syntax correctly.

Tested on Ubuntu 22.04 LTS, Python 3.10.

Have a great day!