### PR TITLE
Also consider block device files when checking for preinstalled images

### DIFF
--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -52,9 +52,9 @@ def setup_config(args):
         if os.path.isdir(preinstalled_images):
             system_path = preinstalled_images + "/system.img"
             vendor_path = preinstalled_images + "/vendor.img"
-            are_files = os.path.isfile(system_path) and os.path.isfile(vendor_path)
-            are_blocks = stat.S_ISBLK(os.stat(system_path).st_mode) and stat.S_ISBLK(os.stat(vendor_path).st_mode)
-            if are_files or are_blocks:
+            system_exists = os.path.isfile(system_path) or stat.S_ISBLK(os.stat(system_path).st_mode)
+            vendor_exists = os.path.isfile(vendor_path) or stat.S_ISBLK(os.stat(vendor_path).st_mode)
+            if system_exists and vendor_exists:
                 has_preinstalled_images = True
                 args.images_path = preinstalled_images
                 break


### PR DESCRIPTION
Hey, so I was trying to `sudo waydroid init  -f` where  both preinstalled system.img and vendor.img are symlinks and the initializer tool just refuses to acknowledge it exists. My use case is irunning Waydroid in a VM and to reduce overhead i had the system.img and vendor.img files in the host's file system where both files are passed to Qemu as disk images. These disks are then symlinked as system.img and vendor.img in the image path, as seen below:
```
ls /etc/waydroid-extra/images/ -l
total 8
lrwxrwxrwx 1 root root 8 Nov 25 21:01 system.img -> /dev/sda
lrwxrwxrwx 1 root root 8 Nov 25 21:01 vendor.img -> /dev/sdb
```
Had to 
1. create empty stub/spoof files
2. `waydroid init -f`
3. replace stub files with links
4. start waydroid
5. works

This PR should remove the need for such a workaround.