### PR TITLE
GitHub Action with Python code static analysis

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version: 2
+updates:
+
+  # Check for updates to GitHub Actions every month
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Check Python Package
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+
+  code-ql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          queries: security-and-quality
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: pip install ruff
+      - name: Run linter
+        run: ruff check --output-format=github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[tool.autopep8]
+max-line-length = 131
+
+[tool.isort]
+line_length = 131
+
+[tool.ruff]
+line-length = 131
+
+[tool.ruff.lint]
+select = [
+	# Standard errors and warnings
+	"E",
+	"W",
+	"F",
+]
+ignore = [
+	"E501", # Do not enforce line length limit for now.
+	"E722", # TODO: Remove this once the usage of bare "except" is refactored.
+	"F401", # TODO: Remove this once unused imports are removed.
+	"F811", # TODO: Remove this once redefined variables are refactored.
+	"F841", # TODO: Remove this once all unused variables are removed.
+]

--- a/tools/actions/session_manager.py
+++ b/tools/actions/session_manager.py
@@ -59,7 +59,7 @@ def start(args, unlocked_cb=None, background=True):
     else:
         xdg_runtime_dir = session["xdg_runtime_dir"]
         if xdg_runtime_dir == "None" or not xdg_runtime_dir:
-            logging.error(f"XDG_RUNTIME_DIR is not set; please don't start a Waydroid session with 'sudo'!")
+            logging.error("XDG_RUNTIME_DIR is not set; please don't start a Waydroid session with 'sudo'!")
             sys.exit(1)
         wayland_socket_path = os.path.join(xdg_runtime_dir, wayland_display)
     if not os.path.exists(wayland_socket_path):

--- a/tools/helpers/drivers.py
+++ b/tools/helpers/drivers.py
@@ -117,7 +117,7 @@ def probeAshmemDriver(args):
 
     if not os.path.exists("/dev/ashmem"):
         return -1
-    
+
     return 0
 
 def setupBinderNodes(args):

--- a/tools/helpers/http.py
+++ b/tools/helpers/http.py
@@ -27,11 +27,11 @@ def download(args, url, prefix, cache=True, loglevel=logging.INFO,
                           with a 404 Not Found error. Only display a warning on
                           stdout (no matter if loglevel is changed).
         :returns: path to the downloaded file in the cache or None on 404 """
-    
+
     # helper functions for progress
     def fromBytesToMB(numBytes, decimalPlaces=2):
         return round(int(numBytes)/1000000, decimalPlaces)
-    
+
     def getDownloadSpeed(lastSize, currentSize, timeTaken, decimalPlaces=2):
         # sizes are in MB and timeTaken in seconds
         speedUnit = "MB/s"
@@ -43,7 +43,7 @@ def download(args, url, prefix, cache=True, loglevel=logging.INFO,
             # for better readability
             sizeDifference*=1000
             speedUnit = "kB/s"
-        
+
         # sizeDifference MB(or kB) was downloaded in timeTaken seconds
         # so downloadSpeed = sizeDifference/timeTaken MB/s(or kB/s)
         return (round(sizeDifference/timeTaken, decimalPlaces), speedUnit)
@@ -53,7 +53,7 @@ def download(args, url, prefix, cache=True, loglevel=logging.INFO,
     def progress(totalSize, destinationPath):
         # convert totalSize to MB before hand,
         # it's value won't change inside while loop and
-        # will be unnecessarily calculated every .01 seconds 
+        # will be unnecessarily calculated every .01 seconds
         totalSize = fromBytesToMB(totalSize)
 
         # this value will be used to figure out maximum chars
@@ -85,7 +85,7 @@ def download(args, url, prefix, cache=True, loglevel=logging.INFO,
             currentSize = str(currentSize).rjust(totalSizeStrLen)
             # assuming max downloadSpeed to be 9999.99 MB/s
             downloadSpeed = f"{str(downloadSpeed[0]).rjust(7)} {downloadSpeed[1]}"
-            
+
             # print progress bar
             print(f"\r[Downloading] {currentSize} MB/{totalSize} MB    {downloadSpeed}(approx.)", end=" ")
             time.sleep(2)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -468,11 +468,11 @@ def shell(args):
     command = ["lxc-attach", "-P", tools.config.defaults["lxc"],
                "-n", "waydroid", "--clear-env"]
     command.extend(android_env_attach_options(args))
-    if args.uid!=None:
+    if args.uid is not None:
         command.append("--uid="+str(args.uid))
-    if args.gid!=None:
+    if args.gid is not None:
         command.append("--gid="+str(args.gid))
-    elif args.uid!=None:
+    elif args.uid is not None:
         command.append("--gid="+str(args.uid))
     if args.nolsm or args.allcaps or args.nocgroup:
         elevatedprivs = "--elevated-privileges="
@@ -493,7 +493,7 @@ def shell(args):
             elevatedprivs+="CGROUP"
             addpipe = True
         command.append(elevatedprivs)
-    if args.context!=None and not args.nolsm:
+    if args.context is not None and not args.nolsm:
         command.append("--context="+args.context)
     command.append("--")
     if args.COMMAND:

--- a/tools/helpers/run_core.py
+++ b/tools/helpers/run_core.py
@@ -53,11 +53,11 @@ def background(args, cmd, working_dir=None):
 
 def pipe(args, cmd, working_dir=None):
     """ Run a subprocess in background and redirect its output to a pipe. """
-    ret = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                            cwd=working_dir)
     threading.Thread(target=forward_stream, args=(proc.stderr, logging.DEBUG), daemon=True).start()
-    logging.verbose("New background process: pid={}, output=pipe".format(ret.pid))
-    return ret
+    logging.verbose("New background process: pid={}, output=pipe".format(proc.pid))
+    return proc
 
 
 def pipe_read(args, process, output_to_stdout=False, output_return=False,


### PR DESCRIPTION
This PR adds some basic static analysis for Python code. It should help to keep the codebase out of some trivial bugs.

List of changes:

- `pyproject.toml` file with line length setup for common Python tools
- GitHub Action with `ruff check` and `code-ql` checks
- Dependabot setup to check for GitHub Actions dependencies updates every month
- Fixes some simple style issues reported by `F` rules
- Fixed `pipe()` function where `proc` used in `proc.stderr` was not defined

After fixing all issues reported by `ruff` (added to the `ignore` list) and `code-ql`, the list of selected `ruff` rules can be extended. In my projects I'm mostly using the list as follows:
```
[tool.ruff.lint]
select = [
  # Standard errors and warnings
  "E",
  "W",
  "F",
  # Ensure that async is used properly
  "ASYNC",
  # Consistent commas and quotes
  "COM",
  "Q",
  # Simplify the code if possible
  "C4",
  "RET",
  "SIM",
  # Ensure that scripts are executable
  "EXE",
  # Check for common exception issues
  "EM",
  "RSE",
  # Check for common logging issues
  "LOG",
  "G",
  # Check for common optimization issues
  "SLOT",
  # Keep syntax up to date
  "UP",
]
```

### Note on line length

The line length in the `pyproject.toml` is based on the current codebase where there is no constraint on the line length (it seems). Since this topic is very "controversial" it's up to maintainer (you) what the line length should be. However, I strongly suggest to set some, because it's very hard to read very long lines which are wrapped in the editor (it's not the case in that project, but in general lack of line length limit leads to such long lines eventually). Why 131 and not 132? The common practice when setting line length is to use `desired_line_length - 1`, e.g.:

```console
$ pep8 --help
...
  --max-line-length=n  set maximum allowed line length (default: 79)
...
```