### PR TITLE
Detect AIDL gralloc5

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -245,6 +245,16 @@ def make_base_props(args):
         except:
             return False
 
+    def find_aidl(intf):
+        if args.vendor_type == "MAINLINE":
+            return False
+
+        try:
+            sm = gbinder.ServiceManager("/dev/binder")
+            return intf in sm.list_sync()
+        except:
+            return False
+
     props = []
 
     if not os.path.exists("/dev/ashmem"):
@@ -260,6 +270,8 @@ def make_base_props(args):
     gralloc = find_hal("gralloc")
     if not gralloc:
         if find_hidl("android.hardware.graphics.allocator@4.0::IAllocator/default"):
+            gralloc = "android"
+        elif find_aidl("android.hardware.graphics.allocator.IAllocator/default"):
             gralloc = "android"
     if not gralloc:
         if dri:


### PR DESCRIPTION
https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-14.0.0_r1/graphics/allocator/aidl

<details>
<summary>potentially interesting logs from a Halium 14 device</summary>

```
phablet@ubuntu-phablet:~$ sudo lxc-attach -n android -- lshal
Warning: Skipping "android.frameworks.sensorservice@1.0::ISensorManager/default": no information for PID 309, are you root?
Warning: Skipping "android.hardware.bluetooth@1.0::IBluetoothHci/default": no information for PID 169, are you root?
Warning: Skipping "android.hardware.media.c2@1.0::IComponentStore/default": no information for PID 175, are you root?
Warning: Skipping "android.hardware.media.c2@1.0::IComponentStore/software": no information for PID 349, are you root?
Warning: Skipping "android.hidl.allocator@1.0::IAllocator/ashmem": no information for PID 167, are you root?
Warning: Skipping "android.hidl.manager@1.0::IServiceManager/default": no information for PID 36, are you root?
Warning: Skipping "vendor.trustonic.tee.tui@1.0::ITui/default": no information for PID 206, are you root?
| All HIDL binderized services (registered with hwservicemanager)
VINTF R Interface                                                    Thread Use Server Clients
FM    Y android.frameworks.sensorservice@1.0::ISensorManager/default N/A        309    
DM,FC Y android.hardware.bluetooth@1.0::IBluetoothHci/default        N/A        169    
DM,FC Y android.hardware.bluetooth@1.1::IBluetoothHci/default        N/A        169    
DM,FC Y android.hardware.media.c2@1.0::IComponentStore/default       N/A        175    
FM,FC Y android.hardware.media.c2@1.0::IComponentStore/software      N/A        349    
DM,FC Y android.hardware.media.c2@1.1::IComponentStore/default       N/A        175    
FM,FC Y android.hardware.media.c2@1.1::IComponentStore/software      N/A        349    
DM,FC Y android.hardware.media.c2@1.2::IComponentStore/default       N/A        175    
FM,FC Y android.hardware.media.c2@1.2::IComponentStore/software      N/A        349    
FM    Y android.hidl.allocator@1.0::IAllocator/ashmem                N/A        167    
X     Y android.hidl.base@1.0::IBase/ashmem                          N/A        167    
X     Y android.hidl.base@1.0::IBase/default                         N/A        309    
X     Y android.hidl.base@1.0::IBase/software                        N/A        349    
FM    Y android.hidl.manager@1.0::IServiceManager/default            N/A        36     
FM    Y android.hidl.manager@1.1::IServiceManager/default            N/A        36     
FM    Y android.hidl.manager@1.2::IServiceManager/default            N/A        36     
FM    Y android.hidl.token@1.0::ITokenManager/default                N/A        36     
DM    Y vendor.trustonic.tee.tui@1.0::ITui/default                   N/A        206    
DM    Y vendor.trustonic.tee@1.0::ITee/default                       N/A        206    
DM    Y vendor.trustonic.tee@1.1::ITee/default                       N/A        206    

| All HIDL interfaces getService() has ever returned as a passthrough interface;
| PIDs / processes shown below might be inaccurate because the process
| might have relinquished the interface or might have died.
| The Server / Server CMD column can be ignored.
| The Clients / Clients CMD column shows all process that have ever dlopen'ed 
| the library and successfully fetched the passthrough implementation.
VINTF R Interface                                             Thread Use Server Clients
FC    ? android.hardware.bluetooth@1.1::IBluetoothHci/default N/A        169    169
DM,FC ? android.hardware.graphics.mapper@4.0::IMapper/default N/A        N/A    173 312

| All available HIDL passthrough implementations (all -impl.so files).
| These may return subclasses through their respective HIDL_FETCH_I* functions.
VINTF R Interface                                                                    Thread Use Server Clients
X     ? android.hardware.audio.effect@6.0::I*/* (/vendor/lib64/hw/)                  N/A        N/A    
X     ? android.hardware.audio.effect@7.0::I*/* (/vendor/lib64/hw/)                  N/A        N/A    
X     ? android.hardware.audio@7.0::I*/* (/vendor/lib64/hw/) (-mediatek)             N/A        N/A    
X     ? android.hardware.audio@7.1::I*/* (/vendor/lib64/hw/) (-mediatek)             N/A        N/A    
X     ? android.hardware.bluetooth.audio@2.0::I*/* (/vendor/lib64/hw/)               N/A        N/A    
X     ? android.hardware.bluetooth.audio@2.1::I*/* (/vendor/lib64/hw/)               N/A        N/A    
X     ? android.hardware.bluetooth@1.1::I*/* (/vendor/lib64/hw/) (-mediatek)         N/A        N/A    169
X     ? android.hardware.camera.provider@2.6::I*/* (/vendor/lib64/hw/) (-mediatek)   N/A        N/A    
X     ? android.hardware.graphics.mapper@4.0::I*/* (/vendor/lib64/hw/) (-mediatek)   N/A        N/A    
X     ? android.hardware.renderscript@1.0::I*/* (/vendor/lib64/hw/)                  N/A        N/A    
X     ? android.hidl.memory@1.0::I*/* (/apex/com.android.vndk.v34/lib/hw/)           N/A        N/A    
X     ? android.hidl.memory@1.0::I*/* (/apex/com.android.vndk.v34/lib64/hw/)         N/A        N/A    
X     ? android.hidl.memory@1.0::I*/* (/system/lib/hw/)                              N/A        N/A    
X     ? android.hidl.memory@1.0::I*/* (/system/lib64/hw/)                            N/A        N/A    
X     ? vendor.mediatek.hardware.bluetooth.audio@2.1::I*/* (/vendor/lib64/hw/)       N/A        N/A    
X     ? vendor.mediatek.hardware.bluetooth.audio@2.2::I*/* (/vendor/lib64/hw/)       N/A        N/A    
X     ? vendor.mediatek.hardware.camera.atms@1.0::I*/* (/vendor/lib64/hw/)           N/A        N/A    
X     ? vendor.mediatek.hardware.camera.atms_aidl@1.0::I*/* (/vendor/lib64/hw/)      N/A        N/A    312
X     ? vendor.mediatek.hardware.camera.bgservice@1.1::I*/* (/vendor/lib64/hw/)      N/A        N/A    
X     ? vendor.mediatek.hardware.camera.bgservice_aidl@1.0::I*/* (/vendor/lib64/hw/) N/A        N/A    312
X     ? vendor.mediatek.hardware.camera.isphal@1.1::I*/* (/vendor/lib64/hw/)         N/A        N/A    
X     ? vendor.mediatek.hardware.camera.isphal_aidl@1.0::I*/* (/vendor/lib64/hw/)    N/A        N/A    312

phablet@ubuntu-phablet:~$ sudo binder-list -d /dev/hwbinder 
android.frameworks.sensorservice@1.0::ISensorManager/default
android.hardware.bluetooth@1.0::IBluetoothHci/default
android.hardware.bluetooth@1.1::IBluetoothHci/default
android.hardware.media.c2@1.0::IComponentStore/default
android.hardware.media.c2@1.0::IComponentStore/software
android.hardware.media.c2@1.1::IComponentStore/default
android.hardware.media.c2@1.1::IComponentStore/software
android.hardware.media.c2@1.2::IComponentStore/default
android.hardware.media.c2@1.2::IComponentStore/software
android.hidl.allocator@1.0::IAllocator/ashmem
android.hidl.base@1.0::IBase/ashmem
android.hidl.base@1.0::IBase/default
android.hidl.base@1.0::IBase/software
android.hidl.manager@1.0::IServiceManager/default
android.hidl.manager@1.1::IServiceManager/default
android.hidl.manager@1.2::IServiceManager/default
android.hidl.token@1.0::ITokenManager/default
vendor.trustonic.tee.tui@1.0::ITui/default
vendor.trustonic.tee@1.0::ITee/default
vendor.trustonic.tee@1.1::ITee/default

phablet@ubuntu-phablet:~$ sudo binder-list -d /dev/binder
activity
android.frameworks.sensorservice.ISensorManager/default
android.frameworks.stats.IStats/default
android.hardware.biometrics.fingerprint.IFingerprint/default
android.hardware.bluetooth.IBluetoothHci/default
android.hardware.boot.IBootControl/default
android.hardware.camera.provider.ICameraProvider/internal/0
android.hardware.cas.IMediaCasService/default
android.hardware.drm.IDrmFactory/clearkey
android.hardware.drm.IDrmFactory/widevine
android.hardware.gatekeeper.IGatekeeper/default
android.hardware.gnss.IGnss/default
android.hardware.graphics.allocator.IAllocator/default
android.hardware.graphics.composer3.IComposer/default
android.hardware.health.IHealth/default
android.hardware.light.ILights/default
android.hardware.memtrack.IMemtrack/default
android.hardware.neuralnetworks.IDevice/mtk-mdla_shim
android.hardware.neuralnetworks.IDevice/mtk-neuron_shim
android.hardware.nfc.INfc/default
android.hardware.power.IPower/default
android.hardware.radio.config.IRadioConfig/default
android.hardware.radio.data.IRadioData/slot1
android.hardware.radio.data.IRadioData/slot2
android.hardware.radio.ims.IRadioIms/slot1
android.hardware.radio.ims.IRadioIms/slot2
android.hardware.radio.messaging.IRadioMessaging/slot1
android.hardware.radio.messaging.IRadioMessaging/slot2
android.hardware.radio.modem.IRadioModem/imsSlot1
android.hardware.radio.modem.IRadioModem/imsSlot2
android.hardware.radio.modem.IRadioModem/se1
android.hardware.radio.modem.IRadioModem/se2
android.hardware.radio.modem.IRadioModem/slot1
android.hardware.radio.modem.IRadioModem/slot2
android.hardware.radio.network.IRadioNetwork/imsSlot1
android.hardware.radio.network.IRadioNetwork/imsSlot2
android.hardware.radio.network.IRadioNetwork/slot1
android.hardware.radio.network.IRadioNetwork/slot2
android.hardware.radio.sap.ISap/slot1
android.hardware.radio.sap.ISap/slot2
android.hardware.radio.sim.IRadioSim/imsSlot1
android.hardware.radio.sim.IRadioSim/imsSlot2
android.hardware.radio.sim.IRadioSim/se1
android.hardware.radio.sim.IRadioSim/se2
android.hardware.radio.sim.IRadioSim/slot1
android.hardware.radio.sim.IRadioSim/slot2
android.hardware.radio.voice.IRadioVoice/imsSlot1
android.hardware.radio.voice.IRadioVoice/imsSlot2
android.hardware.radio.voice.IRadioVoice/slot1
android.hardware.radio.voice.IRadioVoice/slot2
android.hardware.secure_element.ISecureElement/SIM1
android.hardware.secure_element.ISecureElement/SIM2
android.hardware.security.keymint.IKeyMintDevice/default
android.hardware.security.keymint.IRemotelyProvisionedComponent/default
android.hardware.security.secureclock.ISecureClock/default
android.hardware.security.sharedsecret.ISharedSecret/default
android.hardware.sensors.ISensors/default
android.hardware.thermal.IThermal/default
android.hardware.usb.IUsb/default
android.hardware.vibrator.IVibrator/default
android.hardware.vibrator.IVibratorManager/default
android.media.ICameraRecordService
android.media.IMediaRecorderFactory
android.security.identity
android.service.gatekeeper.IGateKeeperService
android.system.suspend.ISystemSuspend/default
apexservice
appops
arm.mali.platform.ICompression/default
batterystats
drm.drmManager
gpu
idmap
incident
installd
manager
media.audio_flinger
media.audio_policy
media.camera
media.extractor
media.metrics
media.player
media.resource_manager
media.resource_observer
package_native
permission
permission_checker
processinfo
sensor_privacy
sensorservice
stats
storaged
storaged_pri
suspend_control
suspend_control_internal
vendor.goodix.hardware.biometrics.fingerprint.IGoodixFingerprintDaemon/default
vendor.lineage.health.IChargingControl/default
vendor.lineage.health.IFastCharge/default
vendor.lineage.powershare.IPowerShare/default
vendor.lineage.touch.IGloveMode/default
vendor.mediatek.hardware.apuware.apusys.INeuronApusys/default
vendor.mediatek.hardware.apuware.utils.IApuwareUtils/default
vendor.mediatek.hardware.camera.atms.IATMs/default
vendor.mediatek.hardware.camera.bgservice.IBGService/default
vendor.mediatek.hardware.camera.isphal.IISPModule/internal/1
vendor.mediatek.hardware.composer_ext.IComposerExt/default
vendor.mediatek.hardware.gnss.IMtkGnss/default
vendor.mediatek.hardware.lbs.ILbs/AgpsDebugInterface
vendor.mediatek.hardware.lbs.ILbs/AgpsInterface
vendor.mediatek.hardware.lbs.ILbs/mtk_agps2framework
vendor.mediatek.hardware.lbs.ILbs/mtk_agpsd2debugService
vendor.mediatek.hardware.lbs.ILbs/mtk_debugService2agpsd
vendor.mediatek.hardware.lbs.ILbs/mtk_debugService2mnld
vendor.mediatek.hardware.lbs.ILbs/mtk_framework2agps
vendor.mediatek.hardware.lbs.ILbs/mtk_jam2mnl
vendor.mediatek.hardware.lbs.ILbs/mtk_lbs_log_v2s
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_agps
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_bt
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_ipaddr
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_lbs
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_network
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_sensor
vendor.mediatek.hardware.lbs.ILbs/mtk_lppe_socket_wlan
vendor.mediatek.hardware.lbs.ILbs/mtk_meta2mnld
vendor.mediatek.hardware.lbs.ILbs/mtk_mnl2jam
vendor.mediatek.hardware.lbs.ILbs/mtk_mnld2debugService
vendor.mediatek.hardware.lbs.ILbs/mtk_mnld2mtklogger
vendor.mediatek.hardware.lbs.ILbs/mtk_mnld2nlputils
vendor.mediatek.hardware.lbs.ILbs/mtk_mtklogger2mnld
vendor.mediatek.hardware.mmlpq.IMmlpq/default
vendor.mediatek.hardware.mtkpower.IMtkPowerService/default
vendor.mediatek.hardware.mtkpower_applist.IMtkpower_applist/default
vendor.mediatek.hardware.mtkradioex.data.IMtkRadioExData/slot1
vendor.mediatek.hardware.mtkradioex.data.IMtkRadioExData/slot2
vendor.mediatek.hardware.mtkradioex.dch.IMtkRadioExDc/slot1
vendor.mediatek.hardware.mtkradioex.dch.IMtkRadioExDc/slot2
vendor.mediatek.hardware.mtkradioex.ims.IMtkRadioExIms/slot1
vendor.mediatek.hardware.mtkradioex.ims.IMtkRadioExIms/slot2
vendor.mediatek.hardware.mtkradioex.messaging.IMtkRadioExMessaging/slot1
vendor.mediatek.hardware.mtkradioex.messaging.IMtkRadioExMessaging/slot2
vendor.mediatek.hardware.mtkradioex.modem.IMtkRadioExModem/slot1
vendor.mediatek.hardware.mtkradioex.modem.IMtkRadioExModem/slot2
vendor.mediatek.hardware.mtkradioex.network.IMtkRadioExNetwork/slot1
vendor.mediatek.hardware.mtkradioex.network.IMtkRadioExNetwork/slot2
vendor.mediatek.hardware.mtkradioex.rcs.IMtkRadioExRcs/slot1
vendor.mediatek.hardware.mtkradioex.rcs.IMtkRadioExRcs/slot2
vendor.mediatek.hardware.mtkradioex.sim.IMtkRadioExSim/slot1
vendor.mediatek.hardware.mtkradioex.sim.IMtkRadioExSim/slot2
vendor.mediatek.hardware.mtkradioex.voice.IMtkRadioExVoice/slot1
vendor.mediatek.hardware.mtkradioex.voice.IMtkRadioExVoice/slot2
vendor.mediatek.hardware.netdagent.INetdagents/default
vendor.mediatek.hardware.nvram.INvram/default
vendor.mediatek.hardware.nwk_opt_new.INwkOptNew/default
vendor.mediatek.hardware.pq_aidl.IPictureQuality_AIDL/default
vendor.mediatek.hardware.videotelephony.IVideoTelephony/default
vold
wifinl80211
```
</details>