### PR TITLE
logcat: Add support for passing arguments

### DIFF
--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -122,6 +122,7 @@ def arguments_shell(subparser):
 
 def arguments_logcat(subparser):
     ret = subparser.add_parser("logcat", help="show android logcat")
+    ret.add_argument('ARGS', nargs='*', help="arguments to pass to logcat")
     return ret
 
 def arguments_adb(subparser):

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -519,6 +519,8 @@ def shell(args):
 
 def logcat(args):
     args.COMMAND = ["/system/bin/logcat"]
+    if args.ARGS:
+        args.COMMAND.extend(args.ARGS)
     args.uid = None
     args.gid = None
     args.nolsm = None


### PR DESCRIPTION
Allow users to pass arbitrary arguments to the logcat command, enabling filtering and formatting options like:
  waydroid logcat -s MyTag
  waydroid logcat -e "pattern"
  waydroid logcat -v time -d

Fixes #2217