### PR TITLE
session: Add opt-in idle monitor to auto-stop sessions

### DIFF
--- a/tools/actions/session_manager.py
+++ b/tools/actions/session_manager.py
@@ -7,6 +7,7 @@ import sys
 import tools.config
 import tools.helpers.ipc
 from tools import services
+from tools.interfaces import IPlatform
 import dbus
 import dbus.service
 import dbus.exceptions
@@ -107,6 +108,53 @@ def start(args, unlocked_cb=None, background=True):
     services.user_manager.start(args, session, unlocked_cb)
     services.clipboard_manager.start(args)
     services.notification_manager.start(args, session)
+
+    cfg = tools.config.load(args)
+    if cfg["waydroid"]["stop_on_idle"] == "True":
+        idle_state = {"count": 0, "platform": None}
+
+        def check_idle():
+            # Check if container is still alive via D-Bus
+            try:
+                container_session = tools.helpers.ipc.DBusContainerService().GetSession()
+                container_alive = container_session["state"] in ("RUNNING", "FROZEN")
+            except (dbus.DBusException, KeyError):
+                container_alive = False
+
+            if not container_alive:
+                idle_state["count"] += 1
+                idle_state["platform"] = None
+            else:
+                # Try to get or reuse the platform service (non-blocking)
+                if idle_state["platform"] is None:
+                    try:
+                        idle_state["platform"] = IPlatform.get_service_nowait(args)
+                    except Exception:
+                        pass
+
+                if idle_state["platform"]:
+                    try:
+                        running = idle_state["platform"].getRunningTasks()
+                    except Exception:
+                        idle_state["platform"] = None
+                        running = -1
+
+                    if running == 0:
+                        idle_state["count"] += 1
+                    elif running > 0:
+                        idle_state["count"] = 0
+                    # running == -1: unsupported, don't change count
+
+            if idle_state["count"] >= 2:
+                logging.info("No active tasks detected, stopping idle session")
+                do_stop(args, mainloop)
+                stop_container(quit_session=False)
+                return False
+
+            return True
+
+        GLib.timeout_add_seconds(15, check_idle)
+
     service(args, mainloop)
 
 def do_stop(args, looper):

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -23,7 +23,8 @@ config_keys = ["arch",
                "vendor_datetime",
                "suspend_action",
                "mount_overlays",
-               "auto_adb"]
+               "auto_adb",
+               "stop_on_idle"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -41,6 +42,7 @@ defaults = {
     "suspend_action": "freeze",
     "mount_overlays": "True",
     "auto_adb": "False",
+    "stop_on_idle": "False",
     "container_xdg_runtime_dir": "/run/xdg",
     "container_wayland_display": "wayland-0",
 }

--- a/tools/interfaces/IPlatform.py
+++ b/tools/interfaces/IPlatform.py
@@ -22,6 +22,7 @@ TRANSACTION_settingsGetString = 10
 TRANSACTION_settingsPutInt = 11
 TRANSACTION_settingsGetInt = 12
 TRANSACTION_launchIntent = 13
+TRANSACTION_getRunningTasks = 14
 
 class IPlatform:
     def __init__(self, remote):
@@ -294,6 +295,40 @@ class IPlatform:
                 logging.error("Failed with code: {}".format(exception))
 
         return None
+
+    def getRunningTasks(self):
+        request = self.client.new_request()
+        reply, status = self.client.transact_sync_reply(
+            TRANSACTION_getRunningTasks, request)
+
+        if status:
+            return -1
+        else:
+            reader = reply.init_reader()
+            status, exception = reader.read_int32()
+            if exception == 0:
+                status, count = reader.read_int32()
+                return count
+            else:
+                return -1
+
+def get_service_nowait(args):
+    """Like get_service but returns None immediately if service is unavailable."""
+    helpers.drivers.loadBinderNodes(args)
+    try:
+        serviceManager = gbinder.ServiceManager("/dev/" + args.BINDER_DRIVER, args.SERVICE_MANAGER_PROTOCOL, args.BINDER_PROTOCOL)
+    except TypeError:
+        serviceManager = gbinder.ServiceManager("/dev/" + args.BINDER_DRIVER)
+
+    if not serviceManager.is_present():
+        return None
+
+    remote, status = serviceManager.get_service_sync(SERVICE_NAME)
+    if not remote:
+        return None
+
+    return IPlatform(remote)
+
 
 def get_service(args):
     helpers.drivers.loadBinderNodes(args)


### PR DESCRIPTION
When `stop_on_idle=True` is set in `waydroid.cfg`, the session periodically checks whether the container is still running and whether there are active user tasks. After 30 seconds of idle state, the session stops itself.

This fixes two long-standing issues:
- The session not stopping when Android shuts down from its own UI (#2234) — detected via D-Bus container state check, works immediately
- The session not stopping when all app windows are closed (#1052) — detected via a new `getRunningTasks` binder transaction, requires the companion Android-side change

The idle monitor uses `GLib.timeout_add_seconds()` inside the existing mainloop. No new threads or dependencies. A non-blocking `get_service_nowait()` is added to `IPlatform` to avoid stalling the main loop.

Enable: add `stop_on_idle=True` to the `[waydroid]` section of `/var/lib/waydroid/waydroid.cfg`

Note: #1052 requires both this PR and the companion Android-side PR to be merged (new Android image built). #2234 is fully fixed by this PR alone.

Companion PR: waydroid/android_vendor_waydroid#48

Fixes #1052
Fixes #2234