### PR TITLE
notification_manager: Handle missing ActionInvoked signal

### DIFF
--- a/tools/services/notification_manager.py
+++ b/tools/services/notification_manager.py
@@ -63,7 +63,7 @@ def start(args, session):
         pending_tokens[int(notification_id)] = str(token)
 
     def onActionInvoked(notification_id, action_id):
-        token = pending_tokens.pop(int(notification_id))
+        token = pending_tokens.pop(int(notification_id), "")
         for listener in listeners:
             listener.onActionInvoked(int(notification_id), str(action_id), str(token))
 


### PR DESCRIPTION
A notification server may not implement ActionInvoked. Do not raise an exception in that case.

Closes: https://github.com/waydroid/waydroid/issues/2246