### PR TITLE
waydroid-net: allow overriding dnsmasq conf path

### DIFF
--- a/data/scripts/waydroid-net.sh
+++ b/data/scripts/waydroid-net.sh
@@ -22,7 +22,9 @@ LXC_NETMASK="255.255.255.0"
 LXC_NETWORK="192.168.240.0/24"
 LXC_DHCP_RANGE="192.168.240.2,192.168.240.254"
 LXC_DHCP_MAX="253"
-LXC_DHCP_CONFILE=""
+# Allow an external dnsmasq config to be injected without changing the
+# default hermetic /dev/null behavior.
+: "${LXC_DHCP_CONFILE:=${WAYDROID_DNSMASQ_CONF:-}}"
 LXC_DHCP_PING="true"
 LXC_DOMAIN=""
 LXC_USE_NFT="false"

--- a/data/scripts/waydroid-net.sh
+++ b/data/scripts/waydroid-net.sh
@@ -199,7 +199,7 @@ start() {
         mkdir "${varlib}"/misc
     fi
 
-    dnsmasq $LXC_DHCP_CONFILE_ARG $LXC_DOMAIN_ARG $LXC_DHCP_PING_ARG -u ${DNSMASQ_USER} \
+    dnsmasq "$LXC_DHCP_CONFILE_ARG" $LXC_DOMAIN_ARG $LXC_DHCP_PING_ARG -u ${DNSMASQ_USER} \
             --strict-order --bind-interfaces --pid-file="${varrun}"/dnsmasq.pid \
             --listen-address ${LXC_ADDR} --dhcp-range ${LXC_DHCP_RANGE} \
             --dhcp-lease-max=${LXC_DHCP_MAX} --dhcp-no-override \


### PR DESCRIPTION
## Summary

Allow `waydroid-net.sh` to optionally inherit a dnsmasq config path from `WAYDROID_DNSMASQ_CONF`, while keeping the current default behavior unchanged.

Closes #2278

## Why

The script already supports `LXC_DHCP_CONFILE` internally and later maps it to:

```sh
--conf-file=${LXC_DHCP_CONFILE:-/dev/null}
```

but there is currently no supported external override for it. As a result, users who need custom dnsmasq behavior end up patching the installed `waydroid-net.sh` script directly.

Related discussion:

- #537
- #670

## Behavior

When `WAYDROID_DNSMASQ_CONF` is unset, behavior stays the same as today:

- `LXC_DHCP_CONFILE` resolves to empty
- dnsmasq still gets `--conf-file=/dev/null`

When it is set, callers can opt in to an external dnsmasq config file without modifying the packaged script.

## Example

```ini
[Service]
Environment="WAYDROID_DNSMASQ_CONF=/etc/waydroid-dnsmasq.conf"
```

## Validation

- `sh -n data/scripts/waydroid-net.sh`
