### PR TITLE
Toggle desktop file

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -23,7 +23,8 @@ config_keys = ["arch",
                "vendor_datetime",
                "suspend_action",
                "mount_overlays",
-               "auto_adb"]
+               "auto_adb",
+               "no_applications"]
 
 # Config file/commandline default values
 # $WORK gets replaced with the actual value for args.work (which may be
@@ -43,6 +44,7 @@ defaults = {
     "auto_adb": "False",
     "container_xdg_runtime_dir": "/run/xdg",
     "container_wayland_display": "wayland-0",
+    "no_applications": "False"
 }
 defaults["images_path"] = defaults["work"] + "/images"
 defaults["rootfs"] = defaults["work"] + "/rootfs"

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -15,7 +15,7 @@ import tools.config
     the "args" variable, which is prominently passed to most functions all
     over the waydroid code base.
 
-    See tools/helpers/args.py for more information about the args variable. """
+    See tools/helpers/arguments.py for more information about the args variable. """
 
 def arguments_init(subparser):
     ret = subparser.add_parser("init", help="set up waydroid specific"

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -14,6 +14,7 @@ stopping = False
 
 
 def start(args, session, unlocked_cb=None):
+    no_applications = tools.config.load(args)["waydroid"]["no_applications"] == "True"
 
     apps_dir = Path(session["xdg_data_home"]) / "applications"
     apps_dir.mkdir(0o700, exist_ok=True)
@@ -36,7 +37,7 @@ def start(args, session, unlocked_cb=None):
         "org.lineageos.eleven",
         "org.lineageos.etar",
         "org.lineageos.jelly",
-        "org.lineageos.recorder"
+        "org.lineageos.recorder",
     ]
 
     def prepend_list(old_list, new_list):
@@ -64,8 +65,17 @@ def start(args, session, unlocked_cb=None):
 
     # Migrate waydroid user configs after upgrade
     def user_migration():
-        if not any(apps_dir.glob('waydroid.*.desktop')):
+        if not any(apps_dir.glob("waydroid.*.desktop")):
             # first ever run, no need to migrate
+            return
+
+        if no_applications:
+            # clean the desktop files just in case
+            for file in apps_dir.glob("waydroid.*.desktop"):
+                try:
+                    file.unlink(True)
+                except Exception as e:
+                    logging.warning(f"Unable to link previous desktop file: {e}")
             return
 
         migrated_main_path = waydroid_user_state_dir / ".migrated-main-desktop-file"
@@ -92,6 +102,10 @@ def start(args, session, unlocked_cb=None):
 
     # Creates, deletes, or updates desktop file
     def updateDesktopFile(appInfo):
+        # this shouldn't do anything in this case
+        if no_applications:
+            return
+
         if appInfo is None:
             return
 
@@ -125,7 +139,11 @@ def start(args, session, unlocked_cb=None):
             desktop_file.set_boolean("Desktop Entry", "NoDisplay", True)
 
         desktop_file.set_string("Desktop Action app-settings", "Name", "App Settings")
-        desktop_file.set_string("Desktop Action app-settings", "Exec", f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:{packageName}")
+        desktop_file.set_string(
+            "Desktop Action app-settings",
+            "Exec",
+            f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:{packageName}",
+        )
         desktop_file.set_string("Desktop Action app-settings", "Icon", str(waydroid_data_icons_dir / "com.android.settings.png"))
 
         desktop_file.save_to_file(str(desktop_file_path))

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -73,9 +73,9 @@ def start(args, session, unlocked_cb=None):
             # clean the desktop files just in case
             for file in apps_dir.glob("waydroid.*.desktop"):
                 try:
-                    file.unlink(True)
+                    file.unlink(missing_ok=True)
                 except Exception as e:
-                    logging.warning(f"Unable to link previous desktop file: {e}")
+                    logging.warning(f"Unable to remove desktop file: {e}")
             return
 
         migrated_main_path = waydroid_user_state_dir / ".migrated-main-desktop-file"


### PR DESCRIPTION
 # Feature
Added a feature to toggle creation of `waydroid.*.desktop` files  
It can be a bit annoying that waydroid recreate those files every time it boots and they come up in search like `krunner`  

## HOW
Add ( or change ) `no_applications` config key in `/usr/lib/waydroid/waydroid.cfg` to:
- True: Disable creation of those files ( and additionally remove them if present )
-  False: Enable creation of those files ( and additionally create them if not present )

### example:
`/var/lib/waydroid/waydroid.cfg`:
```cfg
# other configs...
no_applications = True
# other configs...
```