### PR TITLE
protocol: Use aidl5/6 for service manager on API 35/36

### DIFF
--- a/tools/helpers/protocol.py
+++ b/tools/helpers/protocol.py
@@ -24,10 +24,13 @@ def set_aidl_version(args):
         sm_protocol =     "aidl3"
     elif android_api < 33:
         binder_protocol = "aidl4"
-        sm_protocol = "aidl3"
-    else:
+        sm_protocol =     "aidl3"
+    elif android_api < 35:
         binder_protocol = "aidl3"
         sm_protocol =     "aidl3"
+    else:
+        binder_protocol = "aidl3"
+        sm_protocol =     "aidl5"
 
     cfg["waydroid"]["binder_protocol"] = binder_protocol
     cfg["waydroid"]["service_manager_protocol"] = sm_protocol

--- a/tools/helpers/protocol.py
+++ b/tools/helpers/protocol.py
@@ -28,9 +28,12 @@ def set_aidl_version(args):
     elif android_api < 35:
         binder_protocol = "aidl3"
         sm_protocol =     "aidl3"
-    else:
+    elif android_api < 36:
         binder_protocol = "aidl3"
         sm_protocol =     "aidl5"
+    else:
+        binder_protocol = "aidl3"
+        sm_protocol =     "aidl6"
 
     cfg["waydroid"]["binder_protocol"] = binder_protocol
     cfg["waydroid"]["service_manager_protocol"] = sm_protocol


### PR DESCRIPTION
Requires libgbinder 1.1.45 or above ([waydroid/libgbinder#10](https://github.com/waydroid/libgbinder/pull/4))

Tested with `waydroid app list` on A16