### PR TITLE
hardware_manager: Handle Android reboot/shutdown properly

### DIFF
--- a/tools/interfaces/IHardware.py
+++ b/tools/interfaces/IHardware.py
@@ -13,8 +13,9 @@ TRANSACTION_suspend = 3
 TRANSACTION_reboot = 4
 TRANSACTION_upgrade = 5
 TRANSACTION_upgrade2 = 6
+TRANSACTION_shutdownRequest = 7
 
-def add_service(args, enableNFC, enableBluetooth, suspend, reboot, upgrade):
+def add_service(args, enableNFC, enableBluetooth, suspend, reboot, upgrade, shutdownRequest):
     helpers.drivers.loadBinderNodes(args)
     try:
         serviceManager = gbinder.ServiceManager("/dev/" + args.BINDER_DRIVER, args.SERVICE_MANAGER_PROTOCOL, args.BINDER_PROTOCOL)
@@ -55,6 +56,10 @@ def add_service(args, enableNFC, enableBluetooth, suspend, reboot, upgrade):
             arg3 = reader.read_string16()
             status, arg4 = reader.read_int64()
             upgrade(arg1, arg2, arg3, arg4)
+            local_response.append_int32(0)
+        elif code == TRANSACTION_shutdownRequest:
+            arg1 = reader.read_string16()
+            shutdownRequest(arg1)
             local_response.append_int32(0)
         else:
             return local_response, -99999 # Some error unknown to binder to force a RemoteException

--- a/tools/services/hardware_manager.py
+++ b/tools/services/hardware_manager.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 import threading
+import time
 import os
 import tools.actions.container_manager
 import tools.actions.session_manager
@@ -39,10 +40,28 @@ def start(args):
         helpers.protocol.set_aidl_version(args)
         helpers.lxc.start(args)
 
+    def shutdownRequest(reason):
+        is_reboot = reason and reason.startswith("1")
+        tries = 0
+
+        while helpers.lxc.status(args) != "STOPPED":
+            if tries >= 30:
+                logging.debug(f"Android is still not stopped, give up waiting after {tries} seconds")
+                return
+
+            logging.debug("Waiting for Android to shutdown")
+            time.sleep(1)
+            tries += 1
+
+        if is_reboot:
+            helpers.lxc.start(args)
+        else:
+            tools.actions.container_manager.stop(args)
+
     def service_thread():
         while not stopping:
             IHardware.add_service(
-                args, enableNFC, enableBluetooth, suspend, reboot, upgrade)
+                args, enableNFC, enableBluetooth, suspend, reboot, upgrade, shutdownRequest)
 
     global stopping
     stopping = False


### PR DESCRIPTION
Fixes #1052 
Fixes #1905
Fixes #2234
Requires https://github.com/waydroid/android_vendor_waydroid/pull/50

Currently, the `waydroid session/show-full-ui` command does not exit itself after a reboot/shutdown from inside Android (even when the container is already stopped), and the container stops and never boot again when you do a reboot.


This PR does the following things:
- Add a new method for receiving Android shutdown/reboot events
- On shutdown mode (`sys.shutdown.requested == 0`), stop existing sessions after Android stops
- On reboot mode (`sys.shutdown.requested == 1`), restart the container after Android stops
