### PR TITLE
gpu: Remove radeon from Vulkan driver map

### DIFF
--- a/tools/helpers/gpu.py
+++ b/tools/helpers/gpu.py
@@ -39,7 +39,6 @@ def getVulkanDriver(args, dev):
         "i915": "intel",
         "xe": "intel",
         "amdgpu": "radeon",
-        "radeon": "radeon",
         "panfrost": "panfrost",
         "msm": "freedreno",
         "msm_dpu": "freedreno",


### PR DESCRIPTION
The RADV driver only supports `amdgpu` kernel driver:

> Note that for GFX6-7 (GCN 1-2) GPUs, the amdgpu kernel driver is currently not the default in Linux (by default the old radeon KMD is used for these old GPUs, which is not supported by RADV)