### PR TITLE
lxc: Fix post-stop hook erroring on every container stop

### DIFF
--- a/data/configs/config_base
+++ b/data/configs/config_base
@@ -14,5 +14,5 @@ lxc.console.path = none
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_nodes
 lxc.include = /var/lib/waydroid/lxc/waydroid/config_session
 
-lxc.hook.post-stop = /dev/null
+lxc.hook.post-stop = LXCPOSTSTOP
 

--- a/data/scripts/waydroid-post-stop.sh
+++ b/data/scripts/waydroid-post-stop.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# LXC post-stop hook.
+#
+# waydroid manages the container lifecycle itself, so LXC must not
+# automatically respawn the container when the guest reboots or crashes.
+# LXC suppresses that respawn when the post-stop hook exits non-zero.
+#
+# We only need to suppress it on a reboot; on a normal shutdown we exit 0
+# so that a routine `waydroid session stop` doesn't log a spurious
+# "Failed to run lxc.hook.post-stop" error (the previous no-op hook was
+# `/dev/null`, which is not executable and therefore failed on every stop).
+#
+# LXC_TARGET is "stop" for a shutdown and "reboot" for a reboot. Default to
+# suppressing the respawn for any other/unset value to preserve the old
+# always-non-zero behaviour.
+[ "$LXC_TARGET" = "stop" ] && exit 0
+exit 1

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -164,6 +164,9 @@ def set_lxc_config(args):
     tools.helpers.run.user(args, command)
     command = ["sed", "-i", "s/LXCARCH/{}/".format(platform.machine()), lxc_path + "/config"]
     tools.helpers.run.user(args, command)
+    post_stop_script = tools.config.tools_src + "/data/scripts/waydroid-post-stop.sh"
+    command = ["sed", "-i", "s#LXCPOSTSTOP#{}#".format(post_stop_script), lxc_path + "/config"]
+    tools.helpers.run.user(args, command)
     command = ["cp", "-fpr", seccomp_profile, lxc_path + "/waydroid.seccomp"]
     tools.helpers.run.user(args, command)
     if get_apparmor_status(args):


### PR DESCRIPTION
## Summary

`lxc.hook.post-stop` was set to `/dev/null`. As @aleasto pointed out (and #436 confirms), this hook is **not** a pure no-op: its purpose is to stop LXC from auto-respawning the container when the guest reboots/crashes (waydroid manages the session lifecycle itself). LXC suppresses that respawn when the post-stop hook exits non-zero, and `/dev/null` "works" only because it isn't executable.

The side effect is that the hook fails on **every** container stop — including a normal shutdown — logging an error users routinely misdiagnose:

```
lxc-start: waydroid: utils.c: run_buffer: 569 Script exited with status 126
lxc-start: waydroid: start.c: lxc_end: 1178 Failed to run lxc.hook.post-stop for container "waydroid"
```

Reproduced on **LXC 7.0.0**; status 126 is `execve()` of the non-executable `/dev/null`.

## Change

Replace `/dev/null` with a real post-stop script (`data/scripts/waydroid-post-stop.sh`) that keys off `LXC_TARGET`:

```sh
[ "$LXC_TARGET" = "stop" ] && exit 0
exit 1
```

- On a normal shutdown (`LXC_TARGET=stop`) it exits 0, so a routine `waydroid session stop` no longer logs a failed hook.
- On a reboot (or any other/unset value, e.g. older LXC) it exits non-zero, preserving the respawn-suppression behaviour the `/dev/null` hook provided.

The script path is substituted into the generated config in `set_lxc_config()`, mirroring the existing `LXCARCH` substitution. It ships in `data/scripts/` alongside `waydroid-net.sh` and is installed by the existing `cp -a data ...` rule.

## Notes / testing

- Empirically on LXC 7.0.0, an in-guest reboot/shutdown via `sys.powerctl` makes Android's `init` exit, which LXC reports as `LXC_TARGET=stop` (not `reboot`), so the container stops without respawning regardless of exit code — the non-zero exit only matters on a true LXC `reboot` target. Keying off `LXC_TARGET` keeps the conservative default (suppress) for anything that isn't an explicit clean stop.
- Before: every `lxc-stop`/stop logs `Failed to run lxc.hook.post-stop` (status 126). After: clean `session stop` logs nothing; reboot still suppressed.