### PR TITLE
Added controller_only_input option to config

### DIFF
--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -16,6 +16,7 @@ import dbus.service
 import dbus.exceptions
 from gi.repository import GLib
 
+
 class DbusContainerManager(dbus.service.Object):
     def __init__(self, looper, bus, object_path, args):
         self.args = args
@@ -101,6 +102,16 @@ def set_permissions(args, perm_list=None, mode="777"):
         # DMA-BUF Heaps
         perm_list.extend(glob.glob("/dev/dma_heap/*"))
 
+        cfg = tools.config.load(args)
+        if "properties" in cfg and cfg["properties"].get("waydroid.controller_only_input", "false") == "true":
+            # Input devices (gamepads, joysticks, etc.)
+            for pattern in [
+                    "/dev/input/by-id/*-event-joystick",
+                    "/dev/input/by-path/*-event-joystick"]:
+                for path in glob.glob(pattern):
+                    perm_list.append(os.path.realpath(path))
+            perm_list.extend(glob.glob("/dev/input/js*"))
+
     for path in perm_list:
         chmod(path, mode)
 
@@ -165,6 +176,18 @@ def do_start(args, session):
     command = [tools.config.tools_src +
                "/data/scripts/waydroid-net.sh", "start"]
     tools.helpers.run.user(args, command)
+
+    # Regenerate device node config
+    cfg = tools.config.load(args)
+    args.vendor_type = cfg["waydroid"]["vendor_type"]
+    lxc_path = tools.config.defaults["lxc"] + "/waydroid"
+    nodes = helpers.lxc.generate_nodes_lxc_config(args)
+    config_nodes_tmp_path = args.work + "/config_nodes"
+    with open(config_nodes_tmp_path, "w") as f:
+        f.writelines(node + "\n" for node in nodes)
+    command = ["mv", config_nodes_tmp_path, lxc_path]
+    tools.helpers.run.user(args, command)
+    open(os.path.join(lxc_path, "config_session"), "a").close()
 
     # Sensors
     if which("waydroid-sensord"):
@@ -262,7 +285,7 @@ def stop(args, quit_session=True):
         with suppress(Exception):
             helpers.mount.umount_all(args, tools.config.defaults["data"])
 
-        if "session" in args:
+        if "session" in args and args.session is not None:
             if quit_session:
                 logging.info("Terminating session because the container was stopped")
                 with suppress(OSError):

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -85,6 +85,20 @@ def generate_nodes_lxc_config(args):
     make_entry("none", "dev/pts", "devpts", "defaults,mode=644,ptmxmode=666,create=dir 0 0", False)
     make_entry("/dev/uhid")
 
+    cfg = tools.config.load(args)
+    if "properties" in cfg and cfg["properties"].get("waydroid.controller_only_input", "false") == "true":
+        # Input device nodes (gamepads, joysticks, etc.)
+        input_nodes = set()
+        for pattern in [
+                "/dev/input/by-id/*-event-joystick",
+                "/dev/input/by-path/*-event-joystick"]:
+            for path in glob.glob(pattern):
+                input_nodes.add(os.path.realpath(path))
+        for n in sorted(input_nodes):
+            make_entry(n)
+        for n in glob.glob("/dev/input/js*"):
+            make_entry(n)
+
     # TUN/TAP device node for VPN
     make_entry("/dev/net/tun", "dev/tun")
 
@@ -164,15 +178,12 @@ def set_lxc_config(args):
     tools.helpers.run.user(args, command)
     command = ["sed", "-i", "s/LXCARCH/{}/".format(platform.machine()), lxc_path + "/config"]
     tools.helpers.run.user(args, command)
-    post_stop_script = tools.config.tools_src + "/data/scripts/waydroid-post-stop.sh"
-    command = ["sed", "-i", "s#LXCPOSTSTOP#{}#".format(post_stop_script), lxc_path + "/config"]
-    tools.helpers.run.user(args, command)
     command = ["cp", "-fpr", seccomp_profile, lxc_path + "/waydroid.seccomp"]
     tools.helpers.run.user(args, command)
     if get_apparmor_status(args):
         command = ["sed", "-i", "-E", "/lxc.aa_profile|lxc.apparmor.profile/ s/unconfined/{}/g".format(LXC_APPARMOR_PROFILE), lxc_path + "/config"]
         tools.helpers.run.user(args, command)
-
+    lxc_path = tools.config.defaults["lxc"] + "/waydroid"
     nodes = generate_nodes_lxc_config(args)
     config_nodes_tmp_path = args.work + "/config_nodes"
     with open(config_nodes_tmp_path, "w") as f:


### PR DESCRIPTION
When controller_only_input is set true waydroid will only use controller input.

Note:
We couldn't make kb, mouse and gamepad work all at once so we found this solution.