### PR TITLE
lxc: forward ro.vendor.arm.egl.* props for newer Mali devices

### DIFF
--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -324,6 +324,11 @@ def make_base_props(args):
         opengles = "196610"
     props.append("ro.opengles.version=" + opengles)
 
+    # Some Mali devices require ro.vendor.arm.egl.* props from the
+    # host for libEGL/GLES to work
+    for k, v in tools.helpers.props.host_list(args, "ro.vendor.arm.egl.").items():
+        props.append(k + "=" + v)
+
     if args.images_path not in tools.config.defaults["preinstalled_images_paths"]:
         props.append("waydroid.system_ota=" + args.system_ota)
         props.append("waydroid.vendor_ota=" + args.vendor_ota)

--- a/tools/helpers/props.py
+++ b/tools/helpers/props.py
@@ -14,6 +14,23 @@ def host_get(args, prop):
     else:
         return ""
 
+def host_list(args, prefix=""):
+    if which("getprop") is None:
+        return {}
+    output = subprocess.run(["getprop"], stdout=subprocess.PIPE).stdout.decode('utf-8', errors='ignore')
+    result = {}
+    for line in output.splitlines():
+        line = line.strip()
+        # getprop output format: [key]: [value]
+        if not line.startswith("[" + prefix) or "]: [" not in line:
+            continue
+        key, value = line.split("]: [", 1)
+        key = key[1:]
+        value = value[:-1] if value.endswith("]") else value
+        if key.startswith(prefix):
+            result[key] = value
+    return result
+
 def host_set(args, prop, value):
     if which("setprop") is not None:
         command = ["setprop", prop, value]


### PR DESCRIPTION
Needed for the EGL/GLES driver on Volla Phone Plinius and likely newer MediaTek devices.