### PR TITLE
initializer: Add alternate version detection logic for Halium 15+

### DIFF
--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -21,6 +21,7 @@ def is_initialized(args):
 
 def get_vendor_type(args):
     vndk_str = helpers.props.host_get(args, "ro.vndk.version")
+    vendorapi_str = helpers.props.host_get(args, "ro.vendor.build.version.sdk")
     ret = "MAINLINE"
     if vndk_str != "":
         vndk = int(vndk_str)
@@ -31,6 +32,11 @@ def get_vendor_type(args):
             ret = "HALIUM_" + str(halium_ver)
             if vndk == 32:
                 ret += "L"
+    elif vendorapi_str != "":
+        vendorapi = int(vendorapi_str)
+        if vendorapi > 32:
+            halium_ver = vendorapi - 20
+            ret = "HALIUM_" + str(halium_ver)
 
     return ret
 


### PR DESCRIPTION
[VNDK is deprecated](https://source.android.com/docs/core/architecture/vndk#vndk-deprecation) from 15 onwards with its files now largely just present as normal vendor partition contents. On [Volla Phone Quintus with UT port rebased to latest Android firmware on kernel v6.6](https://gitlab.com/ubports/porting/reference-device-ports/halium13/volla-phone-quintus/volla-algiz/-/tree/halium-16.0) `ro.vndk.version` is no longer defined while the best alternative for the same job seems to be `ro.vendor.build.version.sdk=35`.