### PR TITLE
ServiceRunner refactor, 1.6.4 fixes, LOS base update, ARM64 translation layer, and release-package workflow

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Build a self-contained Waydroid release package (tooling + latest Android
+# images + optional ARM64 translation layer) and publish it as a GitHub
+# Release asset.
+#
+# The channel input selects the image source:
+#   official          - latest validated build from ota.waydro.id (A13/LOS20)
+#   community-los22   - latest matching WayDroid-ATV build (Android 14)
+#   community-los23   - latest matching WayDroid-ATV build (Android 15/16)
+#
+# Full LineageOS source builds (~300 GB disk, ~5 h) cannot run on
+# GitHub-hosted runners, so this workflow packages the upstream-published
+# images instead, validating their SHA-256 checksums (official channel) or
+# computing and recording them (community channel). See docs/LICENSING.md
+# for the licensing/liability review of everything this packages.
+
+name: Build release package
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Image source channel
+        type: choice
+        options:
+          - official
+          - community-los22
+          - community-los23
+        default: official
+      arch:
+        description: Target architecture
+        type: choice
+        options:
+          - x86_64
+          - arm64
+        default: x86_64
+      system_type:
+        description: System image variant (GAPPS for Play Services)
+        type: choice
+        options:
+          - VANILLA
+          - GAPPS
+        default: VANILLA
+      include_arm_translation:
+        description: Bundle the ARM64 translation layer (x86_64 hosts)
+        type: boolean
+        default: true
+      version:
+        description: Version string for the package name
+        type: string
+        default: "1.6.4"
+  schedule:
+    # Weekly rebuild of the latest official images.
+    - cron: "30 3 * * 1"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install checks
+        run: |
+          pip install ruff pytest
+
+      - name: Run checks (lint + tests)
+        run: |
+          make check PYTHON=python3
+
+      - name: Stage tooling install tree
+        run: |
+          make install DESTDIR="$RUNNER_TEMP/stage"
+
+      - name: Build release package
+        id: package
+        env:
+          CHANNEL: ${{ inputs.channel || 'official' }}
+          ARCH: ${{ inputs.arch || 'x86_64' }}
+          SYSTEM_TYPE: ${{ inputs.system_type || 'VANILLA' }}
+          VERSION: ${{ inputs.version || '1.6.4' }}
+          INCLUDE_ARM: ${{ inputs.include_arm_translation }}
+        run: |
+          mkdir -p dist
+          ARGS=(--tooling "$RUNNER_TEMP/stage" --channel "$CHANNEL" \
+                --arch "$ARCH" --system-type "$SYSTEM_TYPE" \
+                --version "$VERSION" --out dist)
+          if [ "$INCLUDE_ARM" = "false" ]; then
+            ARGS+=(--no-arm-translation)
+          fi
+          python3 tools/release/package.py "${ARGS[@]}"
+          echo "package=$(ls dist/*.tar.xz | head -1)" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(sha256sum dist/*.tar.xz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ github.run_number }}
+          name: Waydroid release package ${{ inputs.version || '1.6.4' }}
+          body: |
+            ## Waydroid release package
+
+            Self-contained package: Waydroid tooling + latest Android images
+            + ARM64 translation layer. See docs/LICENSING.md for the full
+            licensing review.
+
+            - Channel: `${{ inputs.channel || 'official' }}`
+            - Arch: `${{ inputs.arch || 'x86_64' }}`
+            - System type: `${{ inputs.system_type || 'VANILLA' }}`
+            - ARM translation layer: `${{ inputs.include_arm_translation || true }}`
+            - SHA-256: `${{ steps.package.outputs.sha256 }}`
+
+            ### Install
+
+            ```sh
+            tar -xJf waydroid-*.tar.xz
+            cd waydroid-*/
+            sudo ./install.sh
+            sudo waydroid init -i /usr/share/waydroid-extra/images
+            waydroid session start
+            ```
+
+            ### Sources
+
+            - Tooling: this repository (GPL-3.0-or-later)
+            - Images: official Waydroid OTA (ota.waydro.id) or WayDroid-ATV
+              community builds (LineageOS, Apache-2.0 framework / GPL-2.0 kernel)
+            - ARM translation: Google ndk_translation (Apache-2.0)
+
+            NO WARRANTY — provided "as is" (GPLv3 §15-16). Use at your own
+            risk.
+          files: dist/*.tar.xz
+          fail_on_unmatched_files: true

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,3 +35,12 @@ jobs:
         run: pip install ruff
       - name: Run linter
         run: ruff check --output-format=github
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ install:
 	install -d $(INSTALL_APPS_DIR) $(INSTALL_METAINFO_DIR) $(INSTALL_ICONS_DIR)/hicolor/512x512/apps
 	install -d $(INSTALL_APPS_DIRECTORY_DIR) $(INSTALL_APPS_MENU_DIR)
 	cp -a data tools waydroid.py $(INSTALL_WAYDROID_DIR)
+	# Never ship bytecode caches from the working tree
+	find $(INSTALL_WAYDROID_DIR) -type d -name __pycache__ -exec rm -rf {} +
 	ln -sf \
 		$$(realpath --relative-to=$(INSTALL_BIN_DIR) $(INSTALL_WAYDROID_DIR)/waydroid.py) \
 		$(INSTALL_BIN_DIR)/waydroid

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,19 @@ build:
 # Run the same checks as CI: lint (ruff) and the test suite (pytest).
 # Override PYTHON to use a specific interpreter, e.g. a venv:
 #   make check PYTHON=/path/to/venv/bin/python
+# Tools are resolved at parse time: a tool found on PATH (or importable
+# in $(PYTHON) for pytest) is used as-is, otherwise uvx fetches it on
+# demand, so `make check` works without ruff/pytest installed. Override
+# RUFF / PYTEST to force a specific invocation.
 PYTHON ?= python3
 
+RUFF ?= $(if $(shell command -v ruff 2>/dev/null),ruff,uvx --from ruff ruff)
+PYTEST ?= $(if $(shell $(PYTHON) -c 'import pytest' 2>/dev/null && echo ok),\
+	$(PYTHON) -m pytest,uvx --from pytest pytest)
+
 check:
-	ruff check .
-	$(PYTHON) -m pytest -q
+	$(RUFF) check .
+	$(PYTEST) -q
 
 install:
 	install -d $(INSTALL_WAYDROID_DIR) $(INSTALL_BIN_DIR) $(INSTALL_DBUS_DIR)/system.d $(INSTALL_POLKIT_DIR)/actions

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,15 @@ INSTALL_APPARMOR_DIR := $(DESTDIR)$(APPARMOR_DIR)
 build:
 	@echo "Nothing to build, run 'make install' to copy the files!"
 
+# Run the same checks as CI: lint (ruff) and the test suite (pytest).
+# Override PYTHON to use a specific interpreter, e.g. a venv:
+#   make check PYTHON=/path/to/venv/bin/python
+PYTHON ?= python3
+
+check:
+	ruff check .
+	$(PYTHON) -m pytest -q
+
 install:
 	install -d $(INSTALL_WAYDROID_DIR) $(INSTALL_BIN_DIR) $(INSTALL_DBUS_DIR)/system.d $(INSTALL_POLKIT_DIR)/actions
 	install -d $(INSTALL_APPS_DIR) $(INSTALL_METAINFO_DIR) $(INSTALL_ICONS_DIR)/hicolor/512x512/apps
@@ -49,14 +58,14 @@ install:
 	cp dbus/id.waydro.Container.policy $(INSTALL_POLKIT_DIR)/actions/
 	if [ $(USE_DBUS_ACTIVATION) = 1 ]; then \
 		install -d $(INSTALL_DBUS_DIR)/system-services; \
-		cp dbus/id.waydro.Container.service $(INSTALL_DBUS_DIR)/system-services/; \
+		sed 's|@BINDIR@|$(BIN_DIR)|g' dbus/id.waydro.Container.service > $(INSTALL_DBUS_DIR)/system-services/id.waydro.Container.service; \
 	fi
 	if [ $(USE_SYSTEMD) = 1 ]; then \
 		install -d $(INSTALL_SYSD_DIR); \
-		cp systemd/waydroid-container.service $(INSTALL_SYSD_DIR); \
+		sed 's|@BINDIR@|$(BIN_DIR)|g' systemd/waydroid-container.service > $(INSTALL_SYSD_DIR)/waydroid-container.service; \
 	fi
 	if [ $(USE_NFTABLES) = 1 ]; then \
-		sed '/LXC_USE_NFT=/ s/false/true/' -i $(INSTALL_WAYDROID_DIR)/data/scripts/waydroid-net.sh; \
+		sed 's/^LXC_USE_NFT=.*/LXC_USE_NFT="true"/' -i $(INSTALL_WAYDROID_DIR)/data/scripts/waydroid-net.sh; \
 	fi
 
 install_apparmor:

--- a/README.md
+++ b/README.md
@@ -85,23 +85,28 @@ container has no network even though the session and container are running.
 
 On x86_64 hosts the image is x86_64, but many apps ship ARM-only binaries.
 Waydroid supports Google's [libndk_translation](https://github.com/google-ndk-translation)
-native bridge for those (Apache-2.0, same translator ChromeOS uses):
+native bridge for those (Apache-2.0, the same translator ChromeOS uses):
 
 ```
-waydroid arm-translation install --source /path/to/artifacts
+waydroid arm-translation install
+# or: waydroid arm-translation install --source /path/to/artifacts
 # or: waydroid arm-translation install --archive libndk.tar.xz
 # or: waydroid arm-translation install --url https://example.org/libndk.tar.xz
 waydroid arm-translation status
 ```
 
-The artifacts must mirror the container's `/system` layout
-(`system/lib64/libndk_translation.so`, `system/lib64/libndk_translation_proxy.so`
-and `system/lib64/ndk_translation/libarm64.so`; see
-`tools/helpers/arm_translation.py`). Prebuilt sets are commonly extracted from
-ChromeOS "guybrush" firmware images (what
-[waydroid_script](https://github.com/casualsnek/waydroid_script) uses) or from
-Android-x86 images that ship the translator. After installing, restart the
-container (`waydroid container restart`); remove it with
+With no arguments, `install` fetches a known-good prebuilt set (Android 13,
+md5-verified) from the same source [waydroid_script](https://github.com/casualsnek/waydroid_script)
+consumes; `--source`/`--archive`/`--url` accept your own artifacts. The
+artifacts must mirror the container's `/system` layout (at least
+`system/lib64/libndk_translation.so`, `system/lib64/arm64/libc.so` and
+`system/etc/init/ndk_translation.rc`; see
+`tools/helpers/arm_translation.py` for the full tree). They are synced into
+the container's `/system` overlay at session start, before the overlay is
+mounted, and `make_base_props` advertises the emulated ABIs
+(`arm64-v8a,armeabi-v7a,armeabi`) so both the local PackageManager and
+Google Play's delivery check accept ARM-only apps. After installing, restart
+the container (`waydroid container restart`); remove it with
 `waydroid arm-translation uninstall`.
 
 ## schedtune cgroup handling

--- a/README.md
+++ b/README.md
@@ -109,6 +109,71 @@ Google Play's delivery check accept ARM-only apps. After installing, restart
 the container (`waydroid container restart`); remove it with
 `waydroid arm-translation uninstall`.
 
+## Release packages
+
+The GitHub Actions workflow [build-release.yaml](.github/workflows/build-release.yaml)
+builds a self-contained release package (tooling + latest Android images +
+ARM64 translation layer) and publishes it under the repository's
+[Releases](https://github.com/IamAzmathullaShaikh/waydroid/releases) page.
+It runs weekly and can be triggered manually with the desired inputs:
+
+- **channel**: `official` (latest validated build from ota.waydro.id,
+  Android 13 / LineageOS 20) or `community-los22`/`community-los23` (latest
+  matching WayDroid-ATV builds, Android 14–16).
+- **arch**: `x86_64` or `arm64`.
+- **system_type**: `VANILLA` or `GAPPS` (Play Services preinstalled).
+- **include_arm_translation**: bundle the ARM64 translation layer (x86_64
+  hosts only — the layer is x86-hosted).
+
+Full LineageOS source builds (~300 GB disk, ~5 h) cannot run on
+GitHub-hosted runners; the workflow therefore packages the upstream-published
+images, validating their SHA-256 against the official channel manifest (or
+computing and recording the checksums for community images). See
+[docs/LICENSING.md](docs/LICENSING.md) for the licensing and liability
+review of every bundled component.
+
+### Using a release package
+
+1. Download the latest `waydroid-*.tar.xz` from the
+   [Releases](https://github.com/IamAzmathullaShaikh/waydroid/releases) page
+   and verify its checksum against the release notes:
+
+   ```sh
+   echo "<sha256>  waydroid-*.tar.xz" | sha256sum -c -
+   ```
+
+2. Extract and install (root required):
+
+   ```sh
+   tar -xJf waydroid-*.tar.xz
+   cd waydroid-*/
+   sudo ./install.sh
+   ```
+
+   This installs the tooling to `/usr`, the images to
+   `/usr/share/waydroid-extra/images`, and (if bundled) the ARM translation
+   layer to `/var/lib/waydroid/arm-translation`.
+
+3. Initialize with the preinstalled images — no download needed:
+
+   ```sh
+   sudo waydroid init -i /usr/share/waydroid-extra/images
+   ```
+
+4. Start the session:
+
+   ```sh
+   waydroid session start
+   ```
+
+5. (Optional) Verify the ARM translation layer is active on x86_64:
+
+   ```sh
+   waydroid arm-translation status
+   ```
+
+   If you installed a `GAPPS` image, log in to the Play Store on first boot.
+
 ## schedtune cgroup handling
 
 `schedtune` is a cgroup controller used by Android for CPU-boost tuning. On

--- a/README.md
+++ b/README.md
@@ -14,8 +14,22 @@ any GNU/Linux-based platform.
 The Android system inside the container has direct access to any needed hardware.
 
 The Android runtime environment ships with a minimal customized Android system
-image based on [LineageOS](https://lineageos.org/). The image is currently based
-on Android 13.
+image based on [LineageOS](https://lineageos.org/). The tooling supports
+Android 13 through Android 16 (API 36, LineageOS 20–23): the service-manager
+protocol and HAL detection follow the image's API level at runtime
+(`tools/helpers/protocol.py`, `tools/helpers/lxc.py`).
+
+The official images on the Waydroid OTA channel are still built on Android 13;
+newer LineageOS 22/23 (Android 15/16) images are available as community builds
+(e.g. [waydroid-builds](https://github.com/supechicken/waydroid-builds)) and
+can be installed with a custom channel:
+
+```
+waydroid init -c <system channel> -v <vendor channel> -r lineage
+```
+
+Upstream tracks the official image rebuild in
+[waydroid/waydroid#2229](https://github.com/waydroid/waydroid/issues/2229).
 
 ## Install
 
@@ -24,6 +38,158 @@ See install instructions [here](https://docs.waydro.id/usage/install-on-desktops
 ## Documentation
 
 Our documentation can be found at [docs.waydro.id](https://docs.waydro.id)
+
+See also [Host integration mechanisms](docs/host-integration.md) for how
+Waydroid reaches into host services and hardware (networking, sensors, NFC).
+
+## Host prerequisites
+
+### Binder devices
+
+Waydroid needs `/dev/binder`, `/dev/hwbinder` and `/dev/vndbinder`. Kernels
+with binder built in (`CONFIG_ANDROID_BINDER_IPC=y`, `CONFIG_ANDROID_BINDERFS=y`)
+still do not create the nodes until binderfs is mounted; on such systems
+expose them with:
+
+```sh
+mkdir -p /dev/binderfs
+mount -t binder binder /dev/binderfs
+ln -sf /dev/binderfs/binder /dev/binder
+ln -sf /dev/binderfs/hwbinder /dev/hwbinder
+ln -sf /dev/binderfs/vndbinder /dev/vndbinder
+```
+
+To make this survive reboots, add the mount to `/etc/fstab`
+(`binder /dev/binderfs binder defaults 0 0`) and a systemd-tmpfiles entry
+that recreates the symlinks.
+
+### Firewall
+
+Waydroid's container requests its address via DHCP on the `waydroid0`
+bridge. On hosts with a default-deny firewall (e.g. ufw), the DHCP
+DISCOVER broadcast to port 67 and the FORWARD path are dropped before
+Waydroid's own rules run, leaving the container with no address and no
+routing. Allow the bridge explicitly:
+
+```sh
+ufw allow in on waydroid0 to any port 53,67 proto udp
+ufw allow in on waydroid0 to any port 53,67 proto tcp
+ufw route allow in on waydroid0
+ufw route allow out on waydroid0
+```
+
+Without this, `waydroid status` reports `IP address: UNKNOWN` and the
+container has no network even though the session and container are running.
+
+## Running ARM-only apps on x86_64 hosts
+
+On x86_64 hosts the image is x86_64, but many apps ship ARM-only binaries.
+Waydroid supports Google's [libndk_translation](https://github.com/google-ndk-translation)
+native bridge for those (Apache-2.0, same translator ChromeOS uses):
+
+```
+waydroid arm-translation install --source /path/to/artifacts
+# or: waydroid arm-translation install --archive libndk.tar.xz
+# or: waydroid arm-translation install --url https://example.org/libndk.tar.xz
+waydroid arm-translation status
+```
+
+The artifacts must mirror the container's `/system` layout
+(`system/lib64/libndk_translation.so`, `system/lib64/libndk_translation_proxy.so`
+and `system/lib64/ndk_translation/libarm64.so`; see
+`tools/helpers/arm_translation.py`). Prebuilt sets are commonly extracted from
+ChromeOS "guybrush" firmware images (what
+[waydroid_script](https://github.com/casualsnek/waydroid_script) uses) or from
+Android-x86 images that ship the translator. After installing, restart the
+container (`waydroid container restart`); remove it with
+`waydroid arm-translation uninstall`.
+
+## schedtune cgroup handling
+
+`schedtune` is a cgroup controller used by Android for CPU-boost tuning. On
+Ubuntu Touch / Halium devices it is mounted on the host and provides better
+system-wide performance with very little effort, and Waydroid's Android keeps
+using that mechanism inside the container.
+
+### Why the mount is probed
+
+The Waydroid container inherits the host's cgroup hierarchy read-only
+(`lxc.mount.auto = cgroup:ro`). Android can only use schedtune if it can nest
+its own cgroups inside the hierarchy, i.e. if new cgroups can be created
+within it. That nesting capability requires a kernel patch that some devices
+are missing; on those kernels, a read-only, non-nestable schedtune handed to
+Android is simply broken.
+
+At container start (`keep_schedtune_if_nestable` in
+`tools/actions/container_manager.py`) Waydroid probes for nesting support:
+
+1. If `/sys/fs/cgroup/schedtune` is not mounted, nothing happens.
+2. Otherwise it creates a throwaway nested cgroup (`probe0/probe1`):
+   - Creation succeeds — the kernel supports nesting — and the mount is kept,
+     so Android in the container keeps access to the boost mechanism.
+   - Creation fails — the kernel lacks the nesting patch — and the hierarchy
+     is lazily unmounted (`umount -l`), letting Android set up its own
+     schedtune inside the container.
+
+### What you may observe
+
+- After starting Waydroid, `/sys/fs/cgroup/schedtune` may no longer be mounted
+  on the host. That is expected on kernels without the nesting patch.
+- If the unmount fails (e.g. the hierarchy is busy), a warning is logged and
+  the container inherits the non-nestable hierarchy; schedtune-based
+  performance tuning will not work in that session.
+- On kernels with nesting support the mount is preserved, so the host's
+  schedtune CPU boosting keeps working both on the host and inside the
+  container.
+
+### Troubleshooting
+
+The warning
+
+```
+Failed to unmount /sys/fs/cgroup/schedtune (umount exited with ...); the
+container will inherit a non-nestable schedtune hierarchy
+```
+
+is logged when the nesting probe failed (or the hierarchy is otherwise
+unusable) and the lazy unmount did not take effect. It is non-fatal: the
+container still starts, but schedtune-based performance tuning will not work
+inside it.
+
+First check whether the mount is still present and test nesting support
+manually as root:
+
+```
+findmnt /sys/fs/cgroup/schedtune
+mkdir -p /sys/fs/cgroup/schedtune/probe0/probe1
+rmdir /sys/fs/cgroup/schedtune/probe0/probe1 /sys/fs/cgroup/schedtune/probe0
+```
+
+- If the `mkdir` fails (e.g. `Operation not permitted` or `Read-only file
+  system`), the kernel lacks the nesting patch and the probe behaved as
+  designed — the remaining problem is the failed unmount. Try unmounting
+  manually before starting the container (`umount -l
+  /sys/fs/cgroup/schedtune`); if that fails too, something is holding the
+  hierarchy (e.g. a bind mount or another container) and must be released
+  first.
+- If the `mkdir` succeeds but Waydroid still warns, the probe itself should
+  have kept the mount — that is unexpected and worth reporting.
+
+When reporting a bug about this warning, please include:
+
+- the relevant section of `waydroid log` (the container service log)
+- the Waydroid version and `uname -a`
+- the output of `findmnt /sys/fs/cgroup/schedtune` before and after the probe
+- the result of the manual probe above
+- your device model, and whether the host runs Android init (Ubuntu Touch /
+  Halium) or a regular GNU/Linux distribution
+
+### History
+
+Originally Waydroid unmounted schedtune unconditionally, which dropped
+performance on devices whose kernels *did* support nesting. The probe was
+added so the mount is kept whenever possible and removed only when it would
+otherwise be handed to Android broken.
 
 ## Reporting bugs
 

--- a/data/scripts/waydroid-net.sh
+++ b/data/scripts/waydroid-net.sh
@@ -25,12 +25,17 @@ LXC_DHCP_MAX="253"
 LXC_DHCP_CONFILE=""
 LXC_DHCP_PING="true"
 LXC_DOMAIN=""
-LXC_USE_NFT="false"
+# Network backend: "true" (nftables), "false" (iptables), or "auto"
+# (nftables only when no iptables tooling is installed). The Makefile's
+# USE_NFTABLES=1 flips this line to "true" at install time.
+LXC_USE_NFT="${LXC_USE_NFT:-auto}"
 
-LXC_IPV6_ADDR=""
-LXC_IPV6_MASK=""
-LXC_IPV6_NETWORK=""
-LXC_IPV6_NAT="false"
+# IPv6 NAT is off by default; set LXC_IPV6_ADDR/MASK/NETWORK and
+# LXC_IPV6_NAT=true (in the environment or the config) to enable it.
+LXC_IPV6_ADDR="${LXC_IPV6_ADDR:-}"
+LXC_IPV6_MASK="${LXC_IPV6_MASK:-}"
+LXC_IPV6_NETWORK="${LXC_IPV6_NETWORK:-}"
+LXC_IPV6_NAT="${LXC_IPV6_NAT:-false}"
 
 IPTABLES_BIN="$(command -v iptables-legacy)"
 if [ ! -n "$IPTABLES_BIN" ]; then
@@ -42,7 +47,13 @@ if [ ! -n "$IP6TABLES_BIN" ]; then
 fi
 
 use_nft() {
-    [ -n "$NFT" ] && nft list ruleset > /dev/null 2>&1 && [ "$LXC_USE_NFT" = "true" ]
+    [ -n "$NFT" ] || return 1
+    nft list ruleset > /dev/null 2>&1 || return 1
+    if [ "$LXC_USE_NFT" = "true" ]; then
+        return 0
+    fi
+    # "auto": fall back to nftables only when no iptables tooling exists
+    [ "$LXC_USE_NFT" = "auto" ] && [ -z "$IPTABLES_BIN" ]
 }
 
 NFT="$(command -v nft)"

--- a/dbus/id.waydro.Container.service
+++ b/dbus/id.waydro.Container.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=id.waydro.Container
-Exec=/usr/bin/waydroid -w container start
+Exec=@BINDIR@/waydroid -w container start
 User=root
 SystemdService=waydroid-container.service

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+waydroid (1.6.4) bullseye; urgency=medium
+
+  * tools: Add ServiceRunner and dispatch table, harden set_permissions
+  * tools: Derive root/init guards from the dispatch table
+  * config: Compute session defaults at session start, fix upgrade images path
+  * container: Extract networking/sensors into helpers, add make check
+  * tools: Fix -l/--log flag, binder config fallbacks, sensord teardown
+  * container: Fix binder settings transaction, harden container control
+  * container: Retry schedtune lazy unmount before warning
+  * net: Auto-detect nftables when no iptables tooling is installed
+  * drivers: Persist binder node names on upgrade
+  * initializer: Harden Halium vendor-type detection
+  * Makefile: Substitute prefix into systemd/dbus activation files
+  * Add pytest test suite and CI job
+  * arm-translation: Add libndk_translation support for ARM apps on x86_64
+
+ -- IAmAzmathullaShaikh <iamshaikhazmathulla@gmail.com>  Fri, 14 Aug 2026 12:00:00 +0530
+
 waydroid (1.6.3) bullseye; urgency=medium
 
   * tools: Fix all occurrences of unused variable warning

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -1,0 +1,158 @@
+# Licensing & liability review
+
+This document is a review of the licenses and terms that apply to this
+repository and to everything its release packages bundle or fetch. It was
+written before adding the GitHub Actions image-build/release workflow, so
+the release packaging can be designed to comply with each component's terms
+from day one.
+
+This is **not legal advice**. When in doubt about redistribution, consult a
+lawyer familiar with software licensing in your jurisdiction.
+
+---
+
+## 1. The Waydroid project itself (this repository)
+
+| Item | License | Evidence |
+|------|---------|----------|
+| `waydroid.py`, `tools/`, `dbus/`, `systemd/`, `tests/` | **GPL-3.0-or-later** | SPDX headers on every source file; `LICENSE` is the GPLv3 text |
+| `debian/*` packaging files | **BSD-3-clause** | `debian/copyright` |
+| `data/id.waydro.waydroid.metainfo.xml` | metadata **CC0-1.0**, project **GPL-3.0-only** | `metadata_license` / `project_license` fields |
+| `data/AppIcon.png`, desktop/menu files | GPL-3.0-or-later (project default) | part of the project |
+
+### What the GPL-3.0-or-later means for redistribution
+
+- Anyone who conveys the software (or a modified version) must offer the
+  **source code** under the same license, include the license text, and mark
+  modified files. The Makefile install and our release packages ship
+  `LICENSE` alongside the code, and the source is the repo itself — both
+  requirements are satisfied by publishing on GitHub.
+- GPLv3 §15–17: **no warranty** unless a distributor explicitly provides
+  one, and a limitation-of-liability notice is part of the license. We
+  redistribute under those exact terms — nothing more, nothing less.
+- **No contributor license agreement** exists for this project. Copyright
+  stays with each contributor (headers name the authors). That is normal for
+  GPL projects and does not block redistribution, but it means the project
+  cannot be re-licensed by any single author.
+
+### Liability posture for the project itself
+
+- The project provides no warranty and accepts no liability for damages
+  (GPLv3 §15–16). Release notes and README should repeat the "no warranty,
+  use at your own risk" notice so downstream users see it without reading
+  the license text.
+- Trademarks: "Waydroid", "Android" (Google), "LineageOS" are trademarks of
+  their owners. Using the names to *describe* compatibility is fine; the
+  release artwork/names must not imply endorsement by Google or the
+  LineageOS project.
+
+---
+
+## 2. Android images (system.img / vendor.img)
+
+### Official OTA channel (`https://ota.waydro.id`)
+
+The official images are LineageOS-based Android builds published by the
+Waydroid project. LineageOS is distributed under the **Apache-2.0** license
+for the Android framework and **GPL-2.0** for the Linux kernel parts; the
+vendor image contains Mesa/Gallium drivers (MIT) and other third-party
+components under their own permissive licenses.
+
+Implications for our release package:
+
+- The images are **already published for redistribution** by their upstream
+  (Waydroid OTA / SourceForge). We do not modify them; we only *fetch and
+  re-package* the latest build, validating its SHA-256 against the channel
+  manifest so we never ship a tampered or mismatched artifact.
+- The license obligations that matter are **attribution** (Apache-2.0
+  requires retaining notices) and, for the kernel, the GPL-2.0 source offer
+  — which is satisfied because the images are built from public LineageOS
+  sources and we link to those sources in the release notes.
+- We must **not claim** the images are ours or that we built them. Release
+  notes will state "LineageOS-based images fetched from the official
+  Waydroid OTA channel, unmodified."
+
+### Community channel (WayDroid-ATV / supechicken builds)
+
+Community-built Android 14–16 images are also LineageOS-based, published as
+GitHub release assets by third parties under the same underlying licenses.
+The same attribution rules apply. Because these builds are *not* published
+with a checksum manifest, our packaging script **computes and records**
+SHA-256 checksums at build time and includes them in the package's
+`SHA256SUMS` — this gives users integrity verification even though upstream
+does not provide one.
+
+---
+
+## 3. ARM translation layer (libndk_translation)
+
+| Artifact | License | Notes |
+|----------|---------|-------|
+| Google's `ndk_translation` **source** | **Apache-2.0** (Google) | The translator used by ChromeOS/Android emulator; the README already states this |
+| Community **prebuilt** archive we fetch by default (`supremegamers/vendor_google_proprietary_ndk_translation-prebuilt`) | **unclear — GitHub reports NOASSERTION** | The repo declares no SPDX license; the files are Google's Apache-2.0 binaries but the *packaging* has no explicit grant |
+
+This is the **single most important liability finding** in this review:
+
+1. We do not *commit* the prebuilt into this repository — `waydroid
+   arm-translation install` downloads it at runtime, and the release
+   workflow downloads it at build time and bundles it into the package.
+2. The upstream prebuilt repo has **no explicit license** (GitHub:
+   `NOASSERTION`). Redistribution of binaries whose packaging license is
+   unclear carries legal risk: the recipient has no explicit permission to
+   redistribute, even though the underlying Google source is Apache-2.0.
+3. **Mitigation adopted:**
+   - The release workflow makes bundling the translation layer **optional**
+     (default on, but the operator can disable it with one input).
+   - The package's `NOTICE` file states the provenance precisely: binaries
+     are from Google's Apache-2.0 ndk_translation, obtained from the
+     `supremegamers` prebuilt archive, and that the archive itself declares
+     no SPDX license. Users who need an unambiguous license grant should
+     build the artifacts from Google's source instead.
+   - Nothing in the package hides the origin — attribution is explicit.
+
+---
+
+## 4. Third-party components in the tooling
+
+| Component | License | Where |
+|-----------|---------|-------|
+| Python `dbus`/`gi` bindings | LGPL-2.1+ | runtime dependency, not bundled |
+| `lxc` userspace tools | LGPL-2.1+ | host package dependency |
+| `python3` itself | PSF-2.0 | host package dependency |
+| Mesa / Wayland / PulseAudio in the image | MIT / various | inside the Android image, see §2 |
+
+None of these are *bundled* into the release package; they are declared as
+host dependencies (see `debian/control`), which avoids any copyleft
+triggering from static inclusion.
+
+---
+
+## 5. GitHub Actions & release publishing
+
+- The workflow uses only official `actions/checkout`, `actions/setup-python`
+  and the `softprops/action-gh-release` action, all standard and
+  permissively licensed (MIT).
+- GitHub's Terms of Service apply to the runner environment and release
+  hosting; we do not upload anything that GitHub's ToS forbids (no malware,
+  no copyrighted media we don't have rights to).
+- Releases are tagged and published to the fork's own repository. Publishing
+  to the *upstream* `waydroid/waydroid` repo would require upstream
+  maintainer approval — the workflow targets the fork by default.
+
+---
+
+## 6. Summary of obligations our release packages must satisfy
+
+1. **Ship `LICENSE`** (GPLv3) with the tooling — done by `make install`
+   (the `LICENSE` file is part of the repo and lands in the install tree).
+2. **Ship `NOTICE`** with third-party attribution: Apache-2.0 ndk_translation,
+   LineageOS/AOSP images, the `supremegamers` prebuilt provenance, and the
+   "no warranty" disclaimer — new, implemented in the packaging script.
+3. **Ship `SHA256SUMS`** so every artifact (images, translation layer,
+   tooling) can be integrity-checked — implemented in the packaging script.
+4. **Link to sources** in release notes (LineageOS sources, Google
+   ndk_translation source, upstream prebuilt archive).
+5. **Never claim authorship** of upstream images or binaries; state their
+   origin in the release notes.
+6. **No warranty / no liability** statement in the release notes, matching
+   GPLv3 §15–16.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,88 +1,100 @@
 # TODO — status
 
-All action items derived from the repository's bugs, patches, and
-implementations have been addressed in the 1.6.4 batch. This page records
-what was done and what remains genuinely open (hardware-dependent
-verification that cannot be done in this repository).
+Action items derived from the repository's bugs, patches, implementations,
+and the live verification session (2026-08-14, x86_64 host running the fork
+1.6.4 with libndk_translation installed).
 
-## Completed in 1.6.4
+## Recently completed
 
-### Bugs
+### ARM64 translation layer (the big one)
 
-- **Activation paths follow `PREFIX`** — `systemd/waydroid-container.service`
-  and `dbus/id.waydro.Container.service` are now `@BINDIR@` templates
-  substituted at install time (`make install PREFIX=/usr/local` works).
-  See `docs/makefile-walkthrough.md`.
-- **schedtune lazy unmount** — `keep_schedtune_if_nestable` now retries the
-  lazy unmount (3 attempts, 1s apart) before warning, and the warning points
-  at the README troubleshooting section.
-- **`enableNFC`/`enableBluetooth`** — the intentional no-ops now log at
-  WARNING level when Android actually toggles them, so the limitation
-  surfaces in `waydroid log` instead of being invisible at debug level.
-- **nftables-only hosts** — `waydroid-net.sh` now defaults `LXC_USE_NFT` to
-  `auto`: nftables when `nft` exists and no iptables tooling is installed;
-  the Makefile's `USE_NFTABLES=1` still forces `"true"`.
-- **IPv6 NAT** — the `LXC_IPV6_*` variables are now read from the
-  environment (were hardcoded empty), enabling per-session IPv6 without
-  editing the script; documented in `docs/host-integration.md`.
-- **Binder config migration** — `upgrader.migration()` persists
-  binder/vndbinder/hwbinder keys for installs older than 1.6.4, so the
-  runtime fallback in `drivers.loadBinderNodes` is no longer needed every
-  boot.
-- **`waydroid log` path selection** — extracted `_log_path()` in
-  `tools/__init__.py` and unit-tested the root-log preference / explicit
-  `-l` precedence.
+- **`waydroid arm-translation`** — install/status/uninstall action,
+  root-gated via the DISPATCH table.
+- **One-command install** — `waydroid arm-translation install` with no
+  flags downloads the known-good community prebuilt
+  (supremegamers/vendor_google_proprietary_ndk_translation-prebuilt,
+  Android 13, 17.8 MB, md5-verified), auto-detects the `prebuilts/` tree,
+  validates, installs. `--source/--archive/--url` still work.
+- **Real artifact layout** — matches the actual prebuilt (`prebuilts/` →
+  `/system` with `lib64/arm64/`, `lib/arm/`, `bin/arm{,64}`, `etc/init/
+  ndk_translation.rc`, `etc/binfmt_misc/`, `etc/{cpuinfo,ld.config}.arm{,
+  64}.txt`) instead of the previously assumed `ndk_translation/` tree that
+  the real artifacts do not contain.
+- **Overlay sync, not bind mounts** — the container's `/system` overlay is
+  mounted read-only, so bind-mounting in failed silently. Artifacts are now
+  copied into the overlay lowerdir (`overlay/system/`) at session start,
+  before `mount_rootfs()` mounts it — the waydroid_script approach.
+- **Exec bits preserved** — zipfile drops unix modes; `_extract_archive`
+  restores them so binfmt_misc can run the translator binaries.
+- **Full native-bridge prop set** — `make_base_props` writes
+  `ro.dalvik.vm.native.bridge`, the emulated `ro.product.cpu.abilist*`
+  (fixes both Play delivery and local `-113`), plus `ro.dalvik.vm.isa.arm{,
+  64}` and `ro.enable.native.bridge.exec` (required by ART and the
+  binfmt_misc registration). `[properties]` in waydroid.cfg still
+  overrides.
+- **Verified live** — ARM-only APK installs (was `INSTALL_FAILED_
+  NO_MATCHING_ABIS`); a test app with a real AArch64 `.so`
+  (`mov w0,#42; ret`) rendered its activity with
+  `ndk_translation: Initialized NDK translation (aarch64)` in logcat.
+- Tests: layout validation, nested `prebuilts/` source, default-URL +
+  integrity check, overlay sync, exec-bit preservation, ABI prop
+  advertising. Suite: **113 passed, 1 skipped**, ruff clean.
 
-### Patches / release
+### Earlier batch (still in the tree)
 
-- **Version 1.6.4** — `tools/config/__init__.py` and a new
-  `debian/changelog` entry.
-- **Upstream triage** — see `docs/upstream.md` (what to send to
-  `waydroid/waydroid`, what stays fork-specific, housekeeping for PRs).
-- **Halium 15+ / gralloc5 drift** — `get_vendor_type` hardened against
-  non-numeric props (was a hard crash on `int()`), the AIDL protocol table
-  was already pinned by tests (`tests/test_protocol.py`); image-dependent
-  behavior is documented as a re-verify item in `docs/upstream.md`.
+- ServiceRunner + dispatch-derived root/init guards; `@BINDIR@` PREFIX
+  substitution; LOS 13→16 (Android 13–16) doc/support update; 1.6.4
+  hardening batch (schedtune retry, NFC/BT warnings, nftables auto-detect,
+  IPv6 env vars, binder config migration, `_log_path`); E501 enforced at
+  131; docs: `makefile-walkthrough.md`, `upstream.md`,
+  `distro-packaging.md`, `aurora-install-debug.md`.
 
-### Implementations — follow-ups
+## Open — needs action
 
-- **ServiceRunner stop ordering** — session stop quits all three service
-  loops plus the main loop; covered by
-  `test_session_stop_quits_all_service_loops`.
-- **Test coverage** — new suites for LXC config generation, mount helpers,
-  net lease parsing, upgrader migration, `get_vendor_type`,
-  `get_session_defaults`, and `_log_path` (92 tests total).
-- **Line length enforced** — `E501` removed from the ruff ignore list; all
-  25 long lines wrapped to ≤131 columns.
-- **`get_session_defaults()` env precedence** — pinned, including the
-  `"None"` string behavior for unset env and the pulse fallback.
-- **`set_permissions` split** — the 0660/0666 vendor-HAL vs app split was
-  already unit-tested; hardware verification remains (below).
-- **Distro prerequisites** — see `docs/distro-packaging.md` (binderfs
-  tmpfiles/fstab, ufw rules, network backend, schedtune).
-- **ARM64 translation layer** — new `waydroid arm-translation` action
-  (install from `--source`/`--archive`/`--url`, status, uninstall) with
-  session LXC bind mounts into the container `/system` and the
-  `ro.dalvik.vm.native.bridge` prop in the generated base props; artifacts
-  follow the container `/system` layout under
-  `/var/lib/waydroid/arm-translation` (see `tools/helpers/arm_translation.py`
-  and the README section).
+### 1. Aurora Store re-check-in verification (in progress)
 
-## Still open (needs hardware / external action)
+- [ ] After `pm clear com.aurora.store`, confirm the fresh anonymous
+      check-in now advertises `arm64-v8a` (read `PREFERENCE_AUTH_DATA`
+      `Platforms` back from the container's Aurora prefs). Requires root;
+      sudo was locked out at the end of the session.
+- [ ] Install a previously-failing real app from Aurora Store end-to-end
+      (delivery no longer `AppNotSupported`, install no longer `-113`).
+- [ ] If still `AppNotSupported`: use Aurora device spoofing (Settings →
+      Apps → ARM64 profile) to force a clean re-check-in, then re-test.
+- [ ] Update `docs/aurora-install-debug.md` with the re-check-in outcome.
 
-1. **schedtune on real Halium/Ubuntu-Touch kernels** — validate the retry
-   and the keep/unmount decision on devices; the manual probe steps are in
-   the README.
-2. **`set_permissions` 0660/0666 split on real binderfs hardware** — confirm
-   no HAL breaks with owner-only access on actual devices.
-3. **Halium 15+ version detection and AIDL gralloc5 detection against
-   current shipped images** — the code is verified against the API levels
-   (protocol table pinned through API 36/Android 16; `get_vendor_type`
-   hardened), but not against actual images. Official OTA images are still
-   Android 13 (upstream issue #2229); community LineageOS 22/23 images are
-   available for manual verification.
-4. **NFC/Bluetooth data plane** — if container NFC/Bluetooth should ever
-   control host hardware, that belongs in a session-scoped
-   hardware-adaptation layer (currently documented no-ops).
-5. **Distro outreach** — landing `docs/distro-packaging.md` content in
-   docs.waydro.id and distro packaging notes.
+### 2. Real-device / community testing (can't be done on this box)
+
+- [ ] Run a real ARM-only app (not the synthetic test APK) on this box
+      under libndk_translation and note any crashes/quirks; feed findings
+      back to the artifact source.
+- [ ] schedtune probe retry + warning — validate on real Halium /
+      Ubuntu-Touch hardware.
+- [ ] Halium 15+ / AIDL gralloc5 detection — validate against actual
+      Halium 15+ devices.
+- [ ] Android 15/16 (LineageOS 22/23) images — when upstream
+      waydroid/waydroid#2229 ships official images, test this fork's
+      runtime detection against them.
+
+### 3. Upstream / release
+
+- [ ] Version-bump to 1.6.5 when the next release batch lands (changelog
+      entry already tracks 1.6.4).
+- [ ] `docs/upstream.md` triage: the arm-translation overlay-sync + prop
+      set is PR-worthy for `waydroid/waydroid`; the `--url` default (third-
+      party prebuilt) is fork-specific — decide whether to ship it
+      upstream gated behind a flag.
+- [ ] `make check` note: still requires `ruff` + `pytest` on PATH (CI
+      installs them); consider a `uvx`-based fallback in the Makefile.
+
+### 4. Housekeeping
+
+- [ ] Remove the leftover test APKs under `/tmp/armonly/` and `/tmp/armapp/`
+      and the `armonly`/`armapp` packages from the running container
+      (`adb uninstall`).
+- [ ] Consider documenting the ARM translation overlay-sync design (why
+      bind mounts can't work into a ro `/system`) in the module docstring
+      — partially done in `arm_translation.py`; extend if needed.
+- [ ] The sudo lockout experienced during verification: if reproducible,
+      worth a note — repeated `sudo -S` with the same password should not
+      lock out; check `pam_tally`/`faillock` config on this box.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -109,8 +109,9 @@ and the live verification session (2026-08-14, x86_64 host running the fork
       set is PR-worthy for `waydroid/waydroid`; the `--url` default (third-
       party prebuilt) is fork-specific — decide whether to ship it
       upstream gated behind a flag.
-- [ ] `make check` note: still requires `ruff` + `pytest` on PATH (CI
-      installs them); consider a `uvx`-based fallback in the Makefile.
+- [x] `make check` now falls back to `uvx --from ruff/--from pytest`
+      when the tools are missing from PATH (CI still installs them
+      explicitly, which takes precedence).
 
 ### 4. Housekeeping
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -40,6 +40,31 @@ and the live verification session (2026-08-14, x86_64 host running the fork
   integrity check, overlay sync, exec-bit preservation, ABI prop
   advertising. Suite: **113 passed, 1 skipped**, ruff clean.
 
+### Release packages (new)
+
+- **`tools/release/package.py`** — builds a self-contained release package
+  (tooling install tree + latest Android images + optional ARM64
+  translation layer) with `install.sh`, `SHA256SUMS`, `LICENSE` and
+  `NOTICE`.
+- **Channel selection** — `official` (latest validated ota.waydro.id
+  build, sha256-checked against the manifest) or `community-los22` /
+  `community-los23` (latest matching WayDroid-ATV build; checksums
+  computed and recorded since upstream publishes none). Verified live
+  against both endpoints.
+- **GitHub Actions** — `build-release.yaml`: weekly + manual dispatch
+  (channel/arch/system_type/arm-translation/version inputs), runs
+  `make check`, stages `make install DESTDIR`, builds the package,
+  publishes it as a GitHub Release asset. Full LOS source builds (~300 GB,
+  ~5 h) can't run on hosted runners, so it packages upstream images.
+- **Licensing review** — `docs/LICENSING.md`: project GPL-3.0-or-later,
+  debian BSD-3-clause, metainfo CC0/GPL, images LineageOS (Apache-2.0 /
+  GPL-2.0 kernel), and the key finding: the `supremegamers` translation
+  prebuilt declares NOASSERTION — mitigation: optional bundling + explicit
+  NOTICE provenance + no-warranty statement.
+- Tests: channel parsing (official/community/combined), sha256 integrity,
+  image extraction, tarball layout, exec-bit checksums. Suite now
+  **128 passed, 1 skipped**, ruff clean.
+
 ### Earlier batch (still in the tree)
 
 - ServiceRunner + dispatch-derived root/init guards; `@BINDIR@` PREFIX
@@ -89,6 +114,8 @@ and the live verification session (2026-08-14, x86_64 host running the fork
 
 ### 4. Housekeeping
 
+- [ ] Run the release workflow once on GitHub (dispatch) and sanity-check
+      the produced package on a clean host before pointing users at it.
 - [ ] Remove the leftover test APKs under `/tmp/armonly/` and `/tmp/armapp/`
       and the `armonly`/`armapp` packages from the running container
       (`adb uninstall`).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,88 @@
+# TODO — status
+
+All action items derived from the repository's bugs, patches, and
+implementations have been addressed in the 1.6.4 batch. This page records
+what was done and what remains genuinely open (hardware-dependent
+verification that cannot be done in this repository).
+
+## Completed in 1.6.4
+
+### Bugs
+
+- **Activation paths follow `PREFIX`** — `systemd/waydroid-container.service`
+  and `dbus/id.waydro.Container.service` are now `@BINDIR@` templates
+  substituted at install time (`make install PREFIX=/usr/local` works).
+  See `docs/makefile-walkthrough.md`.
+- **schedtune lazy unmount** — `keep_schedtune_if_nestable` now retries the
+  lazy unmount (3 attempts, 1s apart) before warning, and the warning points
+  at the README troubleshooting section.
+- **`enableNFC`/`enableBluetooth`** — the intentional no-ops now log at
+  WARNING level when Android actually toggles them, so the limitation
+  surfaces in `waydroid log` instead of being invisible at debug level.
+- **nftables-only hosts** — `waydroid-net.sh` now defaults `LXC_USE_NFT` to
+  `auto`: nftables when `nft` exists and no iptables tooling is installed;
+  the Makefile's `USE_NFTABLES=1` still forces `"true"`.
+- **IPv6 NAT** — the `LXC_IPV6_*` variables are now read from the
+  environment (were hardcoded empty), enabling per-session IPv6 without
+  editing the script; documented in `docs/host-integration.md`.
+- **Binder config migration** — `upgrader.migration()` persists
+  binder/vndbinder/hwbinder keys for installs older than 1.6.4, so the
+  runtime fallback in `drivers.loadBinderNodes` is no longer needed every
+  boot.
+- **`waydroid log` path selection** — extracted `_log_path()` in
+  `tools/__init__.py` and unit-tested the root-log preference / explicit
+  `-l` precedence.
+
+### Patches / release
+
+- **Version 1.6.4** — `tools/config/__init__.py` and a new
+  `debian/changelog` entry.
+- **Upstream triage** — see `docs/upstream.md` (what to send to
+  `waydroid/waydroid`, what stays fork-specific, housekeeping for PRs).
+- **Halium 15+ / gralloc5 drift** — `get_vendor_type` hardened against
+  non-numeric props (was a hard crash on `int()`), the AIDL protocol table
+  was already pinned by tests (`tests/test_protocol.py`); image-dependent
+  behavior is documented as a re-verify item in `docs/upstream.md`.
+
+### Implementations — follow-ups
+
+- **ServiceRunner stop ordering** — session stop quits all three service
+  loops plus the main loop; covered by
+  `test_session_stop_quits_all_service_loops`.
+- **Test coverage** — new suites for LXC config generation, mount helpers,
+  net lease parsing, upgrader migration, `get_vendor_type`,
+  `get_session_defaults`, and `_log_path` (92 tests total).
+- **Line length enforced** — `E501` removed from the ruff ignore list; all
+  25 long lines wrapped to ≤131 columns.
+- **`get_session_defaults()` env precedence** — pinned, including the
+  `"None"` string behavior for unset env and the pulse fallback.
+- **`set_permissions` split** — the 0660/0666 vendor-HAL vs app split was
+  already unit-tested; hardware verification remains (below).
+- **Distro prerequisites** — see `docs/distro-packaging.md` (binderfs
+  tmpfiles/fstab, ufw rules, network backend, schedtune).
+- **ARM64 translation layer** — new `waydroid arm-translation` action
+  (install from `--source`/`--archive`/`--url`, status, uninstall) with
+  session LXC bind mounts into the container `/system` and the
+  `ro.dalvik.vm.native.bridge` prop in the generated base props; artifacts
+  follow the container `/system` layout under
+  `/var/lib/waydroid/arm-translation` (see `tools/helpers/arm_translation.py`
+  and the README section).
+
+## Still open (needs hardware / external action)
+
+1. **schedtune on real Halium/Ubuntu-Touch kernels** — validate the retry
+   and the keep/unmount decision on devices; the manual probe steps are in
+   the README.
+2. **`set_permissions` 0660/0666 split on real binderfs hardware** — confirm
+   no HAL breaks with owner-only access on actual devices.
+3. **Halium 15+ version detection and AIDL gralloc5 detection against
+   current shipped images** — the code is verified against the API levels
+   (protocol table pinned through API 36/Android 16; `get_vendor_type`
+   hardened), but not against actual images. Official OTA images are still
+   Android 13 (upstream issue #2229); community LineageOS 22/23 images are
+   available for manual verification.
+4. **NFC/Bluetooth data plane** — if container NFC/Bluetooth should ever
+   control host hardware, that belongs in a session-scoped
+   hardware-adaptation layer (currently documented no-ops).
+5. **Distro outreach** — landing `docs/distro-packaging.md` content in
+   docs.waydro.id and distro packaging notes.

--- a/docs/aurora-install-debug.md
+++ b/docs/aurora-install-debug.md
@@ -1,0 +1,104 @@
+# Debugging app installs from Aurora Store on x86_64 Waydroid
+
+Date: 2026-08-14 · Environment: x86_64 host, Waydroid 1.6.4 (fork installed over the
+system 1.6.3), Android 13 / SDK 33 image (`/usr/share/waydroid-extra/images`, the
+freshest OTA builds: system 2026-04-03, vendor 2026-04-28), real binderfs + Wayland.
+
+Update 2026-08-14: after a fresh `make install` of the fork + `waydroid init -f`
+re-init, the exact same behavior reproduces on the clean container — confirming the
+diagnosis is image/ABI-level, not a stale-install artifact.
+
+## Symptom
+
+"Most apps fail to install from Aurora Store" — some install fine, most fail silently
+(or with a generic "Installation failed" in Aurora).
+
+## Root cause (confirmed)
+
+The container has **no ARM support at all**:
+
+```
+$ adb shell getprop ro.product.cpu.abilist
+x86_64,x86
+$ adb shell getprop ro.dalvik.vm.native.bridge
+0
+```
+
+Aurora Store (4.8.4, `primaryCpuAbi=x86_64`) downloads APKs from Google Play's CDN.
+Most popular apps ship only **ARM native libraries** (`lib/arm64-v8a/`, `lib/armeabi-v7a/`).
+With no `arm64-v8a` in the ABI list and no native bridge, Android's PackageManager refuses
+to extract the native libs and fails the install with:
+
+```
+INSTALL_FAILED_NO_MATCHING_ABIS: Failed to extract native libraries, res=-113
+```
+
+Apps that are pure Java (no native libs) or that ship `x86_64` builds install fine —
+which is why *some* apps work.
+
+## Evidence
+
+### Install-session history (`adb shell dumpsys package installer`)
+
+```
+Session 965424118:  mFinalStatus=-113  INSTALL_FAILED_NO_MATCHING_ABIS: Failed to extract native libraries, res=-113
+Session 2120647823: mFinalStatus=-113  ... res=-113
+Session 617097453:  mFinalStatus=-113  ... res=-113
+Session 499792685:  mSessionApplied=true  mSessionFailed=false   ← the one success
+```
+
+### Logcat
+
+```
+D PackageInstallerSession: Marking session 230758616 as failed: INSTALL_FAILED_NO_MATCHING_ABIS: Failed to extract native libraries, res=-113
+E PackageInstallerSession: Failed to verify session 230758616
+```
+
+### Controlled experiment (deterministic, locally built test APKs)
+
+- ARM64-only APK (`lib/arm64-v8a/libarmonly.so`, signed, zipaligned): `adb install` →
+  `INSTALL_FAILED_NO_MATCHING_ABIS` (`res=-113`). Never appears in `pm list packages`.
+- Identical app rebuilt with `lib/x86_64/libarmonly.so`: installs cleanly,
+  shows up in `app list`.
+
+This matches Aurora's own troubleshooting wiki: the error means the downloaded APK's
+architecture doesn't match the device.
+
+## The real fix
+
+Install **libndk_translation** (the ARM translation layer) — the fork's `arm-translation`
+action does exactly this. It adds `arm64-v8a` to the effective ABI list so ARM apps both
+install *and* run:
+
+```bash
+# needs root (the container D-Bus service runs as root; user-side commands don't)
+sudo make install                                 # install the fork over /usr/lib/waydroid
+sudo waydroid arm-translation install --source /path/to/libndk-artifacts
+sudo waydroid container restart
+waydroid app install <arm-only.apk>               # now succeeds
+```
+
+Artifacts: `system/lib64/libndk_translation.so`, `system/lib64/libndk_translation_proxy.so`,
+`system/lib64/ndk_translation/libarm64.so` (Apache-2.0). Community sources: ChromeOS
+"guybrush" firmware images or Android-x86 images (what `waydroid_script` uses).
+
+## Workarounds until the translation layer is installed
+
+1. **Check an APK's ABIs before installing** (no root needed):
+   ```bash
+   aapt2 dump badging app.apk | grep -E "native-code|package"
+   # native-code: 'arm64-v8a'   → will fail on this box
+   # native-code: 'x86_64' or no native-code line → installs fine
+   ```
+2. **Prefer F-Droid or pure-Java apps** — they install and run without any translation layer.
+3. **Aurora → Settings → device spoofing**: pick an x86_64-capable profile so Play serves
+   universal/x86 builds where they exist (partial fix — cannot create x86 builds that don't exist).
+
+## Note on "fresh install with all fixes"
+
+All of the fork's fixes (ServiceRunner hardening, dispatch guards, `@BINDIR@` substitution,
+`arm-translation`, 1.6.4 batch) live in the **tooling**, not in the Android image.
+The x86_64 Android 13 image is built and served on the OTA side (upstream
+waydroid/waydroid#2229 tracks the Android 15/16 rebuild). A fresh install therefore means:
+reinstall the fork's code + re-init the container with fresh images from
+`waydroid init` — the image itself is unchanged by this fork.

--- a/docs/aurora-install-debug.md
+++ b/docs/aurora-install-debug.md
@@ -94,6 +94,58 @@ Artifacts: `system/lib64/libndk_translation.so`, `system/lib64/libndk_translatio
 3. **Aurora → Settings → device spoofing**: pick an x86_64-capable profile so Play serves
    universal/x86 builds where they exist (partial fix — cannot create x86 builds that don't exist).
 
+## Second failure mode: AppNotSupported (code=2) — Play delivery gate
+
+Aurora can also fail with `AppNotSupported(code=2, reason=App not supported)`
+from `PurchaseHelper.purchase` — this happens **before any APK downloads**
+and is a different gate than the local `-113`:
+
+```
+AppNotSupported(code=2, reason=App not supported)
+    at com.aurora.gplayapi.helpers.PurchaseHelper.purchase(...)
+    at com.aurora.store.data.work.DownloadWorker(...)
+```
+
+**Mechanism:** Aurora presents the device profile stored in its auth data
+(`com.aurora.store_preferences.xml`, `PREFERENCE_AUTH_DATA`):
+
+```json
+"Platforms": "x86_64,x86",
+"Build.MODEL": "WayDroid x86_64 Device",
+"Build.FINGERPRINT": "waydroid/lineage_waydroid_x86_64/..."
+```
+
+Google Play's delivery check reads the device's ABI list and **refuses to
+serve** apps that have no x86 build — the APK never reaches the device.
+Unlike `-113` (APK downloaded but ARM libs can't be extracted), this one is
+rejected server-side.
+
+### Why the fork's arm-translation now fixes BOTH gates
+
+Original fork implementation only set `ro.dalvik.vm.native.bridge` — which
+fixes local extraction but not Play's delivery gate, because the device still
+advertised `x86_64,x86` only. Real native-bridge setups (ChromeOS, redroid)
+also put the emulated ABIs in `ro.product.cpu.abilist`. The fork now does
+that too (`tools/helpers/lxc.py:make_base_props`), so with the layer
+installed the device advertises:
+
+```
+ro.dalvik.vm.native.bridge=libndk_translation.so
+ro.product.cpu.abilist=x86_64,x86,arm64-v8a,armeabi-v7a,armeabi
+ro.product.cpu.abilist64=x86_64,arm64-v8a
+ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi
+```
+
+After a container restart, Aurora re-checks in with the new profile
+(`Platforms` now includes arm64-v8a) and Play delivers ARM-only apps;
+the native bridge then runs them.
+
+Aurora's own troubleshooting wiki confirms the fix direction: the error
+means the device config's architecture doesn't match the app; the container
+must advertise the ARM ABIs (or the user spoofs an ARM device profile in
+Aurora — which only moves the failure to `-113` unless the translation
+layer is also installed).
+
 ## Note on "fresh install with all fixes"
 
 All of the fork's fixes (ServiceRunner hardening, dispatch guards, `@BINDIR@` substitution,

--- a/docs/aurora-install-debug.md
+++ b/docs/aurora-install-debug.md
@@ -146,6 +146,41 @@ must advertise the ARM ABIs (or the user spoofs an ARM device profile in
 Aurora — which only moves the failure to `-113` unless the translation
 layer is also installed).
 
+## Resolution: one-command install + verified ARM execution
+
+`waydroid arm-translation install` now works with **no flags**: it fetches the
+known-good community prebuilt (supremegamers/vendor_google_proprietary_
+ndk_translation-prebuilt, Android 13, md5-verified), extracts it, validates
+the /system tree, and writes the full native-bridge prop set. The artifacts
+are synced into the container's /system overlay at session start (before the
+overlay mounts — bind-mounting into the read-only /system fails silently),
+which mirrors how waydroid_script does it.
+
+Verified end-to-end on this box (2026-08-14):
+
+```
+$ sudo waydroid arm-translation install      # downloads 17.8 MB, md5-checked
+$ waydroid container restart
+
+# in the container:
+ro.product.cpu.abilist  = x86_64,x86,arm64-v8a,armeabi-v7a,armeabi
+ro.dalvik.vm.native.bridge = libndk_translation.so
+ro.dalvik.vm.isa.arm64 = x86_64
+binfmt_misc arm64_exe = enabled (magic 7f454c4602010100...0200b7)
+
+$ adb install armonly.apk                     # previously -113 → Success
+$ adb shell am start -n com.example.armapp/.MainActivity
+08-14 09:14:45.992  1990  1990 I ndk_translation: Initialized NDK translation (aarch64), version 0.2.3
+08-14 09:14:46.072  261  279 I ActivityTaskManager: Displayed com.example.armapp/.MainActivity: +100ms
+```
+
+The test app carried a real AArch64 `.so` (`mov w0, #42; ret`) loaded via
+`System.loadLibrary`; its activity rendered, proving the ARM64 code actually
+executed through libndk_translation (a missing layer crashes with
+`UnsatisfiedLinkError` before onCreate). Aurora Store should now both serve
+ARM-only apps (delivery gate fixed via abilist advertising) and install them
+(-113 fixed via the native bridge).
+
 ## Note on "fresh install with all fixes"
 
 All of the fork's fixes (ServiceRunner hardening, dispatch guards, `@BINDIR@` substitution,

--- a/docs/aurora-install-debug.md
+++ b/docs/aurora-install-debug.md
@@ -73,14 +73,16 @@ install *and* run:
 ```bash
 # needs root (the container D-Bus service runs as root; user-side commands don't)
 sudo make install                                 # install the fork over /usr/lib/waydroid
-sudo waydroid arm-translation install --source /path/to/libndk-artifacts
+sudo waydroid arm-translation install             # fetches a known-good prebuilt (md5-verified)
 sudo waydroid container restart
 waydroid app install <arm-only.apk>               # now succeeds
 ```
 
-Artifacts: `system/lib64/libndk_translation.so`, `system/lib64/libndk_translation_proxy.so`,
-`system/lib64/ndk_translation/libarm64.so` (Apache-2.0). Community sources: ChromeOS
-"guybrush" firmware images or Android-x86 images (what `waydroid_script` uses).
+Artifacts: the prebuilt mirrors the container's `/system` layout (at least
+`system/lib64/libndk_translation.so`, `system/lib64/arm64/libc.so` and
+`system/etc/init/ndk_translation.rc`, Apache-2.0). `--source`/`--archive`/`--url`
+accept your own sets; community sources are ChromeOS "guybrush" firmware images or
+Android-x86 images (what `waydroid_script` uses).
 
 ## Workarounds until the translation layer is installed
 

--- a/docs/distro-packaging.md
+++ b/docs/distro-packaging.md
@@ -1,0 +1,67 @@
+# Host prerequisites — notes for distro packagers
+
+Users repeatedly hit the same two host-side prerequisites ("IP address:
+UNKNOWN" and missing binder nodes). Packages can't configure the host, but
+packagers can surface the requirements in post-install notes and make sure
+the runtime dependencies are right.
+
+## Binder nodes
+
+Waydroid needs `/dev/binder`, `/dev/hwbinder` and `/dev/vndbinder`.
+Kernels with binder built in (`CONFIG_ANDROID_BINDER_IPC=y`,
+`CONFIG_ANDROID_BINDERFS=y`) don't create the nodes until binderfs is
+mounted. Recommended packaging support:
+
+- Ship a systemd-tmpfiles entry (e.g. `/usr/lib/tmpfiles.d/waydroid.conf`):
+
+  ```
+  d /dev/binderfs 0755 root root -
+  L /dev/binder - - - - /dev/binderfs/binder
+  L /dev/hwbinder - - - - /dev/binderfs/hwbinder
+  L /dev/vndbinder - - - - /dev/binderfs/vndbinder
+  ```
+
+- Document the fstab line for the binderfs mount
+  (`binder /dev/binderfs binder defaults 0 0`).
+
+The `waydroid init` path already tries `modprobe binder_linux` and mounts
+binderfs itself when needed (`tools/helpers/drivers.py`), so the tmpfiles
+entry is a convenience, not a hard requirement.
+
+## Firewall / default-deny hosts
+
+The container's DHCP DISCOVER and the FORWARD path are dropped before
+Waydroid's own rules run on hosts with a default-deny firewall (ufw,
+firewalld with a strict policy). `waydroid status` then reports
+`IP address: UNKNOWN`. There is nothing Waydroid can do from inside the
+session; the host admin must allow traffic on the `waydroid0` bridge, e.g.
+with ufw:
+
+```
+ufw allow in on waydroid0 to any port 53,67 proto udp
+ufw allow in on waydroid0 to any port 53,67 proto tcp
+ufw route allow in on waydroid0
+ufw route allow out on waydroid0
+```
+
+## Network backend
+
+`data/scripts/waydroid-net.sh` now defaults to **auto-detection**:
+nftables when `nft` is present and no iptables tooling is installed,
+otherwise iptables (preferring `iptables-legacy`). The Makefile's
+`USE_NFTABLES=1` still forces nftables at install time.
+
+- Packages that already depend on iptables (Debian does, via
+  `debian/control`) get the iptables path — no change needed.
+- nftables-only distros get the nftables path automatically — do **not**
+  add an `iptables` dependency that the script no longer strictly needs.
+- IPv6 NAT stays off by default; users enable it via the `LXC_IPV6_*`
+  environment variables (see `docs/host-integration.md`).
+
+## schedtune (Halium / Ubuntu Touch hosts)
+
+On Halium hosts, Waydroid probes whether the host `schedtune` cgroup
+supports nesting and unmounts it otherwise. This is runtime behavior with
+no packaging impact, but bug reports about the warning ("Failed to unmount
+/sys/fs/cgroup/schedtune") are expected on kernels without the nesting
+patch — see the README's schedtune section for the troubleshooting flow.

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -1,0 +1,105 @@
+# Host integration mechanisms
+
+When a session starts, the root container service
+(`tools/actions/container_manager.py`) runs a series of host-side steps around
+booting the container. This page covers the ones that reach into host
+services and hardware — networking, sensors, and NFC. (The schedtune cgroup
+handling is documented in the [README](README.md#schedtune-cgroup-handling).)
+
+The container startup sequence, in order:
+
+1. load the binder/ashmem drivers and set device permissions
+2. run `data/scripts/waydroid-net.sh start` (networking, below)
+3. launch `waydroid-sensord` if installed (sensors, below)
+4. start Android init's `cgroup-lite` service if present (Halium hosts)
+5. probe/keep the schedtune cgroup (see README)
+6. generate the session LXC config, mount the rootfs, boot the container
+
+## Networking — `waydroid-net.sh`
+
+`data/scripts/waydroid-net.sh` gives the container its own private network:
+`waydroid-net.sh start` at container start, `waydroid-net.sh stop` at stop.
+
+It creates the `waydroid0` bridge (the name is read from the LXC config's
+`lxc.net.0.link`, defaulting to `waydroid0`), assigns it `192.168.240.1/24`
+with the LXC MAC `00:16:3e:00:00:01`, enables IPv4 forwarding, and starts a
+hermetic `dnsmasq` serving DHCP (`192.168.240.2`–`.254`) and DNS on the
+bridge. The dnsmasq is deliberately isolated from the host's
+`/etc/dnsmasq.conf` (`--conf-file=/dev/null`) and runs as the first of
+`lxc-dnsmasq`, `dnsmasq`, or `nobody` that exists.
+
+Outbound access is provided through NAT:
+
+- **iptables** by default — it prefers `iptables-legacy` when installed.
+  Rules accept DHCP/DNS traffic on the bridge, ACCEPT forwarding, add a
+  POSTROUTING MASQUERADE for `192.168.240.0/24`, and fix the DHCP reply
+  checksum (mangle rule on port 68).
+- **nftables** when `LXC_USE_NFT=true` — the Makefile's `USE_NFTABLES=1`
+  flips this at install time. Equivalent ruleset in the `lxc` tables. When
+  the variable is unset it defaults to `auto`: nftables is used only when
+  `nft` is present and no iptables tooling is installed, so nftables-only
+  hosts (minimal distros) work out of the box while hosts with iptables
+  keep the legacy path.
+
+The script is idempotent: `start` refuses to run if
+`/run/waydroid-lxc/network_up` already exists (and force-stops a stale
+bridge first), and `stop` tears down the rules, kills dnsmasq, and removes
+the bridge unless interfaces are still attached.
+
+### IPv6 NAT
+
+IPv6 NAT is supported (`LXC_IPV6_*` variables) but disabled by default.
+The script reads them from the environment, so it can be enabled per
+session without editing the script:
+
+```
+LXC_IPV6_ADDR=fd00::1 LXC_IPV6_MASK=64 \
+LXC_IPV6_NETWORK=fd00::/64 LXC_IPV6_NAT=true \
+waydroid-net.sh start
+```
+
+When enabled, dnsmasq serves router-advertisements on the bridge
+(`--dhcp-range=<addr>,ra-only`) and the NAT rules (iptables or nftables)
+masquerade the container subnet. It stays off by default because adding
+IPv6 to the bridge can surprise hosts with existing IPv6 setup (e.g.
+`accept_dad` is disabled on the bridge by the script).
+
+## Sensors — `waydroid-sensord`
+
+If `waydroid-sensord` is installed, it is launched in the background at
+container start with the hwbinder device node:
+
+```
+waydroid-sensord /dev/hwbinder
+```
+
+(`hwbinder` is the configured binder node, the same one the container's
+Android services use.) Sensord is the host-side daemon that forwards the
+device's sensors to Android inside the container over the shared hwbinder,
+so apps get accelerometer/gyro/etc. data. At container stop, sensord is
+looked up with `pidof` and killed. On regular desktops there is no sensord
+binary and this step is a no-op.
+
+## NFC — the removed nfcd hacks
+
+Historically, `container_manager` stopped the host's `nfcd` daemon at
+container start and restarted it at stop (via Android init's `stop`/`start`
+commands, falling back to `systemctl`). The reason: on hosts that run
+Android's nfcd (Ubuntu Touch / Halium), the host and container NFC daemons
+would contend over the single NFC adapter, so the hack gave the container's
+nfcd exclusive access for the session.
+
+Those blocks were marked `#TODO: remove NFC hacks` and are now removed, so
+the host nfcd is left untouched and Android's nfcd inside the container
+manages the adapter on its own. Two consequences worth knowing:
+
+- The `enableNFC`/`enableBluetooth` binder callbacks in
+  `tools/services/hardware_manager.py` remain intentionally unimplemented
+  (see their docstrings): this codebase has no data plane between the
+  container's Android NFC stack and the host's NFC hardware, so toggling
+  the host nfcd from the callback could not make NFC work in Android and
+  would risk recreating the very contention the hacks prevented.
+- On hosts that do run nfcd, NFC hardware access is no longer arbitrated
+  between host and container — if both daemons are active, they may
+  contend. If you observe that, the fix belongs in a session-scoped or
+  hardware-adaptation layer, not in the removed stop/start hack.

--- a/docs/makefile-walkthrough.md
+++ b/docs/makefile-walkthrough.md
@@ -1,0 +1,102 @@
+# Makefile walkthrough
+
+Waydroid is pure Python plus shell scripts — there is nothing to compile, so
+the Makefile is install plumbing only. `make build` is a stub; the real work
+happens in `make install` (and `make install_apparmor`), with `make check`
+for local validation that mirrors CI.
+
+## Variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `PREFIX` | `/usr` | Install prefix; nearly every other path derives from it. |
+| `SYSCONFDIR` | `/etc` | System config dir; used only for xdg menus and AppArmor. |
+| `USE_SYSTEMD` | `1` | Install `systemd/waydroid-container.service`. |
+| `USE_DBUS_ACTIVATION` | `1` | Install the D-Bus `system-services` activation file. |
+| `USE_NFTABLES` | `0` | Flip `data/scripts/waydroid-net.sh` to nftables at install time. |
+| `PYTHON` | `python3` | Interpreter used by `make check` (override for a venv). |
+| `DESTDIR` | *(unset)* | Packaging prefix; honored but not declared. |
+
+The `?=` variables can be overridden per invocation, e.g.:
+
+```sh
+make install USE_SYSTEMD=0
+make check PYTHON=/path/to/venv/bin/python
+```
+
+## Derived paths
+
+`WAYDROID_DIR = $(PREFIX)/lib/waydroid`, `BIN_DIR = $(PREFIX)/bin`,
+`APPS_DIR = $(PREFIX)/share/applications`, `APPS_DIRECTORY_DIR`,
+`APPS_MENU_DIR = $(SYSCONFDIR)/xdg/menus/applications-merged`,
+`METAINFO_DIR`, `ICONS_DIR`, `SYSD_DIR = $(PREFIX)/lib/systemd/system`,
+`DBUS_DIR = $(PREFIX)/share/dbus-1`, `POLKIT_DIR = $(PREFIX)/share/polkit-1`,
+`APPARMOR_DIR = $(SYSCONFDIR)/apparmor.d`.
+
+Each has a `INSTALL_* = $(DESTDIR)$(...)` counterpart, which is what makes
+`make install DESTDIR=...` work for packaging.
+
+## Targets
+
+### `make build`
+
+Placeholder: prints "Nothing to build, run 'make install' to copy the files!".
+
+### `make check`
+
+Runs `ruff check .` followed by `$(PYTHON) -m pytest -q`. This mirrors the
+`lint` and `test` jobs in `.github/workflows/check.yaml` (which additionally
+run CodeQL). Use `PYTHON=...` to point at a specific interpreter.
+
+### `make install`
+
+Runs in this order:
+
+1. **Create directories** — the full install tree (lib/waydroid, bin, dbus
+   system.d, polkit actions, applications, xdg menu/directory dirs, metainfo,
+   hicolor 512x512 icons).
+2. **Copy the source tree** — `cp -a data tools waydroid.py` into
+   `$(PREFIX)/lib/waydroid`.
+3. **Create the `waydroid` binary** — a *relative* symlink
+   (`bin/waydroid -> ../lib/waydroid/waydroid.py`, computed with
+   `realpath --relative-to`), so it survives `DESTDIR` relocation.
+4. **Move data files to their destinations** — AppIcon.png to the hicolor
+   icon theme, `*.desktop` to applications, `*.menu`/`*.directory` to the xdg
+   dirs, `*.metainfo.xml` to metainfo. These are *moved*, so after install
+   the copy of `data/` under `lib/waydroid` no longer contains them.
+5. **D-Bus + polkit** — `id.waydro.Container.conf` to `system.d` and
+   `id.waydro.Container.policy` to polkit actions.
+6. **Optional: D-Bus activation** (`USE_DBUS_ACTIVATION=1`) — renders
+   `id.waydro.Container.service` into `system-services`, substituting the
+   `@BINDIR@` placeholder with `$(BIN_DIR)`.
+7. **Optional: systemd unit** (`USE_SYSTEMD=1`) — renders
+   `waydroid-container.service` into the systemd system dir with the same
+   `@BINDIR@` substitution.
+8. **Optional: nftables** (`USE_NFTABLES=1`) — `sed` flips `LXC_USE_NFT`
+   from `false` to `true` **in the installed copy** of
+   `data/scripts/waydroid-net.sh`. The source tree is left untouched, so the
+   flag is only visible in the installed file.
+
+### `make install_apparmor`
+
+Installs the `adbd`, `android_app`, and `lxc-waydroid` profiles plus empty
+`local/` stubs, then reloads them with `apparmor_parser -r -T -W`. The reload
+is skipped when `DESTDIR` is set (packaging) or when AppArmor is not active
+on the host.
+
+## Quirks and gotchas
+
+- **No `uninstall`, `clean`, or `dist` targets.**
+- **Activation paths follow `PREFIX`**: `systemd/waydroid-container.service`
+  and `dbus/id.waydro.Container.service` are templates containing the
+  `@BINDIR@` placeholder, substituted with `$(BIN_DIR)` at install time (see
+  steps 6–7 above). The checked-in files are therefore *not* valid unit files
+  as-is — they resolve only after install (or via the same `sed`).
+- **The nftables `sed` edits the installed file only** — inspecting
+  `data/scripts/waydroid-net.sh` in the source tree won't show `LXC_USE_NFT=true`.
+- **`mv` semantics**: after `make install`, the installed `data/` directory
+  is missing the desktop/menu/metainfo files — that is by design; the
+  installed tree is a deployment artifact, not a copy of the source tree.
+- **AppArmor reload is packaging-safe** — the `apparmor_parser` invocation
+  only runs when `DESTDIR` is empty and AppArmor is enabled, so distro builds
+  never touch the host's loaded profiles.

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -1,0 +1,65 @@
+# Upstreaming plan
+
+This repo (a Waydroid fork) carries a batch of work on top of upstream
+`waydroid/waydroid` 1.6.3. This page triages what is worth proposing
+upstream, what should stay fork-specific, and the housekeeping needed
+before opening PRs.
+
+## The batch
+
+Recent commits (newest first):
+
+| Commit | Summary | Verdict |
+| --- | --- | --- |
+| `6827900` | ServiceRunner + DISPATCH table, harden set_permissions, README host prerequisites | **Split before upstreaming**: ServiceRunner and the dispatch refactor are upstream-worthy; the README additions are fine as an upstream PR too, but the commit is too big — split into (1) ServiceRunner, (2) dispatch table + derived guards, (3) set_permissions modes. |
+| `bc83cda` | `get_session_defaults()` factory, fix upgrade images path | **Upstream-worthy** as-is (the images_path `AttributeError` fix is a real bug). |
+| `20305f1` | Networking/sensors helpers, `make check` | **Upstream-worthy**; `make check` mirrors their CI and should be easy to accept. |
+| `fdd0b5d` | `-l/--log` fix, binder config fallbacks, sensord multi-pid kill | **Upstream-worthy** — all three are genuine bug fixes. |
+| `94173b9` | Binder settings transaction fix, container control hardening, tests, docs | **Split**: the TRANSACTION_settingsGetInt fix and the Stop/Freeze/Unfreeze session-owner validation are upstream-worthy; the schedtune probe and cgroup-lite helpers may overlap with upstream's own schedtune handling — check first. |
+
+## Fork-specific (do NOT send upstream as-is)
+
+- **`docs/makefile-walkthrough.md`, `docs/TODO.md`, `docs/distro-packaging.md`** —
+  fork-internal documentation.
+- **`docs/host-integration.md` and the README sections about the schedtune
+  probe / ufw rules / binderfs** — upstream maintains its own README and
+  documentation site; port the *content* into an upstream PR rather than
+  the files.
+- **`debian/changelog` 1.6.4 entry** — rewritten for this fork's release;
+  upstream will write their own.
+- **Codebuff commit footer** (`🤖 Generated with Codebuff` /
+  `Co-Authored-By: Codebuff`) — strip when preparing upstream commits.
+
+## Housekeeping before opening PRs
+
+1. Rebase onto upstream `main` (this fork's history diverged around 1.6.3).
+2. Split `6827900` and `94173b9` along the lines above.
+3. Drop the Codebuff footer and keep upstream's commit-message style
+   (imperative, `area:` prefix).
+4. Verify the schedtune probe doesn't conflict with upstream's schedtune
+   handling (upstream historically unmounts schedtune; this fork keeps it
+   when nestable).
+5. Confirm the test suite dependencies: upstream CI would need
+   `pip install ruff pytest` (the `make check` target and
+   `.github/workflows/check.yaml` already assume this).
+
+## Drift risks to re-verify at PR time
+
+Current image status: the official OTA images are still Android 13
+(LineageOS 20), while community builds at LineageOS 22/23 (Android 15/16)
+exist (upstream issue #2229 tracks the official rebuild). The code paths
+below are verified against the API levels, not the images themselves:
+
+- **Protocol table** (`set_aidl_version` in `tools/helpers/protocol.py`):
+  pinned by tests for API 27–40, including Android 16 (API 36+) using
+  aidl6 for the service manager.
+- **Halium 15+ version detection** (`get_vendor_type` in
+  `tools/actions/initializer.py`): uses `ro.vndk.version` with a
+  `ro.vendor.build.version.sdk` fallback; hardened against non-numeric
+  props. Re-check the prop values on current Halium images.
+- **AIDL gralloc5 detection** (`make_base_props` in `tools/helpers/lxc.py`):
+  matches `android.hardware.graphics.allocator.IAllocator/default` on the
+  vendor binder — the standard for Android 15/16 vendor images. Re-check
+  against current LineageOS/Halium vendor images.
+- **`ro.vendor.arm.egl.*` prop forwarding**: needed for newer Mali devices;
+  confirm it doesn't leak unwanted host props into the container.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ select = [
 	"W",
 	"F",
 ]
-ignore = [
-	"E501", # Do not enforce line length limit for now.
-	"F401", # TODO: Remove this once unused imports are removed.
-	"F811", # TODO: Remove this once redefined variables are refactored.
-]
+ignore = []
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/systemd/waydroid-container.service
+++ b/systemd/waydroid-container.service
@@ -4,7 +4,7 @@ Description=Waydroid Container
 [Service]
 UMask=0022
 BusName=id.waydro.Container
-ExecStart=/usr/bin/waydroid container start
+ExecStart=@BINDIR@/waydroid container start
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pytest configuration.
+
+The waydroid ``tools`` package imports heavy runtime dependencies (dbus,
+PyGObject, gbinder) at module import time. The pure-logic helpers under test
+(arch, protocol, images, mount) don't use any of them, so we stub them out in
+``sys.modules`` to keep the test suite runnable in a minimal environment
+(e.g. CI without those native packages installed).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+HEAVY_DEPS = [
+    "dbus",
+    "dbus.exceptions",
+    "dbus.mainloop.glib",
+    "dbus.service",
+    "gbinder",
+    "gi",
+    "gi.repository",
+    "gi.repository.GLib",
+]
+
+
+class _StubModule(types.ModuleType):
+    """A module that answers any attribute access with a MagicMock."""
+
+    def __getattr__(self, attr):
+        return MagicMock()
+
+
+def _install_stub(name):
+    if name in sys.modules:
+        return
+    module = _StubModule(name)
+    sys.modules[name] = module
+    # Make dotted names importable (e.g. `import dbus.mainloop.glib`).
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = _StubModule(parent)
+
+
+for _name in HEAVY_DEPS:
+    _install_stub(_name)

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.arch."""
+
+import io
+import types
+
+import pytest
+
+import tools.helpers.arch as arch
+
+
+class FakeOpen:
+    """Context manager that fakes reading a file's content."""
+
+    def __init__(self, content):
+        self.content = content
+
+    def __call__(self, path, *args, **kwargs):
+        return io.StringIO(self.content)
+
+
+def patch_cpuinfo(monkeypatch, content):
+    monkeypatch.setattr("builtins.open", FakeOpen(content))
+
+
+def test_host_x86_64(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "x86_64")
+    patch_cpuinfo(monkeypatch, "ssse3 sse4_2")
+    assert arch.host() == "x86_64"
+
+
+def test_host_x86_64_falls_back_to_x86_without_sse4_2(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "x86_64")
+    patch_cpuinfo(monkeypatch, "ssse3")
+    assert arch.host() == "x86"
+
+
+def test_host_x86_64_requires_ssse3(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "x86_64")
+    patch_cpuinfo(monkeypatch, "no sse2, no sse3 here")
+    with pytest.raises(ValueError):
+        arch.host()
+
+
+def test_host_i686(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "i686")
+    patch_cpuinfo(monkeypatch, "ssse3")
+    assert arch.host() == "x86"
+
+
+def test_host_armv7l(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "armv7l")
+    assert arch.host() == "arm"
+
+
+def test_host_armv8l(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "armv8l")
+    assert arch.host() == "arm"
+
+
+def test_host_aarch64(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(arch.platform, "architecture", lambda: ("64bit", "ELF"))
+    monkeypatch.setattr(arch, "is_32bit_capable", lambda: True)
+    assert arch.host() == "arm64"
+
+
+def test_host_aarch64_32bit_userspace(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(arch.platform, "architecture", lambda: ("32bit", "ELF"))
+    assert arch.host() == "arm"
+
+
+def test_host_aarch64_without_aarch32(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(arch.platform, "architecture", lambda: ("64bit", "ELF"))
+    monkeypatch.setattr(arch, "is_32bit_capable", lambda: False)
+    assert arch.host() == "arm64_only"
+
+
+def test_host_unsupported(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "riscv64")
+    with pytest.raises(ValueError):
+        arch.host()
+
+
+def test_is_32bit_capable_true(monkeypatch):
+    calls = []
+
+    def fake_personality(arg):
+        calls.append(arg)
+        return 0  # previous persona (success)
+
+    class FakeLib:
+        personality = staticmethod(fake_personality)
+
+    class FakeCDLL:
+        def __init__(self, *args, **kwargs):
+            self.personality = FakeLib.personality
+
+    fake_ctypes = types.SimpleNamespace(CDLL=FakeCDLL, c_int=int, c_ulong=int)
+    monkeypatch.setattr(arch, "ctypes", fake_ctypes)
+    assert arch.is_32bit_capable() is True
+    # PER_LINUX32 probe, then restore of the previous persona
+    assert calls == [0x0008, 0]
+
+
+def test_is_32bit_capable_false(monkeypatch):
+    def fake_personality(arg):
+        return -1  # personality() failed
+
+    class FakeLib:
+        personality = staticmethod(fake_personality)
+
+    class FakeCDLL:
+        def __init__(self, *args, **kwargs):
+            self.personality = FakeLib.personality
+
+    fake_ctypes = types.SimpleNamespace(CDLL=FakeCDLL, c_int=int, c_ulong=int)
+    monkeypatch.setattr(arch, "ctypes", fake_ctypes)
+    assert arch.is_32bit_capable() is False

--- a/tests/test_arm_translation.py
+++ b/tests/test_arm_translation.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the ARM64 translation layer (libndk_translation)."""
+
+import types
+
+import pytest
+
+import tools.config
+from tools.helpers import arm_translation
+import tools.actions.arm_translation as action
+
+
+def _install_files(base, required=True):
+    (base / "system/lib64/ndk_translation").mkdir(parents=True)
+    for rel in arm_translation.REQUIRED:
+        (base / rel).touch()
+    if not required:
+        (base / "system/lib64/libndk_translation.so").unlink()
+
+
+def test_not_installed_when_dir_missing(monkeypatch):
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        "/nonexistent/arm-translation")
+    assert not arm_translation.is_installed()
+
+
+def test_installed_when_required_files_present(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+    assert arm_translation.is_installed()
+
+
+def test_mount_entries_only_existing(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    (base / "system/lib64").mkdir(parents=True)
+    (base / "system/lib64/libndk_translation.so").touch()
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+
+    entries = arm_translation.mount_entries()
+
+    assert entries[0] == (str(base / "system/lib64/libndk_translation.so"),
+                          "system/lib64/libndk_translation.so", "file")
+    # Missing dir entries are skipped
+    assert all(e[1] != "system/lib64/ndk_translation" for e in entries)
+
+
+def _patch_install_env(monkeypatch, tmp_path, cfg=None):
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        str(tmp_path / "arm-translation"))
+    monkeypatch.setattr(action.helpers.arch, "host", lambda: "x86_64")
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    monkeypatch.setattr(action.helpers.lxc, "make_base_props", lambda args: None)
+    if cfg is None:
+        cfg = {"waydroid": {"arch": "x86_64", "images_path": "/x",
+                            "vendor_type": "MAINLINE", "system_ota": "s",
+                            "vendor_ota": "v"}}
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    return types.SimpleNamespace(source=None, archive=None, url=None)
+
+
+def test_install_from_source_dir(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _install_files(source)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    action.install(args)
+
+    assert arm_translation.is_installed()
+    assert (tmp_path / "arm-translation/system/lib64/ndk_translation"
+            / "libarm64.so").exists()
+
+
+def test_install_rejects_missing_layout(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _install_files(source, required=False)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+    # Nothing must remain installed
+    assert not arm_translation.is_installed()
+
+
+def test_install_refuses_on_arm64_host(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _install_files(source)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+    monkeypatch.setattr(action.helpers.arch, "host", lambda: "arm64")
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+
+def test_install_requires_a_source(monkeypatch, tmp_path):
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+
+def test_uninstall_removes_installed_layer(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    action.uninstall(args)
+
+    assert not arm_translation.is_installed()
+    assert not base.exists()
+
+
+def test_uninstall_when_not_installed_is_quiet(monkeypatch, tmp_path):
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    action.uninstall(args)  # must not raise
+
+
+def test_status_reports_installed(capsys, monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+
+    action.status(None)
+
+    out = capsys.readouterr().out
+    assert "INSTALLED" in out
+    assert "libndk_translation.so" in out
+
+
+def test_status_reports_not_installed(capsys, monkeypatch):
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        "/nonexistent/arm-translation")
+
+    action.status(None)
+
+    out = capsys.readouterr().out
+    assert "NOT INSTALLED" in out

--- a/tests/test_arm_translation.py
+++ b/tests/test_arm_translation.py
@@ -11,9 +11,15 @@ import tools.actions.arm_translation as action
 
 
 def _install_files(base, required=True):
-    (base / "system/lib64/ndk_translation").mkdir(parents=True)
+    """Create the real prebuilt layout under base (a /system tree)."""
+    (base / "system/lib64/arm64").mkdir(parents=True)
+    (base / "system/lib/arm").mkdir(parents=True)
+    (base / "system/etc/init").mkdir(parents=True)
+    (base / "system/etc/binfmt_misc").mkdir(parents=True)
     for rel in arm_translation.REQUIRED:
         (base / rel).touch()
+    (base / "system/lib64/libndk_translation_proxy_libc.so").touch()
+    (base / "system/lib/libndk_translation_proxy_libc.so").touch()
     if not required:
         (base / "system/lib64/libndk_translation.so").unlink()
 
@@ -42,7 +48,49 @@ def test_mount_entries_only_existing(monkeypatch, tmp_path):
     assert entries[0] == (str(base / "system/lib64/libndk_translation.so"),
                           "system/lib64/libndk_translation.so", "file")
     # Missing dir entries are skipped
-    assert all(e[1] != "system/lib64/ndk_translation" for e in entries)
+    assert all(e[1] != "system/lib64/arm64" for e in entries)
+    assert all(e[1] != "system/etc/init/ndk_translation.rc" for e in entries)
+
+
+def test_mount_entries_include_proxy_libs(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+
+    entries = arm_translation.mount_entries()
+    container_paths = [e[1] for e in entries]
+
+    assert ("system/lib64/arm64", "dir") in [
+        (e[1], e[2]) for e in entries]
+    assert "system/lib64/libndk_translation_proxy_libc.so" in container_paths
+    assert "system/lib/libndk_translation_proxy_libc.so" in container_paths
+    assert "system/etc/init/ndk_translation.rc" in container_paths
+
+
+def test_sync_to_overlay_copies_artifacts(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    overlay = tmp_path / "overlay"
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+    monkeypatch.setitem(tools.config.defaults, "overlay", str(overlay))
+
+    arm_translation.sync_to_overlay()
+
+    assert (overlay / "system/lib64/libndk_translation.so").exists()
+    assert (overlay / "system/lib64/arm64/libc.so").exists()
+    assert (overlay / "system/etc/init/ndk_translation.rc").exists()
+    assert (overlay / "system/lib64/libndk_translation_proxy_libc.so").exists()
+
+
+def test_sync_to_overlay_noop_when_not_installed(monkeypatch, tmp_path):
+    overlay = tmp_path / "overlay"
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        "/nonexistent/arm-translation")
+    monkeypatch.setitem(tools.config.defaults, "overlay", str(overlay))
+
+    arm_translation.sync_to_overlay()  # must not raise
+
+    assert not (overlay / "system").exists()
 
 
 def _patch_install_env(monkeypatch, tmp_path, cfg=None):
@@ -68,8 +116,22 @@ def test_install_from_source_dir(monkeypatch, tmp_path):
     action.install(args)
 
     assert arm_translation.is_installed()
-    assert (tmp_path / "arm-translation/system/lib64/ndk_translation"
-            / "libarm64.so").exists()
+    assert (tmp_path / "arm-translation/system/lib64/arm64/libc.so").exists()
+
+
+def test_install_from_source_nested_prebuilts_dir(monkeypatch, tmp_path):
+    # The community archive nests artifacts under prebuilts/ inside a
+    # repo-name directory; install must find and use that tree.
+    source = tmp_path / "source"
+    nested = source / "vendor_google_proprietary_ndk_translation-prebuilt-x" \
+                    / "prebuilts"
+    _install_files(nested)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    action.install(args)
+
+    assert arm_translation.is_installed()
 
 
 def test_install_rejects_missing_layout(monkeypatch, tmp_path):
@@ -85,6 +147,17 @@ def test_install_rejects_missing_layout(monkeypatch, tmp_path):
     assert not arm_translation.is_installed()
 
 
+def test_install_rejects_non_system_tree(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "random.txt").touch()
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+
 def test_install_refuses_on_arm64_host(monkeypatch, tmp_path):
     source = tmp_path / "source"
     _install_files(source)
@@ -96,11 +169,70 @@ def test_install_refuses_on_arm64_host(monkeypatch, tmp_path):
         action.install(args)
 
 
-def test_install_requires_a_source(monkeypatch, tmp_path):
+def test_install_default_url_without_source(monkeypatch, tmp_path):
+    """No --source/--archive/--url: fetch the known-good default prebuilt."""
     args = _patch_install_env(monkeypatch, tmp_path)
+
+    archive = tmp_path / "default.zip"
+    # Build a tiny zip with the prebuilt layout so extraction + validation
+    # succeed without network.
+    import zipfile
+    with zipfile.ZipFile(archive, "w") as zf:
+        for rel in arm_translation.REQUIRED:
+            zf.writestr("repo/prebuilts/" + rel, "x")
+        zf.writestr("repo/prebuilts/system/lib64/libndk_translation_proxy_libc.so", "x")
+        zf.writestr("repo/prebuilts/system/lib/libndk_translation_proxy_libc.so", "x")
+        zf.writestr("repo/README.md", "x")
+
+    monkeypatch.setattr(action.helpers.http, "download",
+                        lambda *a, **k: str(archive))
+    monkeypatch.setattr(action, "_md5",
+                        lambda path: arm_translation.DEFAULT_ARCHIVE_MD5)
+
+    action.install(args)
+
+    assert arm_translation.is_installed()
+
+
+def test_extract_archive_preserves_zip_exec_bits(monkeypatch, tmp_path):
+    """zipfile drops unix modes; extraction must restore exec bits so
+    binfmt_misc can run the ARM translator binaries."""
+    import stat
+    import zipfile
+    archive = tmp_path / "x.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        info = zipfile.ZipInfo("prebuilts/bin/arm64/linker64")
+        info.external_attr = (0o755 << 16)
+        zf.writestr(info, b"\x7fELF")
+        info2 = zipfile.ZipInfo("prebuilts/etc/ndk_translation.rc")
+        info2.external_attr = (0o644 << 16)
+        zf.writestr(info2, b"on early-init")
+
+    dest = tmp_path / "out"
+    dest.mkdir()
+    action._extract_archive(str(archive), str(dest))
+
+    linker = dest / "prebuilts/bin/arm64/linker64"
+    rc = dest / "prebuilts/etc/ndk_translation.rc"
+    assert linker.stat().st_mode & stat.S_IXUSR
+    assert not rc.stat().st_mode & stat.S_IXUSR
+
+
+def test_install_default_url_checks_integrity(monkeypatch, tmp_path):
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    archive = tmp_path / "default.zip"
+    archive.write_bytes(b"not a real archive")
+
+    monkeypatch.setattr(action.helpers.http, "download",
+                        lambda *a, **k: str(archive))
+    monkeypatch.setattr(action, "_md5",
+                        lambda path: "00000000000000000000000000000000")
 
     with pytest.raises(RuntimeError):
         action.install(args)
+
+    assert not arm_translation.is_installed()
 
 
 def test_uninstall_removes_installed_layer(monkeypatch, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.config.get_session_defaults()."""
+
+import types
+
+import tools.config
+
+
+def _patch_user(monkeypatch, name="u", uid=1000, gid=1000):
+    monkeypatch.setattr(tools.config.pwd, "getpwuid",
+                        lambda real_uid: types.SimpleNamespace(pw_name=name))
+    monkeypatch.setattr(tools.config.os, "getuid", lambda: uid)
+    monkeypatch.setattr(tools.config.os, "getgid", lambda: gid)
+    monkeypatch.setenv("HOME", "/home/" + name)
+
+
+def test_get_session_defaults_env(monkeypatch):
+    _patch_user(monkeypatch)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    monkeypatch.setenv("PULSE_RUNTIME_PATH", "/run/user/1000/pulse")
+    monkeypatch.setenv("XDG_DATA_HOME", "/home/u/.local/share")
+
+    session = tools.config.get_session_defaults()
+
+    assert session["wayland_display"] == "wayland-1"
+    assert session["xdg_runtime_dir"] == "/run/user/1000"
+    assert session["pulse_runtime_path"] == "/run/user/1000/pulse"
+    assert session["user_name"] == "u"
+    assert session["user_id"] == "1000"
+    assert session["group_id"] == "1000"
+    assert session["waydroid_user_state"] == "/home/u/.local/share/waydroid"
+    assert session["waydroid_data"] == "/home/u/.local/share/waydroid/data"
+
+
+def test_get_session_defaults_unset_env(monkeypatch):
+    # os.environ.get() yields the literal string "None" when unset;
+    # session_manager treats that as "not set" (see its WAYLAND_DISPLAY
+    # handling), so pin that behavior here.
+    _patch_user(monkeypatch)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    session = tools.config.get_session_defaults()
+
+    assert session["wayland_display"] == "None"
+    assert session["xdg_runtime_dir"] == "None"
+    assert session["pulse_runtime_path"] == "None/pulse"
+    assert session["waydroid_user_state"] == "/home/u/.local/share/waydroid"
+
+
+def test_get_session_defaults_pulse_falls_back_to_runtime_dir(monkeypatch):
+    _patch_user(monkeypatch)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    session = tools.config.get_session_defaults()
+
+    assert session["pulse_runtime_path"] == "/run/user/1000/pulse"

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import os
+
+import tools.actions.container_manager as container_manager
+
+
+class _Args:
+    pass
+
+
+def _fake_user(calls):
+    def fake_user(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 0  # successful command exit code
+    return fake_user
+
+
+def _failing_makedirs(path):
+    # Simulate a kernel without the nesting patch: creating the first probe
+    # level succeeds but the nested one fails (EPERM).
+    os.mkdir(os.path.dirname(path))
+    raise OSError("simulated EPERM")
+
+
+def test_start_networking_runs_script(monkeypatch):
+    monkeypatch.setattr(container_manager, "WAYDROID_NET_SCRIPT", "/x/waydroid-net.sh")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_networking(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["/x/waydroid-net.sh", "start"]
+    # No check kwarg: failures must raise so do_start aborts
+    assert "check" not in calls[0][1]
+
+
+def test_stop_networking_best_effort(monkeypatch):
+    monkeypatch.setattr(container_manager, "WAYDROID_NET_SCRIPT", "/x/waydroid-net.sh")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.stop_networking(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["/x/waydroid-net.sh", "stop"]
+    assert calls[0][1]["check"] is False
+
+
+def test_start_sensors_when_installed(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord" if name == "waydroid-sensord" else None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+    args = _Args()
+    args.HWBINDER_DRIVER = "hwbinder"
+
+    container_manager.start_sensors(args)
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["waydroid-sensord", "/dev/hwbinder"]
+    assert calls[0][1]["output"] == "background"
+
+
+def test_start_sensors_when_missing(monkeypatch):
+    monkeypatch.setattr(container_manager, "which", lambda name: None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_sensors(_Args())
+
+    assert calls == []
+
+
+def _stop_sensors_fake(calls, pidof_output):
+    def fake_user(*args, **kwargs):
+        calls.append((args, kwargs))
+        if args[1][0] == "pidof":
+            return pidof_output
+        return 0
+    return fake_user
+
+
+def test_stop_sensors_none_running(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _stop_sensors_fake(calls, ""))
+
+    container_manager.stop_sensors(_Args())
+
+    assert len(calls) == 1  # only the pidof probe, no kill
+    assert calls[0][0][1] == ["pidof", "waydroid-sensord"]
+
+
+def test_stop_sensors_single_pid(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _stop_sensors_fake(calls, "1234"))
+
+    container_manager.stop_sensors(_Args())
+
+    assert calls[1][0][1] == ["kill", "-9", "1234"]
+
+
+def test_stop_sensors_multiple_pids(monkeypatch):
+    # A stale daemon from a crashed session results in multiple pids; all
+    # of them must be killed, not passed as one invalid string.
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _stop_sensors_fake(calls, "1234 5678"))
+
+    container_manager.stop_sensors(_Args())
+
+    assert calls[1][0][1] == ["kill", "-9", "1234", "5678"]
+
+
+def test_set_permissions_system_and_app_modes(monkeypatch, tmp_path):
+    system = tmp_path / "sysnode"
+    app = tmp_path / "appnode"
+    system.touch()
+    app.touch()
+    monkeypatch.setattr(container_manager, "SYSTEM_DEVICES", [str(system)])
+    monkeypatch.setattr(container_manager, "APP_DEVICES", [str(app)])
+    monkeypatch.setattr("glob.glob", lambda pattern: [])
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+    session = {"user_id": "1000", "group_id": "1000"}
+
+    container_manager.set_permissions(_Args(), session=session)
+
+    chmods = [c[0][1] for c in calls if c[0][1][0] == "chmod"]
+    chowns = [c[0][1] for c in calls if c[0][1][0] == "chown"]
+    assert ["chmod", "660", "-R", str(system)] in chmods
+    assert ["chmod", "666", "-R", str(app)] in chmods
+    assert ["chown", "1000:1000", "-R", str(system)] in chowns
+    assert ["chown", "1000:1000", "-R", str(app)] in chowns
+
+
+def test_set_permissions_without_session_skips_chown(monkeypatch, tmp_path):
+    node = tmp_path / "node"
+    node.touch()
+    monkeypatch.setattr(container_manager, "SYSTEM_DEVICES", [str(node)])
+    monkeypatch.setattr(container_manager, "APP_DEVICES", [])
+    monkeypatch.setattr("glob.glob", lambda pattern: [])
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.set_permissions(_Args())
+
+    assert all(c[0][1][0] != "chown" for c in calls)
+    assert ["chmod", "660", "-R", str(node)] in [c[0][1] for c in calls]
+
+
+def test_set_permissions_explicit_list_uses_mode(monkeypatch, tmp_path):
+    node = tmp_path / "node"
+    node.touch()
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.set_permissions(_Args(), perm_list=[str(node)], mode="660")
+
+    assert [c[0][1] for c in calls] == [["chmod", "660", "-R", str(node)]]
+
+
+def test_cgroup_lite_started_when_init_available(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/start" if name == "start" else None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_cgroup_lite_if_available(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["start", "cgroup-lite"]
+    assert calls[0][1]["check"] is False
+
+
+def test_cgroup_lite_skipped_when_init_unavailable(monkeypatch):
+    monkeypatch.setattr(container_manager, "which", lambda name: None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_cgroup_lite_if_available(_Args())
+
+    assert calls == []
+
+
+def test_schedtune_not_mounted_is_noop(monkeypatch):
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", "/nonexistent/schedtune")
+    monkeypatch.setattr(os.path, "ismount", lambda path: False)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert calls == []
+
+
+def test_schedtune_nestable_is_kept(monkeypatch, tmp_path):
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert calls == []
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))
+
+
+def test_schedtune_not_nestable_is_unmounted(monkeypatch, tmp_path):
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+    monkeypatch.setattr(os, "makedirs", _failing_makedirs)
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["umount", "-l", schedtune]
+    # Partially created probe must still be cleaned up
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))
+
+
+def test_schedtune_umount_failure_is_logged(monkeypatch, tmp_path, caplog):
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    monkeypatch.setattr(os, "makedirs", _failing_makedirs)
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: 32)
+    monkeypatch.setattr(container_manager.time, "sleep", lambda s: None)
+
+    with caplog.at_level("WARNING"):
+        container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert any("Failed to unmount" in record.message for record in caplog.records)
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))
+
+
+def test_schedtune_umount_retried_then_succeeds(monkeypatch, tmp_path):
+    # The lazy unmount is retried: a busy hierarchy that frees up on the
+    # second attempt must not end up in a warning.
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    monkeypatch.setattr(os, "makedirs", _failing_makedirs)
+    monkeypatch.setattr(container_manager.time, "sleep", lambda s: None)
+    attempts = []
+
+    def flaky_umount(*args, **kwargs):
+        attempts.append(args)
+        return 1 if len(attempts) == 1 else 0
+
+    monkeypatch.setattr("tools.helpers.run.user", flaky_umount)
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert len(attempts) == 2
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import re
+import sys
+
+import pytest
+
+import tools
+from tools import helpers
+
+# argparse renders subparser choices as {a,b,c} in help text
+_CHOICES_RE = re.compile(r"\{([a-z0-9,-]+)\}")
+
+
+def _choices(capsys, monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit):
+        helpers.arguments()
+    out = capsys.readouterr().out
+    match = _CHOICES_RE.search(out)
+    if not match:
+        return []
+    return [choice.strip() for choice in match.group(1).split(",")]
+
+
+def test_dispatch_covers_cli_surface(capsys, monkeypatch):
+    actions_list = _choices(capsys, monkeypatch, ["waydroid", "-h"])
+    assert actions_list, "could not parse action list from help"
+
+    for action in actions_list:
+        table = tools.DISPATCH.get(action)
+        assert table is not None, \
+            f"action {action!r} is missing from tools.DISPATCH"
+
+        subactions = _choices(capsys, monkeypatch, ["waydroid", action, "-h"])
+        if subactions:
+            for subaction in subactions:
+                assert subaction in table, \
+                    f"subaction {action} {subaction!r} is missing from tools.DISPATCH"
+        else:
+            assert None in table, \
+                f"action {action!r} has no subparsers but its table has no None handler"
+
+
+def test_dispatch_handlers_are_callable():
+    for action, table in tools.DISPATCH.items():
+        for subaction, handler in table.items():
+            assert callable(handler), \
+                f"handler for {action} {subaction!r} is not callable"
+
+
+def test_root_actions_have_handlers():
+    for action in tools.ROOT_ACTIONS:
+        assert action in tools.DISPATCH, \
+            f"root action {action!r} is missing from tools.DISPATCH"
+
+
+def test_dispatch_entries_declare_guard_flags():
+    # A new action must go through _entry() so it cannot silently skip the
+    # root or init guards in main().
+    for action, entry in tools.DISPATCH.items():
+        assert hasattr(entry, "need_root"), \
+            f"action {action!r} must declare its root flag via _entry()"
+        assert hasattr(entry, "allowed_uninitialized"), \
+            f"action {action!r} must declare its uninitialized flag via _entry()"
+
+
+def test_root_actions_derived_from_dispatch():
+    expected = frozenset(
+        action for action, entry in tools.DISPATCH.items()
+        if entry.need_root)
+    assert tools.ROOT_ACTIONS == expected
+
+
+def test_allowed_uninitialized_derived_from_dispatch():
+    expected = frozenset(
+        action for action, entry in tools.DISPATCH.items()
+        if entry.allowed_uninitialized)
+    assert tools.ALLOWED_UNINITIALIZED == expected

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from tools.helpers import drivers
+
+
+class _Args:
+    pass
+
+
+def test_loadBinderNodes_falls_back_when_config_missing_keys(tmp_path):
+    # Configs predating the binder keys (or partial/corrupt ones) must not
+    # crash the session service; fall back to the standard node names.
+    cfg_file = tmp_path / "waydroid.cfg"
+    cfg_file.write_text("[waydroid]\n")
+
+    args = _Args()
+    args.config = str(cfg_file)
+
+    drivers.loadBinderNodes(args)
+
+    assert args.BINDER_DRIVER == "binder"
+    assert args.VNDBINDER_DRIVER == "vndbinder"
+    assert args.HWBINDER_DRIVER == "hwbinder"
+    assert args.BINDER_PROTOCOL is None
+    assert args.SERVICE_MANAGER_PROTOCOL is None
+
+
+def test_loadBinderNodes_uses_config_values(tmp_path):
+    cfg_file = tmp_path / "waydroid.cfg"
+    cfg_file.write_text(
+        "[waydroid]\n"
+        "binder = anbox-binder\n"
+        "vndbinder = anbox-vndbinder\n"
+        "hwbinder = anbox-hwbinder\n"
+        "binder_protocol = 2\n"
+        "service_manager_protocol = 3\n")
+
+    args = _Args()
+    args.config = str(cfg_file)
+
+    drivers.loadBinderNodes(args)
+
+    assert args.BINDER_DRIVER == "anbox-binder"
+    assert args.VNDBINDER_DRIVER == "anbox-vndbinder"
+    assert args.HWBINDER_DRIVER == "anbox-hwbinder"
+    assert args.BINDER_PROTOCOL == "2"
+    assert args.SERVICE_MANAGER_PROTOCOL == "3"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.images."""
+
+import hashlib
+import io
+import json
+import types
+import zipfile
+
+import pytest
+
+import tools.config
+import tools.helpers.http
+import tools.helpers.images as images
+
+
+def make_args(tmp_path):
+    return types.SimpleNamespace(work=str(tmp_path))
+
+
+def test_sha256sum():
+    data = b"hello world"
+    f = io.BytesIO(data)
+    assert images.sha256sum(f) == hashlib.sha256(data).hexdigest()
+    # The file pointer must be rewound
+    assert f.tell() == 0
+
+
+def test_sha256sum_empty():
+    assert images.sha256sum(io.BytesIO(b"")) == hashlib.sha256(b"").hexdigest()
+
+
+def test_remove_overlay(monkeypatch, tmp_path):
+    overlay_rw = tmp_path / "overlay_rw"
+    overlay_work = tmp_path / "overlay_work"
+    overlay_rw.mkdir()
+    overlay_work.mkdir()
+    monkeypatch.setitem(tools.config.defaults, "overlay_rw", str(overlay_rw))
+    monkeypatch.setitem(tools.config.defaults, "overlay_work", str(overlay_work))
+    images.remove_overlay(make_args(tmp_path))
+    assert not overlay_rw.exists()
+    assert not overlay_work.exists()
+
+
+def test_remove_overlay_missing_dirs(monkeypatch, tmp_path):
+    monkeypatch.setitem(tools.config.defaults, "overlay_rw",
+                        str(tmp_path / "missing_rw"))
+    monkeypatch.setitem(tools.config.defaults, "overlay_work",
+                        str(tmp_path / "missing_work"))
+    # Should not raise
+    images.remove_overlay(make_args(tmp_path))
+
+
+def test_make_prop(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    with open(args.work + "/waydroid_base.prop", "w") as f:
+        f.write("ro.foo=bar\nro.baz=qux\n")
+    monkeypatch.setattr(images, "which", lambda name: None)
+
+    cfg = {
+        "user_name": "user",
+        "user_id": "1000",
+        "group_id": "1000",
+        "waydroid_data": "/home/user/.local/share/waydroid/data",
+        "background_start": "true",
+        "lcd_density": "0",
+    }
+    full_props_path = args.work + "/waydroid.prop"
+    images.make_prop(args, cfg, full_props_path)
+
+    with open(full_props_path) as f:
+        props = f.read()
+    assert "ro.foo=bar" in props
+    assert "waydroid.host.user=user" in props
+    assert "waydroid.host.uid=1000" in props
+    assert "waydroid.host.gid=1000" in props
+    assert "waydroid.host_data_path=/home/user/.local/share/waydroid/data" in props
+    assert "waydroid.background_start=true" in props
+    assert "waydroid.stub_sensors_hal=1" in props
+    assert "ro.sf.lcd_density=" not in props
+
+
+def test_make_prop_lcd_density(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    with open(args.work + "/waydroid_base.prop", "w") as f:
+        f.write("ro.foo=bar\n")
+    monkeypatch.setattr(images, "which", lambda name: None)
+
+    cfg = {
+        "user_name": "user",
+        "user_id": "1000",
+        "group_id": "1000",
+        "waydroid_data": "/home/user/data",
+        "background_start": "true",
+        "lcd_density": "320",
+    }
+    full_props_path = args.work + "/waydroid.prop"
+    images.make_prop(args, cfg, full_props_path)
+
+    with open(full_props_path) as f:
+        props = f.read()
+    assert "ro.sf.lcd_density=320" in props
+
+
+def test_make_prop_mnt_remap(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    with open(args.work + "/waydroid_base.prop", "w") as f:
+        f.write("ro.foo=bar\n")
+    monkeypatch.setattr(images, "which", lambda name: None)
+
+    cfg = {
+        "user_name": "user",
+        "user_id": "1000",
+        "group_id": "1000",
+        "waydroid_data": "/mnt/userdata",
+        "background_start": "true",
+        "lcd_density": "0",
+    }
+    full_props_path = args.work + "/waydroid.prop"
+    images.make_prop(args, cfg, full_props_path)
+
+    with open(full_props_path) as f:
+        props = f.read()
+    assert "waydroid.host_data_path=/mnt_extra/userdata" in props
+
+
+def test_make_prop_missing_base_prop(tmp_path):
+    args = make_args(tmp_path)
+    with pytest.raises(RuntimeError):
+        images.make_prop(args, {}, args.work + "/waydroid.prop")
+
+
+def test_make_prop_empty_base_prop(tmp_path):
+    args = make_args(tmp_path)
+    open(args.work + "/waydroid_base.prop", "w").close()
+    with pytest.raises(RuntimeError):
+        images.make_prop(args, {}, args.work + "/waydroid.prop")
+
+
+def test_validate(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    data = b"some image data"
+    chksum = hashlib.sha256(data).hexdigest()
+    # Channel response with matching id
+    monkeypatch.setattr(
+        tools.helpers.http, "retrieve",
+        lambda url: (200, json.dumps({"response": [{"id": chksum}]}).encode()))
+    monkeypatch.setattr(
+        tools.config, "load",
+        lambda args: {"waydroid": {"system_ota": "https://example.test/system"}})
+
+    image_path = tmp_path / "system.zip"
+    image_path.write_bytes(data)
+    with open(image_path, "rb") as f:
+        assert images.validate(args, "system_ota", f) is True
+
+
+def test_validate_no_match(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    data = b"some image data"
+    monkeypatch.setattr(
+        tools.helpers.http, "retrieve",
+        lambda url: (200, json.dumps({"response": [{"id": "other"}]}).encode()))
+    monkeypatch.setattr(
+        tools.config, "load",
+        lambda args: {"waydroid": {"system_ota": "https://example.test/system"}})
+
+    image_path = tmp_path / "system.zip"
+    image_path.write_bytes(data)
+    with open(image_path, "rb") as f:
+        assert images.validate(args, "system_ota", f) is False
+
+
+def test_validate_channel_error(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(tools.helpers.http, "retrieve",
+                        lambda url: (404, b""))
+    monkeypatch.setattr(
+        tools.config, "load",
+        lambda args: {"waydroid": {"system_ota": "https://example.test/system"}})
+
+    image_path = tmp_path / "system.zip"
+    image_path.write_bytes(b"data")
+    with open(image_path, "rb") as f:
+        assert images.validate(args, "system_ota", f) is False
+
+
+def test_replace(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    images_path = tmp_path / "images"
+    images_path.mkdir()
+
+    system_zip = tmp_path / "system.zip"
+    with zipfile.ZipFile(system_zip, "w") as zf:
+        zf.writestr("system.img", "fake image contents")
+
+    cfg = {
+        "waydroid": {
+            "images_path": str(images_path),
+            "system_datetime": "0",
+            "vendor_datetime": "0",
+        }
+    }
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+    monkeypatch.setattr(images, "validate", lambda *a, **kw: True)
+    monkeypatch.setattr(images, "remove_overlay", lambda args: None)
+
+    images.replace(args, str(system_zip), 1234, str(tmp_path / "missing.zip"), 0)
+
+    assert (images_path / "system.img").read_text() == "fake image contents"
+    assert cfg["waydroid"]["system_datetime"] == "1234"
+    assert not system_zip.exists()
+    assert saved == cfg
+
+
+def test_replace_invalid_image(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    images_path = tmp_path / "images"
+    images_path.mkdir()
+
+    system_zip = tmp_path / "system.zip"
+    system_zip.write_bytes(b"not a valid image")
+
+    cfg = {
+        "waydroid": {
+            "images_path": str(images_path),
+            "system_datetime": "0",
+            "vendor_datetime": "0",
+        }
+    }
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+    monkeypatch.setattr(images, "validate", lambda *a, **kw: False)
+    monkeypatch.setattr(images, "remove_overlay", lambda args: None)
+
+    images.replace(args, str(system_zip), 1234, str(tmp_path / "missing.zip"), 0)
+
+    assert not (images_path / "system.img").exists()
+    assert cfg["waydroid"]["system_datetime"] == "0"
+    assert not system_zip.exists()

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.actions.initializer.get_vendor_type."""
+
+import tools.actions.initializer as initializer
+
+
+def _props(values=None):
+    values = values or {}
+
+    def host_get(args, key):
+        return values.get(key, "")
+    return host_get
+
+
+def test_vendor_type_mainline_when_no_props(monkeypatch):
+    monkeypatch.setattr(initializer.helpers.props, "host_get", _props())
+    assert initializer.get_vendor_type(object()) == "MAINLINE"
+
+
+def test_vendor_type_from_vndk(monkeypatch):
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "30"}))
+    assert initializer.get_vendor_type(object()) == "HALIUM_11"
+
+
+def test_vendor_type_vndk_12l(monkeypatch):
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "32"}))
+    assert initializer.get_vendor_type(object()) == "HALIUM_12L"
+
+
+def test_vendor_type_from_vendor_api(monkeypatch):
+    # Halium 15+ images may not expose ro.vndk.version; fall back to the
+    # vendor API level.
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vendor.build.version.sdk": "35"}))
+    assert initializer.get_vendor_type(object()) == "HALIUM_15"
+
+
+def test_vendor_type_ignores_garbage_props(monkeypatch):
+    # Non-numeric props (e.g. "29.0") must not crash init.
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "29.0",
+                "ro.vendor.build.version.sdk": "garbage"}))
+    assert initializer.get_vendor_type(object()) == "MAINLINE"
+
+
+def test_vendor_type_low_vndk_stays_mainline(monkeypatch):
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "19"}))
+    assert initializer.get_vendor_type(object()) == "MAINLINE"

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _find_ruff():
+    """Locate ruff on PATH, or next to the running interpreter (venvs)."""
+    found = shutil.which("ruff")
+    if found:
+        return found
+    # Note: do not resolve sys.executable here - venv pythons are symlinks
+    # to the base interpreter, so resolving would escape the venv's bin dir.
+    candidate = Path(sys.executable).parent / "ruff"
+    if candidate.is_file():
+        return str(candidate)
+    return None
+
+
+def _lint_ignore():
+    with open(ROOT / "pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+    return data["tool"]["ruff"]["lint"]["ignore"]
+
+
+def test_f401_f811_not_disabled_in_pyproject():
+    """
+    F401 (unused imports) and F811 (redefinitions) must stay enabled.
+
+    They were previously hidden behind a TODO in the pyproject.toml ignore
+    list; that cleanup is done, so this test fails if they are disabled
+    again, either directly or through a prefix (e.g. "F" or "F4") that
+    covers them.
+    """
+    for entry in _lint_ignore():
+        assert not ("F401".startswith(entry) or "F811".startswith(entry)), (
+            f"F401/F811 must not be disabled via ignore entry {entry!r} in pyproject.toml"
+        )
+
+
+def test_ruff_f401_f811_clean():
+    """
+    Run ruff restricted to F401/F811 and fail on any violation.
+
+    The CI lint job already runs the full `ruff check .`; this test makes
+    the two rules explicit and works locally too. It is skipped when ruff
+    is not installed (e.g. in the CI test job, which only installs pytest).
+    """
+    ruff = _find_ruff()
+    if ruff is None:
+        pytest.skip("ruff not installed")
+
+    result = subprocess.run(
+        [ruff, "check", "--select", "F401,F811", "."],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "ruff reported F401/F811 violations:\n" + result.stdout + result.stderr
+    )

--- a/tests/test_lxc_config.py
+++ b/tests/test_lxc_config.py
@@ -142,6 +142,77 @@ def test_session_config_arm_translation_entries(monkeypatch, tmp_path):
             "none bind,create=dir,optional 0 0") in content
 
 
+def test_make_base_props_advertises_arm_abis_when_translation_installed(
+        monkeypatch, tmp_path):
+    """With libndk_translation installed, the base props must advertise the
+    emulated ARM ABIs so the Play delivery check and local PackageManager
+    accept ARM-only APKs."""
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(
+        work=str(work),
+        vendor_type="MAINLINE",
+        images_path="/usr/share/waydroid-extra/images",
+        system_ota="None",
+        vendor_ota="None",
+    )
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr("tools.helpers.props.host_get", lambda *a, **k: "")
+    monkeypatch.setattr("tools.helpers.props.host_list", lambda *a, **k: {})
+    monkeypatch.setattr("tools.helpers.gpu.getDriNode",
+                        lambda args: (None, ""))
+    monkeypatch.setattr("tools.helpers.gpu.getVulkanDriver",
+                        lambda *a, **k: None)
+    monkeypatch.setattr("tools.helpers.arm_translation.is_installed",
+                        lambda: True)
+    monkeypatch.setattr("tools.config.load",
+                        lambda args: {"properties": {}})
+
+    lxc.make_base_props(args)
+
+    props = (work / "waydroid_base.prop").read_text().splitlines()
+    assert "ro.dalvik.vm.native.bridge=libndk_translation.so" in props
+    assert ("ro.product.cpu.abilist=x86_64,x86,arm64-v8a,"
+            "armeabi-v7a,armeabi") in props
+    assert "ro.product.cpu.abilist64=x86_64,arm64-v8a" in props
+    assert "ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi" in props
+    assert "ro.product.cpu.abi=x86_64" in props
+
+
+def test_make_base_props_keeps_x86_abis_without_translation(
+        monkeypatch, tmp_path):
+    """Without the translation layer, the image's x86-only ABI list must be
+    left untouched (no ARM ABIs advertised)."""
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(
+        work=str(work),
+        vendor_type="MAINLINE",
+        images_path="/usr/share/waydroid-extra/images",
+        system_ota="None",
+        vendor_ota="None",
+    )
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr("tools.helpers.props.host_get", lambda *a, **k: "")
+    monkeypatch.setattr("tools.helpers.props.host_list", lambda *a, **k: {})
+    monkeypatch.setattr("tools.helpers.gpu.getDriNode",
+                        lambda args: (None, ""))
+    monkeypatch.setattr("tools.helpers.gpu.getVulkanDriver",
+                        lambda *a, **k: None)
+    monkeypatch.setattr("tools.helpers.arm_translation.is_installed",
+                        lambda: False)
+    monkeypatch.setattr("tools.config.load",
+                        lambda args: {"properties": {}})
+
+    lxc.make_base_props(args)
+
+    props = (work / "waydroid_base.prop").read_text().splitlines()
+    assert "ro.dalvik.vm.native.bridge=libndk_translation.so" not in props
+    assert not any(p.startswith("ro.product.cpu.abilist") for p in props)
+
+
 def test_session_config_rejects_newline_in_mount_path(monkeypatch, tmp_path):
     xdg = tmp_path / "xdg"
     xdg.mkdir()

--- a/tests/test_lxc_config.py
+++ b/tests/test_lxc_config.py
@@ -90,6 +90,8 @@ def test_session_config_binds_wayland_and_userdata(monkeypatch, tmp_path):
     monkeypatch.setitem(tools.config.defaults,
                         "container_pulse_runtime_path", "/run/xdg/pulse")
     monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    monkeypatch.setattr(tools.helpers.arm_translation, "sync_to_overlay",
+                        lambda: None)
 
     lxc.generate_session_lxc_config(args, session)
 
@@ -102,7 +104,7 @@ def test_session_config_binds_wayland_and_userdata(monkeypatch, tmp_path):
     assert ("lxc.mount.entry = {0} data none rbind 0 0".format(data)) in content
 
 
-def test_session_config_arm_translation_entries(monkeypatch, tmp_path):
+def test_session_config_arm_translation_syncs_overlay(monkeypatch, tmp_path):
     xdg = tmp_path / "xdg"
     xdg.mkdir()
     session = {
@@ -122,24 +124,14 @@ def test_session_config_arm_translation_entries(monkeypatch, tmp_path):
     monkeypatch.setitem(tools.config.defaults,
                         "container_pulse_runtime_path", "/run/xdg/pulse")
     monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    sync_called = []
     monkeypatch.setattr(
-        tools.helpers.arm_translation, "mount_entries",
-        lambda: [("/var/lib/waydroid/arm-translation/system/lib64/"
-                  "libndk_translation.so",
-                  "system/lib64/libndk_translation.so", "file"),
-                 ("/var/lib/waydroid/arm-translation/system/lib64/"
-                  "ndk_translation",
-                  "system/lib64/ndk_translation", "dir")])
+        tools.helpers.arm_translation, "sync_to_overlay",
+        lambda: sync_called.append(True))
 
     lxc.generate_session_lxc_config(args, session)
 
-    content = (work / "config_session").read_text()
-    assert ("lxc.mount.entry = /var/lib/waydroid/arm-translation/system/lib64/"
-            "libndk_translation.so system/lib64/libndk_translation.so "
-            "none bind,create=file,optional 0 0") in content
-    assert ("lxc.mount.entry = /var/lib/waydroid/arm-translation/system/lib64/"
-            "ndk_translation system/lib64/ndk_translation "
-            "none bind,create=dir,optional 0 0") in content
+    assert sync_called == [True]
 
 
 def test_make_base_props_advertises_arm_abis_when_translation_installed(

--- a/tests/test_lxc_config.py
+++ b/tests/test_lxc_config.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the LXC config generation in tools.helpers.lxc."""
+
+import types
+
+import pytest
+
+import tools.config
+import tools.helpers.lxc as lxc
+
+
+class _Args:
+    vendor_type = "MAINLINE"
+    BINDER_DRIVER = "binder"
+    VNDBINDER_DRIVER = "vndbinder"
+    HWBINDER_DRIVER = "hwbinder"
+
+
+def _fake_glob(pattern):
+    return {
+        "/dev/fb*": ["/dev/fb0"],
+        "/dev/graphics/fb*": [],
+        "/dev/video*": [],
+        "/dev/dma_heap/*": [],
+    }.get(pattern, [])
+
+
+def _build_nodes(monkeypatch, exists=None):
+    monkeypatch.setattr("glob.glob", _fake_glob)
+    monkeypatch.setattr(tools.helpers.gpu, "getDriNode",
+                        lambda args: ("/dev/dri/renderD128", ""))
+    if exists is None:
+        monkeypatch.setattr("os.path.exists", lambda path: True)
+    else:
+        monkeypatch.setattr("os.path.exists", exists)
+    return lxc.generate_nodes_lxc_config(_Args())
+
+
+def test_nodes_include_core_entries(monkeypatch):
+    text = "\n".join(_build_nodes(monkeypatch))
+
+    assert "lxc.mount.entry = tmpfs dev tmpfs nosuid 0 0" in text
+    assert ("lxc.mount.entry = /dev/dri/renderD128 dev/dri/renderD128 "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/binder dev/binder "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/vndbinder dev/vndbinder "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/hwbinder dev/hwbinder "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/net/tun dev/tun "
+            "none bind,create=file,optional 0 0") in text
+    assert "lxc.mount.entry = /dev/fb0 dev/fb0" in text
+
+
+def test_nodes_skip_missing_check_nodes(monkeypatch):
+    # Only /dev/zero exists; everything else with check=True is skipped.
+    text = "\n".join(_build_nodes(
+        monkeypatch, exists=lambda path: path == "/dev/zero"))
+
+    # check=False entries are always present (binder, tmpfs)
+    assert "lxc.mount.entry = /dev/binder dev/binder" in text
+    assert "lxc.mount.entry = tmpfs dev tmpfs nosuid 0 0" in text
+    # check=True entries for missing nodes are skipped
+    assert "/dev/ion" not in text
+    assert "/dev/ashmem" not in text
+    assert "/dev/sw_sync" not in text
+    assert "/dev/null" not in text
+
+
+def test_session_config_binds_wayland_and_userdata(monkeypatch, tmp_path):
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    data = tmp_path / "data"
+    data.mkdir()
+    session = {
+        "user_id": "1000",
+        "xdg_runtime_dir": str(xdg),
+        "wayland_display": "wayland-0",
+        "pulse_runtime_path": str(xdg) + "/pulse",
+        "waydroid_data": str(data),
+    }
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(work=str(work))
+    monkeypatch.setitem(tools.config.defaults, "container_xdg_runtime_dir",
+                        "/run/xdg")
+    monkeypatch.setitem(tools.config.defaults, "container_wayland_display",
+                        "wayland-0")
+    monkeypatch.setitem(tools.config.defaults,
+                        "container_pulse_runtime_path", "/run/xdg/pulse")
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+
+    lxc.generate_session_lxc_config(args, session)
+
+    content = (work / "config_session").read_text()
+    assert "lxc.mount.entry = tmpfs /run/xdg none create=dir 0 0" in content
+    assert ("lxc.mount.entry = {0}/wayland-0 run/xdg/wayland-0 "
+            "none rbind,create=file 0 0".format(xdg)) in content
+    assert ("lxc.mount.entry = {0}/pulse/native run/xdg/pulse/native "
+            "none rbind,create=file 0 0".format(xdg)) in content
+    assert ("lxc.mount.entry = {0} data none rbind 0 0".format(data)) in content
+
+
+def test_session_config_arm_translation_entries(monkeypatch, tmp_path):
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    session = {
+        "user_id": "1000",
+        "xdg_runtime_dir": str(xdg),
+        "wayland_display": "wayland-0",
+        "pulse_runtime_path": str(xdg) + "/pulse",
+        "waydroid_data": str(tmp_path / "data"),
+    }
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(work=str(work))
+    monkeypatch.setitem(tools.config.defaults, "container_xdg_runtime_dir",
+                        "/run/xdg")
+    monkeypatch.setitem(tools.config.defaults, "container_wayland_display",
+                        "wayland-0")
+    monkeypatch.setitem(tools.config.defaults,
+                        "container_pulse_runtime_path", "/run/xdg/pulse")
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    monkeypatch.setattr(
+        tools.helpers.arm_translation, "mount_entries",
+        lambda: [("/var/lib/waydroid/arm-translation/system/lib64/"
+                  "libndk_translation.so",
+                  "system/lib64/libndk_translation.so", "file"),
+                 ("/var/lib/waydroid/arm-translation/system/lib64/"
+                  "ndk_translation",
+                  "system/lib64/ndk_translation", "dir")])
+
+    lxc.generate_session_lxc_config(args, session)
+
+    content = (work / "config_session").read_text()
+    assert ("lxc.mount.entry = /var/lib/waydroid/arm-translation/system/lib64/"
+            "libndk_translation.so system/lib64/libndk_translation.so "
+            "none bind,create=file,optional 0 0") in content
+    assert ("lxc.mount.entry = /var/lib/waydroid/arm-translation/system/lib64/"
+            "ndk_translation system/lib64/ndk_translation "
+            "none bind,create=dir,optional 0 0") in content
+
+
+def test_session_config_rejects_newline_in_mount_path(monkeypatch, tmp_path):
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    session = {
+        "user_id": "1000",
+        "xdg_runtime_dir": str(xdg),
+        "wayland_display": "bad\npath",
+        "pulse_runtime_path": str(xdg) + "/pulse",
+        "waydroid_data": str(tmp_path / "data"),
+    }
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(work=str(work))
+    monkeypatch.setitem(tools.config.defaults, "container_xdg_runtime_dir",
+                        "/run/xdg")
+    monkeypatch.setitem(tools.config.defaults, "container_wayland_display",
+                        "wayland-0")
+    monkeypatch.setitem(tools.config.defaults,
+                        "container_pulse_runtime_path", "/run/xdg/pulse")
+
+    with pytest.raises(OSError):
+        lxc.generate_session_lxc_config(args, session)

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.mount."""
+
+import io
+import os
+
+import pytest
+
+import tools.helpers.mount as mount
+from tools.helpers.version import kernel_version, versiontuple
+
+
+def write_mounts(tmp_path, content):
+    path = tmp_path / "mounts"
+    path.write_text(content)
+    return str(path)
+
+
+def test_umount_all_list(tmp_path):
+    content = "\n".join([
+        "overlay /var/lib/waydroid/rootfs overlay rw 0 0",
+        "/dev/sda1 /var/lib/waydroid/rootfs/vendor ext4 ro 0 0",
+        "/dev/sdb1 /other ext4 rw 0 0",
+    ]) + "\n"
+    source = write_mounts(tmp_path, content)
+    result = mount.umount_all_list("/var/lib/waydroid/rootfs", source)
+    assert result == ["/var/lib/waydroid/rootfs/vendor",
+                      "/var/lib/waydroid/rootfs"]
+
+
+def test_umount_all_list_no_match(tmp_path):
+    content = "/dev/sda1 /var/lib/waydroid/rootfs ext4 ro 0 0\n"
+    source = write_mounts(tmp_path, content)
+    assert mount.umount_all_list("/tmp", source) == []
+
+
+def test_umount_all_list_deleted_suffix(tmp_path):
+    # Deleted mount points have a "\040(deleted)" suffix that must be stripped
+    content = "/dev/sda1 /var/lib/waydroid/rootfs\\040(deleted) ext4 ro 0 0\n"
+    source = write_mounts(tmp_path, content)
+    result = mount.umount_all_list("/var/lib/waydroid", source)
+    assert result == ["/var/lib/waydroid/rootfs"]
+
+
+def test_umount_all_list_bad_line(tmp_path):
+    # A mount line with fewer than 2 fields is malformed
+    content = "onlyonefield\n"
+    source = write_mounts(tmp_path, content)
+    with pytest.raises(RuntimeError):
+        mount.umount_all_list("/var/lib/waydroid", source)
+
+
+def test_ismount(monkeypatch, tmp_path):
+    folder = "/var/lib/waydroid/rootfs"
+    content = "overlay {} overlay rw 0 0\n".format(folder)
+
+    class FakeOpen:
+        def __call__(self, path, *args, **kwargs):
+            return io.StringIO(content)
+
+    monkeypatch.setattr("builtins.open", FakeOpen())
+    assert mount.ismount(folder)
+    assert not mount.ismount("/var/lib/waydroid/nonexistent")
+
+
+def test_ismount_source_dest(monkeypatch):
+    # ismount() also matches when the folder appears as the source of a bind
+    source = "/dev/sda1"
+    dest = "/var/lib/waydroid/rootfs"
+    content = "{} {} ext4 rw 0 0\n".format(source, dest)
+
+    class FakeOpen:
+        def __call__(self, path, *args, **kwargs):
+            return io.StringIO(content)
+
+    monkeypatch.setattr("builtins.open", FakeOpen())
+    assert mount.ismount(source)
+
+
+def _mount_capturing_fake(calls):
+    # Simulates the effect of a successful mount: after a `mount` command
+    # runs, the destination counts as mounted for the ismount() verification.
+    mounted = set()
+
+    def fake_ismount(path):
+        return path in mounted
+
+    def fake_user(*args, **kwargs):
+        command = args[1]
+        calls.append((args, kwargs))
+        if command[0] == "mount":
+            mounted.add(command[-1])
+        return 0
+    return fake_ismount, fake_user
+
+
+def test_bind_mounts_and_creates_destination(monkeypatch, tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    calls = []
+    fake_ismount, fake_user = _mount_capturing_fake(calls)
+    monkeypatch.setattr(mount, "ismount", fake_ismount)
+    monkeypatch.setattr("tools.helpers.run.user", fake_user)
+
+    mount.bind(object(), str(src), str(dst))
+
+    commands = [c[0][1] for c in calls]
+    assert ["mkdir", "-p", str(dst)] in commands
+    assert ["mount", "-o", "bind", str(src), str(dst)] in commands
+
+
+def test_mount_type_and_options(monkeypatch, tmp_path):
+    dst = tmp_path / "dst"
+    calls = []
+    fake_ismount, fake_user = _mount_capturing_fake(calls)
+    monkeypatch.setattr(mount, "ismount", fake_ismount)
+    monkeypatch.setattr("tools.helpers.run.user", fake_user)
+
+    mount.mount(object(), "overlay", str(dst), mount_type="overlay",
+                options=["lowerdir=/a:/b"])
+
+    commands = [c[0][1] for c in calls]
+    assert ["mount", "-t", "overlay", "-o", "ro,lowerdir=/a:/b",
+            "overlay", str(dst)] in commands
+
+
+def test_versiontuple():
+    assert versiontuple("1.2.3") == (1, 2, 3)
+    assert versiontuple("0") == (0,)
+
+
+def test_kernel_version(monkeypatch):
+    class FakeUname:
+        release = "6.8.0-arch1-1"
+
+    monkeypatch.setattr(os, "uname", lambda: FakeUname())
+    assert kernel_version() == (6, 8)

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.net."""
+
+import io
+
+import tools.helpers.net as net
+
+
+def test_get_device_ip_address(monkeypatch):
+    lease = ("1692540000 00:16:3e:00:00:01 192.168.240.2 "
+             "waydroid 00:16:3e:00:00:01\n")
+    monkeypatch.setattr("builtins.open", lambda *a, **kw: io.StringIO(lease))
+
+    assert net.get_device_ip_address() == "192.168.240.2"
+
+
+def test_get_device_ip_address_no_lease(monkeypatch):
+    def raise_ioerror(*a, **kw):
+        raise IOError("no lease file")
+
+    monkeypatch.setattr("builtins.open", raise_ioerror)
+
+    assert net.get_device_ip_address() is None
+
+
+def test_get_device_ip_address_no_match(monkeypatch):
+    monkeypatch.setattr("builtins.open",
+                        lambda *a, **kw: io.StringIO("no ip here\n"))
+
+    assert net.get_device_ip_address() is None

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.protocol."""
+
+import types
+
+import tools.config
+import tools.helpers.props
+import tools.helpers.protocol as protocol
+
+
+def make_args():
+    return types.SimpleNamespace()
+
+
+def test_set_aidl_version(monkeypatch):
+    cfg = {"waydroid": {}}
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+    # (sdk, binder_protocol, service_manager_protocol)
+    cases = [
+        (0, "aidl", "aidl"),
+        (27, "aidl", "aidl"),
+        (28, "aidl2", "aidl2"),
+        (29, "aidl2", "aidl2"),
+        (30, "aidl3", "aidl3"),
+        (31, "aidl4", "aidl3"),
+        (32, "aidl4", "aidl3"),
+        (33, "aidl3", "aidl3"),
+        (34, "aidl3", "aidl3"),
+        (35, "aidl3", "aidl5"),
+        (36, "aidl3", "aidl6"),
+        # Android 16 (API 36) and newer stay on aidl6 for the service manager
+        (37, "aidl3", "aidl6"),
+        (40, "aidl3", "aidl6"),
+    ]
+    for sdk, binder, sm in cases:
+        monkeypatch.setattr(tools.helpers.props, "file_get",
+                            lambda *args, **kwargs: str(sdk))
+        protocol.set_aidl_version(make_args())
+        assert cfg["waydroid"]["binder_protocol"] == binder, \
+            "binder protocol for sdk {}".format(sdk)
+        assert cfg["waydroid"]["service_manager_protocol"] == sm, \
+            "service manager protocol for sdk {}".format(sdk)
+
+
+def test_set_aidl_version_parse_error(monkeypatch):
+    """A failing build.prop read falls back to the lowest protocol."""
+    cfg = {"waydroid": {}}
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    def raise_file_get(*args, **kwargs):
+        raise Exception("no build.prop")
+
+    monkeypatch.setattr(tools.helpers.props, "file_get", raise_file_get)
+    protocol.set_aidl_version(make_args())
+    assert cfg["waydroid"]["binder_protocol"] == "aidl"
+    assert cfg["waydroid"]["service_manager_protocol"] == "aidl"

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the release packaging script (tools/release/package.py)."""
+
+import hashlib
+import os
+import shutil
+import tarfile
+import zipfile
+
+import pytest
+
+from tools.release import package
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _zip_with(dest, files):
+    """Create a zip archive containing {name: bytes} entries."""
+    with zipfile.ZipFile(dest, "w") as handle:
+        for name, data in files.items():
+            handle.writestr(name, data)
+    return dest
+
+
+@pytest.fixture
+def tooling_tree(tmp_path):
+    """A fake 'make install DESTDIR' tree."""
+    root = tmp_path / "tooling"
+    (root / "usr" / "lib" / "waydroid").mkdir(parents=True)
+    (root / "usr" / "lib" / "waydroid" / "waydroid.py").write_text(
+        "print('waydroid')")
+    (root / "usr" / "bin").mkdir(parents=True)
+    (root / "usr" / "bin" / "waydroid").write_text("#!/bin/sh\n")
+    return str(root)
+
+
+@pytest.fixture
+def images_dir(tmp_path):
+    """A directory with minimal system.img / vendor.img files."""
+    root = tmp_path / "images"
+    root.mkdir()
+    (root / "system.img").write_bytes(b"SYSTEM-IMAGE-DATA")
+    (root / "vendor.img").write_bytes(b"VENDOR-IMAGE-DATA")
+    return str(root)
+
+
+@pytest.fixture
+def arm_dir(tmp_path):
+    """A minimal translation layer tree (system/lib64/...)."""
+    root = tmp_path / "arm"
+    lib64 = root / "system" / "lib64"
+    lib64.mkdir(parents=True)
+    (lib64 / "libndk_translation.so").write_bytes(b"\x7fELF")
+    (root / "system" / "etc" / "init").mkdir(parents=True)
+    (root / "system" / "etc" / "init" / "ndk_translation.rc").write_text(
+        "on boot\n")
+    return str(root)
+
+
+# ---------------------------------------------------------------------------
+# Official channel parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_official_channel_picks_newest():
+    data = {"response": [
+        {"datetime": 100, "filename": "old.zip", "url": "https://x/old.zip",
+         "id": "a" * 64},
+        {"datetime": 200, "filename": "new.zip", "url": "https://x/new.zip",
+         "id": "b" * 64},
+    ]}
+    result = package.parse_official_channel(data, "VANILLA", "MAINLINE",
+                                            "x86_64")
+    assert result["system"]["filename"] == "new.zip"
+    assert result["system"]["sha256"] == "b" * 64
+    assert result["vendor"]["channel"] == "official/x86_64/MAINLINE"
+
+
+def test_parse_official_channel_empty_raises():
+    with pytest.raises(ValueError):
+        package.parse_official_channel({"response": []}, "VANILLA",
+                                       "MAINLINE", "x86_64")
+
+
+def test_parse_official_channel_requires_sha():
+    data = {"response": [{"datetime": 100, "filename": "x.zip",
+                          "url": "https://x/x.zip"}]}
+    with pytest.raises(ValueError):
+        package.parse_official_channel(data, "VANILLA", "MAINLINE", "x86_64")
+
+
+# ---------------------------------------------------------------------------
+# Community channel parsing
+# ---------------------------------------------------------------------------
+
+def _release(tag, assets):
+    return {"tag_name": tag, "published_at": "2026-07-17T00:00:00Z",
+            "assets": [{"name": a} for a in assets]}
+
+
+def test_community_matches_modern_split_assets():
+    release = _release("20260717", [
+        "lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip",
+        "lineage-23.2-20260717-MAINLINE-waydroid_x86_64-vendor.zip",
+        "lineage-23.2-20260717-GAPPS-waydroid_x86_64-system.zip",
+    ])
+    result = package.parse_community_releases([release], 23, "x86_64",
+                                              "VANILLA")
+    assert "VANILLA-waydroid_x86_64-system.zip" in result["system"]["url"]
+    assert "MAINLINE-waydroid_x86_64-vendor.zip" in result["vendor"]["url"]
+    assert result["system"]["sha256"] is None
+
+
+def test_community_matches_combined_asset():
+    release = _release("20260224", [
+        "lineage-22.2-20260224-UNOFFICIAL-waydroid_x86_64.zip",
+    ])
+    result = package.parse_community_releases([release], 22, "x86_64",
+                                              "VANILLA")
+    assert result["system"]["filename"] == result["vendor"]["filename"]
+    assert "UNOFFICIAL-waydroid_x86_64.zip" in result["system"]["url"]
+
+
+def test_community_skips_wrong_android_major():
+    release = _release("20260717", [
+        "lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip",
+        "lineage-23.2-20260717-MAINLINE-waydroid_x86_64-vendor.zip",
+    ])
+    with pytest.raises(ValueError):
+        package.parse_community_releases([release], 22, "x86_64", "VANILLA")
+
+
+def test_community_requires_vendor_asset():
+    release = _release("20260717", [
+        "lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip",
+    ])
+    with pytest.raises(ValueError):
+        package.parse_community_releases([release], 23, "x86_64", "VANILLA")
+
+
+# ---------------------------------------------------------------------------
+# resolve_builds wiring
+# ---------------------------------------------------------------------------
+
+def test_resolve_builds_official(tmp_path):
+    def fake_fetch(url):
+        if "vendor" in url:
+            return {"response": [
+                {"datetime": 300, "filename": "vendor.zip",
+                 "url": "https://x/vendor.zip", "id": "c" * 64}]}
+        return {"response": [
+            {"datetime": 200, "filename": "system.zip",
+             "url": "https://x/system.zip", "id": "b" * 64}]}
+
+    result = package.resolve_builds("official", "x86_64", "VANILLA",
+                                    "MAINLINE", fake_fetch)
+    assert result["system"]["sha256"] == "b" * 64
+    assert result["vendor"]["sha256"] == "c" * 64
+
+
+def test_resolve_builds_unknown_channel():
+    with pytest.raises(ValueError):
+        package.resolve_builds("nope", "x86_64", "VANILLA", "MAINLINE",
+                               lambda url: {})
+
+
+# ---------------------------------------------------------------------------
+# Integrity helpers
+# ---------------------------------------------------------------------------
+
+def test_sha256(tmp_path):
+    path = tmp_path / "f.bin"
+    path.write_bytes(b"hello")
+    assert package.sha256(str(path)) == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_extract_images(tmp_path):
+    zipped = _zip_with(str(tmp_path / "imgs.zip"), {
+        "system.img": b"SYS",
+        "vendor.img": b"VND",
+        "META-INF/manifest": b"ignored",
+    })
+    dest = tmp_path / "out"
+    dest.mkdir()
+    package.extract_images(zipped, str(dest))
+    assert (dest / "system.img").read_bytes() == b"SYS"
+    assert (dest / "vendor.img").read_bytes() == b"VND"
+    assert not (dest / "META-INF").exists()
+
+
+# ---------------------------------------------------------------------------
+# Package assembly
+# ---------------------------------------------------------------------------
+
+def test_assemble_package_layout(tooling_tree, images_dir, arm_dir,
+                                 tmp_path):
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, arm_dir, out,
+                             "official", "1.6.4")
+    assert os.path.exists(out)
+    with tarfile.open(out, "r:xz") as tar:
+        names = tar.getnames()
+        joined = "\n".join(names)
+        assert "/install.sh" in joined
+        assert "/SHA256SUMS" in joined
+        assert "/LICENSE" in joined
+        assert "/NOTICE" in joined
+        assert "/images/system.img" in joined
+        assert "/images/vendor.img" in joined
+        assert "/arm-translation/system/lib64/libndk_translation.so" in joined
+        assert "/waydroid/usr/bin/waydroid" in joined
+        # install.sh must be executable
+        member = tar.getmember(
+            next(n for n in names if n.endswith("/install.sh")))
+        assert member.mode & 0o111
+
+
+def test_arm_tree_nested_under_system(tmp_path):
+    """The staged translation tree must live under system/ so install.sh can
+    drop it into /var/lib/waydroid/arm-translation directly."""
+    work = tmp_path / "work"
+    work.mkdir()
+    # Fake the prebuilt archive: prebuilts/lib64/libndk_translation.so
+    # plus etc/init/ndk_translation.rc at the prebuilts root.
+    prebuilts = work / "repo" / "prebuilts"
+    (prebuilts / "lib64").mkdir(parents=True)
+    (prebuilts / "lib64" / "libndk_translation.so").write_bytes(b"\x7fELF")
+    (prebuilts / "lib").mkdir()
+    (prebuilts / "lib" / "libndk_translation.so").write_bytes(b"\x7fELF")
+    (prebuilts / "etc" / "init").mkdir(parents=True)
+    (prebuilts / "etc" / "init" / "ndk_translation.rc").write_text("on boot\n")
+    zip_path = str(work / "arm.zip")
+    _zip_with(zip_path, {
+        "repo/prebuilts/lib64/libndk_translation.so": b"\x7fELF",
+        "repo/prebuilts/lib/libndk_translation.so": b"\x7fELF",
+        "repo/prebuilts/etc/init/ndk_translation.rc": b"on boot\n",
+    })
+    extract = work / "extract"
+    extract.mkdir()
+    with zipfile.ZipFile(zip_path) as handle:
+        handle.extractall(extract)
+    root = package._find_prebuilts_root(str(extract))
+    assert root.endswith("prebuilts")
+
+    # _prepare_arm_translation downloads; verify the staging layout instead
+    # by exercising the same nesting logic the fixed function performs.
+    arm_dir = str(work / "arm-translation")
+    os.makedirs(arm_dir)
+    system_dir = os.path.join(arm_dir, "system")
+    os.makedirs(system_dir)
+    for name in os.listdir(root):
+        shutil.copytree(os.path.join(root, name),
+                        os.path.join(system_dir, name))
+    assert os.path.isfile(os.path.join(
+        arm_dir, "system", "lib64", "libndk_translation.so"))
+    assert os.path.isfile(os.path.join(
+        arm_dir, "system", "etc", "init", "ndk_translation.rc"))
+
+
+def test_assemble_package_skips_arm(tooling_tree, images_dir, tmp_path):
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, None, out,
+                             "official", "1.6.4",
+                             with_arm_translation=False)
+    with tarfile.open(out, "r:xz") as tar:
+        assert not any("arm-translation" in n for n in tar.getnames())
+
+
+def test_sha256sums_manifest_validates(tooling_tree, images_dir, arm_dir,
+                                       tmp_path):
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, arm_dir, out,
+                             "official", "1.6.4")
+    with tarfile.open(out, "r:xz") as tar:
+        checksums = tar.extractfile(
+            next(n for n in tar.getnames() if n.endswith("/SHA256SUMS"))
+        ).read().decode()
+    entries = dict(reversed(line.split("  "))
+                    for line in checksums.strip().splitlines())
+    assert entries  # non-empty
+    with tarfile.open(out, "r:xz") as tar:
+        names = tar.getnames()
+        for name, expected in entries.items():
+            member = next(n for n in names
+                          if n.endswith("/" + name)
+                          and tar.getmember(n).isfile())
+            data = tar.extractfile(member).read()
+            assert hashlib.sha256(data).hexdigest() == expected

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -258,6 +258,24 @@ def test_arm_tree_nested_under_system(tmp_path):
         arm_dir, "system", "etc", "init", "ndk_translation.rc"))
 
 
+def test_assemble_package_keeps_bin_symlink(tooling_tree, images_dir,
+                                             arm_dir, tmp_path):
+    """The usr/bin/waydroid symlink must survive packaging: installing a
+    dereferenced copy breaks sys.path[0] resolution (import tools)."""
+    bin_waydroid = os.path.join(tooling_tree, "usr", "bin", "waydroid")
+    os.remove(bin_waydroid)  # fixture creates it as a regular file
+    os.symlink("../lib/waydroid/waydroid.py", bin_waydroid)
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, arm_dir, out,
+                             "official", "1.6.4")
+    with tarfile.open(out, "r:xz") as tar:
+        member = next(n for n in tar.getnames()
+                      if n.endswith("/waydroid/usr/bin/waydroid"))
+        info = tar.getmember(member)
+        assert info.issym(), "usr/bin/waydroid must stay a symlink"
+        assert info.linkname == "../lib/waydroid/waydroid.py"
+
+
 def test_assemble_package_skips_arm(tooling_tree, images_dir, tmp_path):
     out = str(tmp_path / "pkg.tar.xz")
     package.assemble_package(tooling_tree, images_dir, None, out,
@@ -279,11 +297,13 @@ def test_sha256sums_manifest_validates(tooling_tree, images_dir, arm_dir,
     entries = dict(reversed(line.split("  "))
                     for line in checksums.strip().splitlines())
     assert entries  # non-empty
+    # Entries must be relative to the package root so `sha256sum -c` works
+    # from the extracted directory.
     with tarfile.open(out, "r:xz") as tar:
         names = tar.getnames()
-        for name, expected in entries.items():
+        for rel, expected in entries.items():
             member = next(n for n in names
-                          if n.endswith("/" + name)
+                          if n.endswith("/" + rel)
                           and tar.getmember(n).isfile())
             data = tar.extractfile(member).read()
             assert hashlib.sha256(data).hexdigest() == expected

--- a/tests/test_services_runner.py
+++ b/tests/test_services_runner.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import time
+
+from tools.services.runner import ServiceRunner
+
+
+class _Args:
+    pass
+
+
+class _Loop:
+    def __init__(self):
+        self.quit_called = False
+
+    def quit(self):
+        self.quit_called = True
+
+
+def test_start_runs_until_stopped():
+    calls = []
+
+    def run_fn():
+        calls.append(1)
+        time.sleep(0.01)
+
+    args = _Args()
+    runner = ServiceRunner("Test", "testLoop")
+    runner.start(run_fn)
+    time.sleep(0.05)
+    assert len(calls) >= 2
+
+    runner.stop(args)
+    runner.join()
+    count_at_stop = len(calls)
+    time.sleep(0.03)
+    assert len(calls) == count_at_stop
+
+
+def test_stop_quits_glib_loop():
+    args = _Args()
+    args.testLoop = _Loop()
+    runner = ServiceRunner("Test", "testLoop")
+
+    runner.stop(args)
+
+    assert args.testLoop.quit_called
+
+
+def test_stop_when_never_started_is_quiet(caplog):
+    import logging
+    runner = ServiceRunner("Test", "testLoop")
+
+    with caplog.at_level(logging.DEBUG):
+        runner.stop(_Args())
+
+    assert any("not even started" in record.message for record in caplog.records)
+
+
+def test_session_stop_quits_all_service_loops(monkeypatch):
+    # The session stop path must quit the GLib loop of every per-session
+    # service (user/clipboard/notification) plus the session main loop.
+    import types
+
+    import tools.actions.session_manager as session_manager
+
+    loops = {name: _Loop() for name in
+             ("userMonitorLoop", "clipboardLoop", "notificationLoop")}
+    args = types.SimpleNamespace(**loops)
+    mainloop = _Loop()
+
+    session_manager.do_stop(args, mainloop)
+
+    for loop in loops.values():
+        assert loop.quit_called
+    assert mainloop.quit_called
+
+
+def test_join_returns_after_stop():
+    runner = ServiceRunner("Test", "testLoop")
+    runner.start(lambda: None)
+    runner.stop(_Args())
+    # Should not hang or raise
+    runner.join(timeout=2)

--- a/tests/test_tools_init.py
+++ b/tests/test_tools_init.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools/__init__.py helpers (log path selection)."""
+
+import types
+
+import tools
+import tools.config
+
+
+def make_args(user_log=None, log="/var/lib/waydroid/waydroid.log"):
+    return types.SimpleNamespace(user_log=user_log, log=log)
+
+
+def test_log_path_root_uses_own_log(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 0)
+    args = make_args()
+    assert tools._log_path(args) == args.log
+
+
+def test_log_path_nonroot_prefers_root_log_when_readable(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(tools.os, "access", lambda path, mode: True)
+    args = make_args()
+    root_log = tools.config.defaults["work"] + "/waydroid.log"
+    assert tools._log_path(args) == root_log
+
+
+def test_log_path_nonroot_explicit_log_wins(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(tools.os, "access", lambda path, mode: True)
+    # main() redirects args.log to the explicit -l path before _log runs, so
+    # the root-log preference must not kick in even though it is readable.
+    args = make_args(user_log="/tmp/custom.log", log="/tmp/custom.log")
+    assert tools._log_path(args) == "/tmp/custom.log"
+
+
+def test_log_path_nonroot_root_log_unreadable(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(tools.os, "access", lambda path, mode: False)
+    args = make_args()
+    assert tools._log_path(args) == args.log

--- a/tests/test_upgrader.py
+++ b/tests/test_upgrader.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.actions.upgrader.migration()."""
+
+import types
+
+import tools.config
+import tools.actions.upgrader as upgrader
+
+
+def make_args():
+    return types.SimpleNamespace(work="/var/lib/waydroid")
+
+
+def test_migration_adds_missing_binder_keys(monkeypatch):
+    cfg = {"waydroid": {}}
+    # Old tools version 1.6.3: only the 1.6.3 migration step runs.
+    monkeypatch.setattr(tools.helpers.props, "file_get",
+                        lambda *a, **kw: "1.6.3")
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    upgrader.migration(make_args())
+
+    assert cfg["waydroid"]["binder"] == "binder"
+    assert cfg["waydroid"]["vndbinder"] == "vndbinder"
+    assert cfg["waydroid"]["hwbinder"] == "hwbinder"
+    assert saved == cfg
+
+
+def test_migration_keeps_existing_binder_keys(monkeypatch):
+    cfg = {"waydroid": {"binder": "anbox-binder",
+                        "vndbinder": "anbox-vndbinder",
+                        "hwbinder": "anbox-hwbinder"}}
+    monkeypatch.setattr(tools.helpers.props, "file_get",
+                        lambda *a, **kw: "1.6.3")
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    upgrader.migration(make_args())
+
+    assert cfg["waydroid"]["binder"] == "anbox-binder"
+    # Nothing changed, so the config must not be rewritten.
+    assert saved == {}
+
+
+def test_migration_new_install_is_noop(monkeypatch):
+    cfg = {"waydroid": {}}
+    monkeypatch.setattr(tools.helpers.props, "file_get",
+                        lambda *a, **kw: "1.6.4")
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    upgrader.migration(make_args())
+
+    assert saved == {}
+    assert "binder" not in cfg["waydroid"]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -14,6 +14,10 @@ from . import config
 from . import helpers
 from .helpers import logging as tools_logging
 
+# ROOT_ACTIONS and ALLOWED_UNINITIALIZED are derived from the guard flags
+# declared on each DISPATCH entry below, so a new action declares its guards
+# in the one place it is added.
+
 def prep_args(args):
     args.cache = {}
     args.work = config.defaults["work"]
@@ -22,24 +26,134 @@ def prep_args(args):
     args.sudo_timer = True
     args.timeout = 1800
 
-def main():
-    def actionNeedRoot(action):
-        if os.geteuid() != 0:
-            raise RuntimeError(
-                "Action \"{}\" needs root access".format(action))
+def _action_need_root(action):
+    if os.geteuid() != 0:
+        raise RuntimeError(
+            "Action \"{}\" needs root access".format(action))
 
+def _log_path(args):
+    """
+    Choose the log file that `waydroid log` should follow.
+
+    Non-root users prefer the root container log (where container service
+    errors land) when it is readable, unless an explicit -l/--log was given.
+    """
+    if os.geteuid() != 0 and not args.user_log:
+        root_log = config.defaults["work"] + "/waydroid.log"
+        if os.access(root_log, os.R_OK):
+            return root_log
+    return args.log
+
+def _log(args):
+    """Follow the log file, preferring the root container log as a user."""
+    log_path = _log_path(args)
+    if args.clear_log:
+        helpers.run.user(args, ["truncate", "-s", "0", args.log])
+    try:
+        helpers.run.user(
+            args, ["tail", "-n", args.lines, "-F", log_path], output="tui")
+    except KeyboardInterrupt:
+        pass
+
+def _first_launch(args):
+    if not actions.initializer.is_initialized(args):
+        actions.remote_init_client(args)
+    if actions.initializer.is_initialized(args):
+        actions.app_manager.showFullUI(args)
+
+def _init(args):
+    if args.client:
+        actions.remote_init_client(args)
+    else:
+        _action_need_root("init")
+        actions.init(args)
+
+class _ActionEntry(dict):
+    """A DISPATCH entry: {subaction or None: handler} plus guard flags.
+
+    Subclassing dict keeps lookups (``table.get(subaction)``, ``None in
+    table``) unchanged; the flags declare how the action is gated in main()
+    and are what ROOT_ACTIONS / ALLOWED_UNINITIALIZED are derived from.
+    """
+
+
+def _entry(handlers, *, root=False, uninitialized=False):
+    """Build a DISPATCH entry, marking the action's guard flags."""
+    entry = _ActionEntry(handlers)
+    entry.need_root = root
+    entry.allowed_uninitialized = uninitialized
+    return entry
+
+
+# Action dispatch table: action -> entry mapping {subaction or None: handler}
+# plus guard flags. Adding a new action or subaction requires only a new
+# entry here; ROOT_ACTIONS and ALLOWED_UNINITIALIZED are derived from the
+# flags below.
+DISPATCH = {
+    # "init" runs as a user for the --client variant; root is checked inside
+    # _init instead of via the need_root flag.
+    "init": _entry({None: _init}, uninitialized=True),
+    "upgrade": _entry({None: actions.upgrade}, root=True),
+    "session": _entry({"start": actions.session_manager.start,
+                       "stop": actions.session_manager.stop}),
+    "container": _entry({"start": actions.container_manager.start,
+                         "stop": actions.container_manager.stop,
+                         "restart": actions.container_manager.restart,
+                         "freeze": actions.container_manager.freeze,
+                         "unfreeze": actions.container_manager.unfreeze},
+                        root=True, uninitialized=True),
+    "app": _entry({"install": actions.app_manager.install,
+                   "remove": actions.app_manager.remove,
+                   "launch": actions.app_manager.launch,
+                   "intent": actions.app_manager.intent,
+                   "list": actions.app_manager.list}),
+    "prop": _entry({"get": actions.prop.get,
+                    "set": actions.prop.set}),
+    "shell": _entry({None: helpers.lxc.shell}, root=True),
+    "logcat": _entry({None: helpers.lxc.logcat}, root=True),
+    "show-full-ui": _entry({None: actions.app_manager.showFullUI}),
+    "first-launch": _entry({None: _first_launch}, uninitialized=True),
+    "status": _entry({None: actions.status.print_status}),
+    "adb": _entry({"connect": helpers.net.adb_connect,
+                   "disconnect": helpers.net.adb_disconnect}),
+    "log": _entry({None: _log}, uninitialized=True),
+    "bugreport": _entry({None: actions.bugreport}, uninitialized=True),
+    "arm-translation": _entry({"install": actions.arm_translation.install,
+                               "status": actions.arm_translation.status,
+                               "uninstall": actions.arm_translation.uninstall},
+                              root=True),
+}
+
+# Actions that may run before waydroid is initialized, and actions that
+# always require root. Derived from the DISPATCH flags so the two can't
+# drift from the table. "init" is deliberately absent from ROOT_ACTIONS:
+# its --client variant runs as a user and checks root itself in _init.
+ALLOWED_UNINITIALIZED = frozenset(
+    action for action, entry in DISPATCH.items()
+    if entry.allowed_uninitialized)
+ROOT_ACTIONS = frozenset(
+    action for action, entry in DISPATCH.items() if entry.need_root)
+
+def main():
     # Wrap everything to display nice error messages
     args = None
     try:
         # Parse arguments, set up logging
         args = helpers.arguments()
+        user_log = args.log
         prep_args(args)
 
         if os.geteuid() == 0:
             if not os.path.exists(args.work):
                 os.mkdir(args.work)
-        elif not os.path.exists(args.log):
+        elif not user_log and not os.path.exists(args.log):
+            # Non-root users cannot write to the root work dir; fall back
+            # to a per-user log unless an explicit -l/--log was given.
             args.log = "/tmp/tools.log"
+
+        if user_log:
+            args.log = user_log
+        args.user_log = user_log
 
         tools_logging.init(args)
 
@@ -50,98 +164,22 @@ def main():
             args.action = "first-launch"
 
         if not actions.initializer.is_initialized(args) and \
-                args.action not in ("init", "container", "first-launch", "log", "bugreport"):
+                args.action not in ALLOWED_UNINITIALIZED:
             print('Waydroid is not initialized, run "waydroid init"')
             return 0
 
-        if args.action == "init":
-            if args.client:
-                actions.remote_init_client(args)
-            else:
-                actionNeedRoot(args.action)
-                actions.init(args)
-        elif args.action == "upgrade":
-            actionNeedRoot(args.action)
-            actions.upgrade(args)
-        elif args.action == "session":
-            if args.subaction == "start":
-                actions.session_manager.start(args)
-            elif args.subaction == "stop":
-                actions.session_manager.stop(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "container":
-            actionNeedRoot(args.action)
-            if args.subaction == "start":
-                actions.container_manager.start(args)
-            elif args.subaction == "stop":
-                actions.container_manager.stop(args)
-            elif args.subaction == "restart":
-                actions.container_manager.restart(args)
-            elif args.subaction == "freeze":
-                actions.container_manager.freeze(args)
-            elif args.subaction == "unfreeze":
-                actions.container_manager.unfreeze(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "app":
-            if args.subaction == "install":
-                actions.app_manager.install(args)
-            elif args.subaction == "remove":
-                actions.app_manager.remove(args)
-            elif args.subaction == "launch":
-                actions.app_manager.launch(args)
-            elif args.subaction == "intent":
-                actions.app_manager.intent(args)
-            elif args.subaction == "list":
-                actions.app_manager.list(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "prop":
-            if args.subaction == "get":
-                actions.prop.get(args)
-            elif args.subaction == "set":
-                actions.prop.set(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "shell":
-            actionNeedRoot(args.action)
-            helpers.lxc.shell(args)
-        elif args.action == "logcat":
-            actionNeedRoot(args.action)
-            helpers.lxc.logcat(args)
-        elif args.action == "show-full-ui":
-            actions.app_manager.showFullUI(args)
-        elif args.action == "first-launch":
-            if not actions.initializer.is_initialized(args):
-                actions.remote_init_client(args)
-            if actions.initializer.is_initialized(args):
-                actions.app_manager.showFullUI(args)
-        elif args.action == "status":
-            actions.status.print_status(args)
-        elif args.action == "adb":
-            if args.subaction == "connect":
-                helpers.net.adb_connect(args)
-            elif args.subaction == "disconnect":
-                helpers.net.adb_disconnect(args)
-            else:
-                logging.info("Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "log":
-            if args.clear_log:
-                helpers.run.user(args, ["truncate", "-s", "0", args.log])
-            try:
-                helpers.run.user(
-                    args, ["tail", "-n", args.lines, "-F", args.log], output="tui")
-            except KeyboardInterrupt:
-                pass
-        elif args.action == "bugreport":
-            actions.bugreport(args)
-        else:
+        action_handlers = DISPATCH.get(args.action)
+        if action_handlers is None:
             logging.info("Run waydroid -h for usage information.")
+        else:
+            if args.action in ROOT_ACTIONS:
+                _action_need_root(args.action)
+            handler = action_handlers.get(getattr(args, "subaction", None))
+            if handler is None:
+                logging.info(
+                    "Run waydroid {} -h for usage information.".format(args.action))
+            else:
+                handler(args)
 
         #logging.info("Done")
 

--- a/tools/actions/__init__.py
+++ b/tools/actions/__init__.py
@@ -1,10 +1,11 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
+from tools.actions import (app_manager, arm_translation, container_manager,
+                           prop, session_manager, status, upgrader)
+from tools.actions.bugreport import bugreport
 from tools.actions.initializer import init, remote_init_client
 from tools.actions.upgrader import upgrade
-from tools.actions.session_manager import start, stop
-from tools.actions.container_manager import start, stop, freeze, unfreeze
-from tools.actions.app_manager import install, remove, launch, list
-from tools.actions.status import print_status
-from tools.actions.prop import get, set
-from tools.actions.bugreport import bugreport
+
+__all__ = ["app_manager", "arm_translation", "container_manager", "prop",
+           "session_manager", "status", "upgrader", "bugreport", "init",
+           "remote_init_client", "upgrade"]

--- a/tools/actions/app_manager.py
+++ b/tools/actions/app_manager.py
@@ -20,7 +20,7 @@ def install(args):
         if session["state"] == "FROZEN":
             cm.Unfreeze()
 
-        tmp_dir = tools.config.session_defaults["waydroid_data"] + "/waydroid_tmp"
+        tmp_dir = tools.config.get_session_defaults()["waydroid_data"] + "/waydroid_tmp"
         if not os.path.exists(tmp_dir):
             os.makedirs(tmp_dir)
 

--- a/tools/actions/arm_translation.py
+++ b/tools/actions/arm_translation.py
@@ -1,5 +1,6 @@
 # Copyright 2026 Waydroid Project
 # SPDX-License-Identifier: GPL-3.0-or-later
+import hashlib
 import logging
 import os
 import shutil
@@ -34,8 +35,64 @@ def _extract_archive(archive_path, dest):
     elif zipfile.is_zipfile(archive_path):
         with zipfile.ZipFile(archive_path) as handle:
             handle.extractall(dest)
+            # zipfile does not restore the unix permission bits that
+            # tarfile keeps; the prebuilt's bin/ executables must stay
+            # executable for binfmt_misc to run them.
+            for info in handle.infolist():
+                mode = (info.external_attr >> 16) & 0o7777
+                if mode and not info.is_dir():
+                    os.chmod(os.path.join(dest, info.filename),
+                             mode & 0o7777)
     else:
         raise RuntimeError("Unsupported archive format: " + archive_path)
+
+
+def _md5(path):
+    """md5 of a file, for verifying downloaded archives."""
+    digest = hashlib.md5()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_prebuilts_root(extracted):
+    """Locate the directory holding the artifacts inside an extracted tree.
+
+    The community prebuilt archive (supremegamers/vendor_google_...)
+    nests the files under ``prebuilts/`` inside a repo-name directory; plain
+    user-made archives may put them directly at the top. Returns the path
+    whose children look like a /system tree (lib/lib64/etc/bin).
+    """
+    candidates = [extracted]
+    for root, dirs, files in os.walk(extracted):
+        if "lib64" in dirs and "lib" in dirs and "etc" in dirs:
+            candidates.append(root)
+    # Deepest match first: a prebuilts/ dir wins over the archive root.
+    candidates.sort(key=lambda p: p.count(os.sep), reverse=True)
+    for candidate in candidates:
+        if (os.path.isdir(candidate + "/lib64")
+                and os.path.isdir(candidate + "/etc")):
+            return candidate
+    return None
+
+
+def _copy_to_system_tree(root, dest):
+    """Copy a /system artifact tree into dest/system/.
+
+    The helper stores artifacts as ``work/arm-translation/system/...``
+    (mirroring the container /system paths); ``root`` is a directory whose
+    children are the top-level /system entries (lib/lib64/etc/bin).
+    """
+    system_dir = dest + "/system"
+    os.makedirs(system_dir, exist_ok=True)
+    for name in os.listdir(root):
+        source_path = os.path.join(root, name)
+        target_path = os.path.join(system_dir, name)
+        if os.path.isdir(source_path):
+            shutil.copytree(source_path, target_path, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source_path, target_path)
 
 
 def _regenerate_base_props(args):
@@ -58,12 +115,17 @@ def install(args):
     # The action always runs as root (ROOT_ACTIONS), so plain rmtree works.
     shutil.rmtree(dest, ignore_errors=True)
 
+    extracted = None
     if args.source:
         source = os.path.abspath(args.source)
         if not os.path.isdir(source):
             raise RuntimeError("Source is not a directory: " + args.source)
-        os.makedirs(dest)
-        shutil.copytree(source, dest, dirs_exist_ok=True)
+        root = _find_prebuilts_root(source)
+        if root is None:
+            raise RuntimeError(
+                "Source does not look like a /system artifact tree (no "
+                "lib64/ and etc/ directories): " + args.source)
+        _copy_to_system_tree(root, dest)
     elif args.archive or args.url:
         archive = args.archive
         if args.url:
@@ -72,21 +134,54 @@ def install(args):
             if archive is None:
                 raise RuntimeError(
                     "Failed to download the ARM translation archive")
-        os.makedirs(dest)
-        _extract_archive(archive, dest)
+        if (args.url and args.url == arm_translation.DEFAULT_ARCHIVE_URL
+                and _md5(archive) != arm_translation.DEFAULT_ARCHIVE_MD5):
+            raise RuntimeError("Downloaded archive failed the integrity "
+                               "check; refusing to install")
+        extracted = dest + ".extract"
+        shutil.rmtree(extracted, ignore_errors=True)
+        os.makedirs(extracted)
+        _extract_archive(archive, extracted)
+        root = _find_prebuilts_root(extracted)
+        if root is None:
+            shutil.rmtree(extracted, ignore_errors=True)
+            raise RuntimeError(
+                "The archive does not contain a /system artifact tree "
+                "(no lib64/ and etc/ directories)")
+        _copy_to_system_tree(root, dest)
+        shutil.rmtree(extracted, ignore_errors=True)
     else:
-        raise RuntimeError(
-            "Specify --source <dir>, --archive <file> or --url <url> with "
-            "the ARM translation artifacts")
+        # No source given: fetch the known-good default prebuilt.
+        logging.info("Downloading the standard libndk_translation prebuilt "
+                     "(Android 13)...")
+        archive = helpers.http.download(
+            args, arm_translation.DEFAULT_ARCHIVE_URL, "arm_translation")
+        if archive is None:
+            raise RuntimeError(
+                "Failed to download the ARM translation archive")
+        if _md5(archive) != arm_translation.DEFAULT_ARCHIVE_MD5:
+            raise RuntimeError("Downloaded archive failed the integrity "
+                               "check; refusing to install")
+        extracted = dest + ".extract"
+        shutil.rmtree(extracted, ignore_errors=True)
+        os.makedirs(extracted)
+        _extract_archive(archive, extracted)
+        root = _find_prebuilts_root(extracted)
+        if root is None:
+            shutil.rmtree(extracted, ignore_errors=True)
+            raise RuntimeError(
+                "The default archive does not contain a /system artifact "
+                "tree (no lib64/ and etc/ directories)")
+        _copy_to_system_tree(root, dest)
+        shutil.rmtree(extracted, ignore_errors=True)
 
     if not arm_translation.is_installed():
         shutil.rmtree(dest, ignore_errors=True)
         raise RuntimeError(
             "The provided files are missing the expected layout; expected "
             "at least system/lib64/libndk_translation.so, "
-            "system/lib64/libndk_translation_proxy.so and "
-            "system/lib64/ndk_translation/libarm64.so. Nothing was "
-            "installed.")
+            "system/lib64/arm64/libc.so and "
+            "system/etc/init/ndk_translation.rc. Nothing was installed.")
 
     _regenerate_base_props(args)
     logging.info("ARM translation layer installed; restart the container "

--- a/tools/actions/arm_translation.py
+++ b/tools/actions/arm_translation.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+import os
+import shutil
+import tarfile
+import zipfile
+
+import tools.config
+from tools import helpers
+from tools.helpers import arm_translation
+
+
+def get_config(args):
+    """Load the config-derived args needed to regenerate the base props."""
+    cfg = tools.config.load(args)
+    args.arch = cfg["waydroid"]["arch"]
+    args.images_path = cfg["waydroid"]["images_path"]
+    args.vendor_type = cfg["waydroid"]["vendor_type"]
+    args.system_ota = cfg["waydroid"]["system_ota"]
+    args.vendor_ota = cfg["waydroid"]["vendor_ota"]
+    args.session = None
+
+
+def _extract_archive(archive_path, dest):
+    """Extract a .tar/.tar.gz/.tar.xz or .zip archive into dest."""
+    if tarfile.is_tarfile(archive_path):
+        with tarfile.open(archive_path) as handle:
+            try:
+                handle.extractall(dest, filter="data")
+            except TypeError:
+                # Python < 3.12 has no filter parameter
+                handle.extractall(dest)
+    elif zipfile.is_zipfile(archive_path):
+        with zipfile.ZipFile(archive_path) as handle:
+            handle.extractall(dest)
+    else:
+        raise RuntimeError("Unsupported archive format: " + archive_path)
+
+
+def _regenerate_base_props(args):
+    """Rewrite waydroid_base.prop so the native-bridge property updates."""
+    get_config(args)
+    helpers.lxc.make_base_props(args)
+
+
+def install(args):
+    if helpers.arch.host() not in ("x86", "x86_64"):
+        raise RuntimeError(
+            "ARM translation is only needed on x86/x86_64 hosts, this host "
+            "is " + helpers.arch.host())
+
+    dest = arm_translation.ARM_TRANSLATION_DIR
+    if os.path.isdir(dest) and os.listdir(dest):
+        logging.warning("An ARM translation layer is already installed, "
+                        "replacing it")
+
+    # The action always runs as root (ROOT_ACTIONS), so plain rmtree works.
+    shutil.rmtree(dest, ignore_errors=True)
+
+    if args.source:
+        source = os.path.abspath(args.source)
+        if not os.path.isdir(source):
+            raise RuntimeError("Source is not a directory: " + args.source)
+        os.makedirs(dest)
+        shutil.copytree(source, dest, dirs_exist_ok=True)
+    elif args.archive or args.url:
+        archive = args.archive
+        if args.url:
+            archive = helpers.http.download(
+                args, args.url, "arm_translation")
+            if archive is None:
+                raise RuntimeError(
+                    "Failed to download the ARM translation archive")
+        os.makedirs(dest)
+        _extract_archive(archive, dest)
+    else:
+        raise RuntimeError(
+            "Specify --source <dir>, --archive <file> or --url <url> with "
+            "the ARM translation artifacts")
+
+    if not arm_translation.is_installed():
+        shutil.rmtree(dest, ignore_errors=True)
+        raise RuntimeError(
+            "The provided files are missing the expected layout; expected "
+            "at least system/lib64/libndk_translation.so, "
+            "system/lib64/libndk_translation_proxy.so and "
+            "system/lib64/ndk_translation/libarm64.so. Nothing was "
+            "installed.")
+
+    _regenerate_base_props(args)
+    logging.info("ARM translation layer installed; restart the container "
+                 "(waydroid container restart) for it to take effect")
+
+
+def uninstall(args):
+    dest = arm_translation.ARM_TRANSLATION_DIR
+    if not os.path.isdir(dest):
+        logging.info("ARM translation layer is not installed")
+        return
+    # The action always runs as root (ROOT_ACTIONS), so plain rmtree works.
+    shutil.rmtree(dest, ignore_errors=True)
+    _regenerate_base_props(args)
+    logging.info("ARM translation layer removed")
+
+
+def status(args):
+    if arm_translation.is_installed():
+        print("ARM translation:\tINSTALLED (libndk_translation)")
+        for host, container_path, kind in arm_translation.mount_entries():
+            print("  -> " + container_path)
+    else:
+        print("ARM translation:\tNOT INSTALLED")

--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -5,6 +5,7 @@ import logging
 import os
 import glob
 import signal
+import time
 import tools.config
 from contextlib import suppress
 from shutil import which
@@ -16,6 +17,12 @@ import dbus.service
 import dbus.exceptions
 from gi.repository import GLib
 
+# Host path of the schedtune cgroup hierarchy (Ubuntu Touch / Halium)
+SCHEDTUNE_PATH = "/sys/fs/cgroup/schedtune"
+
+# Script that sets up the container's private network
+WAYDROID_NET_SCRIPT = tools.config.tools_src + "/data/scripts/waydroid-net.sh"
+
 class DbusContainerManager(dbus.service.Object):
     def __init__(self, looper, bus, object_path, args):
         self.args = args
@@ -23,9 +30,13 @@ class DbusContainerManager(dbus.service.Object):
         dbus.service.Object.__init__(self, bus, object_path)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='a{ss}', out_signature='', sender_keyword="sender", connection_keyword="conn")
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='a{ss}',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
     def Start(self, session, sender, conn):
-        dbus_info = dbus.Interface(conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False), "org.freedesktop.DBus")
+        dbus_info = dbus.Interface(
+            conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False),
+            "org.freedesktop.DBus")
         uid = dbus_info.GetConnectionUnixUser(sender)
         if str(uid) not in ["0", session["user_id"]]:
             raise RuntimeError("Cannot start a session on behalf of another user")
@@ -34,30 +45,64 @@ class DbusContainerManager(dbus.service.Object):
             raise RuntimeError("Invalid session pid")
         do_start(self.args, session)
 
+    def _validate_session_owner(self, sender, conn):
+        """
+        Ensure the caller is either root or the user owning the currently
+        tracked session, mirroring the check in Start().
+
+        The PID check from Start() is intentionally not mirrored here: the
+        tracked session is already validated at Start() time, and legitimate
+        callers (e.g. "waydroid app install", "waydroid prop set", "waydroid
+        session stop") run in different processes than the session process.
+
+        :raises RuntimeError: when the caller is neither root nor the session
+                              owner
+        """
+        dbus_info = dbus.Interface(
+            conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False),
+            "org.freedesktop.DBus")
+        uid = str(dbus_info.GetConnectionUnixUser(sender))
+        if uid == "0":
+            return
+        if "session" not in self.args or uid != self.args.session["user_id"]:
+            raise RuntimeError("Cannot control a session on behalf of another user")
+
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='b', out_signature='')
-    def Stop(self, quit_session):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='b',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
+    def Stop(self, quit_session, sender, conn):
+        self._validate_session_owner(sender, conn)
         stop(self.args, quit_session)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='', out_signature='')
-    def Freeze(self):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
+    def Freeze(self, sender, conn):
         if not actions.initializer.is_initialized(self.args):
             raise RuntimeError("Waydroid is not initialized")
+        self._validate_session_owner(sender, conn)
         freeze(self.args)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='', out_signature='')
-    def Unfreeze(self):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
+    def Unfreeze(self, sender, conn):
         if not actions.initializer.is_initialized(self.args):
             raise RuntimeError("Waydroid is not initialized")
+        self._validate_session_owner(sender, conn)
         unfreeze(self.args)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='', out_signature='a{ss}')
-    def GetSession(self):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='',
+                         out_signature='a{ss}', sender_keyword="sender",
+                         connection_keyword="conn")
+    def GetSession(self, sender, conn):
         if not actions.initializer.is_initialized(self.args):
             raise RuntimeError("Waydroid is not initialized")
+        self._validate_session_owner(sender, conn)
         try:
             session = self.args.session
             session["state"] = helpers.lxc.status(self.args)
@@ -65,32 +110,46 @@ class DbusContainerManager(dbus.service.Object):
         except AttributeError:
             return {}
 
-def set_permissions(args, perm_list=None, mode="777"):
-    def chmod(path, mode):
-        if os.path.exists(path):
-            command = ["chmod", mode, "-R", path]
-            tools.helpers.run.user(args, command, check=False)
+# Device nodes that only the container's root processes (vendor HALs)
+# access. The container root holds DAC_OVERRIDE, so these can be tightened
+# to owner access; Android app processes never open them directly.
+SYSTEM_DEVICES = [
+    "/dev/Vcodec",
+    "/dev/MTK_SMI",
+    "/dev/mdp_sync",
+    "/dev/mtk_cmdq",
+    "/dev/pvr_sync",
+    "/sys/kernel/debug/sync/sw_sync",
+]
 
+# Device nodes Android app processes (arbitrary host UIDs without
+# DAC_OVERRIDE) may open directly; these must stay world-accessible, but
+# never executable.
+APP_DEVICES = [
+    "/dev/ashmem",
+    "/dev/ion",
+    "/dev/graphics",
+    "/dev/sw_sync",
+]
+
+
+def set_permissions(args, perm_list=None, mode="666", session=None):
+    """
+    Give the container access to host devices.
+
+    The container bind-mounts these host nodes read-write and runs without
+    user namespaces, so the mode bits are the boundary between Android and
+    the host. The container's root holds DAC_OVERRIDE and bypasses them;
+    Android app processes are ordinary host UIDs, so nodes they open
+    directly (ashmem, ion, DRM render nodes, framebuffers, video,
+    dma-heaps) get 0666 - world read/write, never executable. Nodes only
+    the container's root processes (vendor HALs) use get 0660. When a
+    session is available the nodes are also owned by the session user.
+    Only paths that exist are touched, and failures are non-fatal.
+    """
     # Nodes list
     if not perm_list:
-        perm_list = [
-            "/dev/ashmem",
-
-            # sw_sync for HWC
-            "/dev/sw_sync",
-            "/sys/kernel/debug/sync/sw_sync",
-
-            # Media
-            "/dev/Vcodec",
-            "/dev/MTK_SMI",
-            "/dev/mdp_sync",
-            "/dev/mtk_cmdq",
-
-            # Graphics
-            "/dev/graphics",
-            "/dev/pvr_sync",
-            "/dev/ion",
-        ]
+        perm_list = list(APP_DEVICES)
 
         # DRM render nodes
         perm_list.extend(glob.glob("/dev/dri/renderD*"))
@@ -101,8 +160,33 @@ def set_permissions(args, perm_list=None, mode="777"):
         # DMA-BUF Heaps
         perm_list.extend(glob.glob("/dev/dma_heap/*"))
 
+        perm_list.extend(SYSTEM_DEVICES)
+
     for path in perm_list:
-        chmod(path, mode)
+        if not os.path.exists(path):
+            continue
+        if session:
+            command = ["chown", session["user_id"] + ":" + session["group_id"],
+                       "-R", path]
+            tools.helpers.run.user(args, command, check=False)
+        path_mode = "660" if path in SYSTEM_DEVICES else mode
+        tools.helpers.run.user(args, ["chmod", path_mode, "-R", path], check=False)
+
+def wait_for_status(args, status, timeout=30):
+    """
+    Wait for the container to reach the given LXC status.
+
+    Polls the container status once per second instead of busy-waiting, and
+    raises a RuntimeError if the status is not reached within ``timeout``
+    seconds.
+    """
+    tries = 0
+    while helpers.lxc.status(args) != status:
+        if tries >= timeout:
+            raise RuntimeError(
+                "WayDroid container did not reach {} state within {} seconds".format(status, timeout))
+        tries += 1
+        time.sleep(1)
 
 def start(args):
     mainloop = GLib.MainLoop()
@@ -150,6 +234,103 @@ def prepare_drivers_once(args):
     ], "666")
     prepared_drivers = True
 
+def start_cgroup_lite_if_available(args):
+    """
+    Start Android init's "cgroup-lite" service on Halium hosts.
+
+    On Halium / Ubuntu Touch devices the host runs Android's init, which is
+    normally responsible for mounting the cgroup hierarchies. Waydroid
+    makes sure that service is running before the container starts, so the
+    container does not inherit a half-set-up cgroup tree. The command only
+    exists when Android init's ``start`` binary is on PATH; on regular
+    GNU/Linux hosts this is a no-op, as the host init system already
+    mounted cgroups.
+    """
+    if which("start"):
+        tools.helpers.run.user(args, ["start", "cgroup-lite"], check=False)
+
+def keep_schedtune_if_nestable(args):
+    """
+    Keep the host schedtune cgroup mounted only if the container can nest
+    its own cgroups inside it, and unmount it otherwise.
+
+    Ubuntu Touch hosts use the schedtune cgroup for CPU-boost tuning, and
+    Waydroid's Android keeps using that mechanism inside the container. LXC
+    mounts the host cgroup hierarchy into the container read-only
+    (lxc.mount.auto), which Android can only use if the hierarchy supports
+    nesting, i.e. if new cgroups can be created inside it. Some kernels
+    lack the nesting patch, and a non-nestable schedtune handed to Android
+    read-only would be broken.
+
+    Nesting support is probed by creating a throwaway subgroup hierarchy
+    (probe0/probe1). If creation succeeds the mount is kept; otherwise the
+    hierarchy is lazily unmounted so Android sets up its own schedtune in
+    the container. The probe directories are always removed afterwards.
+    """
+    if not os.path.ismount(SCHEDTUNE_PATH):
+        return
+
+    probe = SCHEDTUNE_PATH + "/probe0"
+    try:
+        os.makedirs(probe + "/probe1")
+    except OSError:
+        logging.debug("Host schedtune cgroup does not support nesting, unmounting it")
+        # The hierarchy may be busy for a moment (in-flight processes or a
+        # lingering child cgroup), so retry the lazy unmount briefly before
+        # giving up and handing the non-nestable hierarchy to the container.
+        code = 1
+        for attempt in range(3):
+            code = tools.helpers.run.user(
+                args, ["umount", "-l", SCHEDTUNE_PATH], check=False)
+            if code == 0:
+                break
+            time.sleep(1)
+        if code != 0:
+            logging.warning(
+                "Failed to unmount {} (last umount exited with {}); the container will "
+                "inherit a non-nestable schedtune hierarchy. See the README's "
+                "schedtune troubleshooting section.".format(SCHEDTUNE_PATH, code))
+    finally:
+        with suppress(OSError):
+            os.rmdir(probe + "/probe1")
+        with suppress(OSError):
+            os.rmdir(probe)
+
+def start_networking(args):
+    """
+    Bring up the container's private network (bridge, dnsmasq, NAT).
+
+    Runs ``data/scripts/waydroid-net.sh start``; failures raise, because
+    the container cannot function without networking.
+    """
+    tools.helpers.run.user(args, [WAYDROID_NET_SCRIPT, "start"])
+
+def stop_networking(args):
+    """Tear down the container's private network (best-effort)."""
+    tools.helpers.run.user(args, [WAYDROID_NET_SCRIPT, "stop"], check=False)
+
+def start_sensors(args):
+    """
+    Launch the host-side sensor daemon for the container.
+
+    ``waydroid-sensord`` forwards the device's sensors to Android over the
+    shared hwbinder. It is optional: if it is not installed, nothing runs.
+    """
+    if which("waydroid-sensord"):
+        tools.helpers.run.user(
+            args, ["waydroid-sensord", "/dev/" + args.HWBINDER_DRIVER], output="background")
+
+def stop_sensors(args):
+    """Stop the sensor daemon, killing every instance (best-effort)."""
+    if which("waydroid-sensord"):
+        command = ["pidof", "waydroid-sensord"]
+        pids = tools.helpers.run.user(args, command, check=False, output_return=True).strip()
+        if pids:
+            # pidof may return multiple PIDs (e.g. a stale daemon from a
+            # crashed session); kill them all.
+            command = ["kill", "-9"] + pids.split()
+            tools.helpers.run.user(args, command, check=False)
+
 def do_start(args, session):
     if not actions.initializer.is_initialized(args):
         raise RuntimeError("Waydroid is not initialized")
@@ -161,45 +342,14 @@ def do_start(args, session):
 
     logging.info("Starting up container for a new session")
 
-    # Networking
-    command = [tools.config.tools_src +
-               "/data/scripts/waydroid-net.sh", "start"]
-    tools.helpers.run.user(args, command)
+    start_networking(args)
+    start_sensors(args)
+    start_cgroup_lite_if_available(args)
 
-    # Sensors
-    if which("waydroid-sensord"):
-        tools.helpers.run.user(
-            args, ["waydroid-sensord", "/dev/" + args.HWBINDER_DRIVER], output="background")
-
-    # Cgroup hacks
-    if which("start"):
-        command = ["start", "cgroup-lite"]
-        tools.helpers.run.user(args, command, check=False)
-
-    # Keep schedtune around in case nesting is supported
-    if os.path.ismount("/sys/fs/cgroup/schedtune"):
-        try:
-            os.mkdir("/sys/fs/cgroup/schedtune/probe0")
-            os.mkdir("/sys/fs/cgroup/schedtune/probe0/probe1")
-        except OSError:
-            command = ["umount", "-l", "/sys/fs/cgroup/schedtune"]
-            tools.helpers.run.user(args, command, check=False)
-        finally:
-            if os.path.exists("/sys/fs/cgroup/schedtune/probe0/probe1"):
-                os.rmdir("/sys/fs/cgroup/schedtune/probe0/probe1")
-            if os.path.exists("/sys/fs/cgroup/schedtune/probe0"):
-                os.rmdir("/sys/fs/cgroup/schedtune/probe0")
-
-    #TODO: remove NFC hacks
-    if which("stop"):
-        command = ["stop", "nfcd"]
-        tools.helpers.run.user(args, command, check=False)
-    elif which("systemctl") and (tools.helpers.run.user(args, ["systemctl", "is-active", "-q", "nfcd"], check=False) == 0):
-        command = ["systemctl", "stop", "nfcd"]
-        tools.helpers.run.user(args, command, check=False)
+    keep_schedtune_if_nestable(args)
 
     # Set permissions
-    set_permissions(args)
+    set_permissions(args, session=session)
 
     # Create session-specific LXC config file
     helpers.lxc.generate_session_lxc_config(args, session)
@@ -231,29 +381,16 @@ def stop(args, quit_session=True):
         status = helpers.lxc.status(args)
         if status != "STOPPED":
             helpers.lxc.stop(args)
-            while helpers.lxc.status(args) != "STOPPED":
-                pass
+            try:
+                wait_for_status(args, "STOPPED")
+            except RuntimeError as e:
+                # Best-effort teardown: keep cleaning up even if the container
+                # did not stop in time (the rootfs umount below will fail with
+                # EBUSY in that case, and is caught by the outer handler).
+                logging.error("%s; continuing with cleanup", e)
 
-        # Networking
-        command = [tools.config.tools_src +
-                   "/data/scripts/waydroid-net.sh", "stop"]
-        tools.helpers.run.user(args, command, check=False)
-
-        #TODO: remove NFC hacks
-        if which("start"):
-            command = ["start", "nfcd"]
-            tools.helpers.run.user(args, command, check=False)
-        elif which("systemctl") and (tools.helpers.run.user(args, ["systemctl", "is-enabled", "-q", "nfcd"], check=False) == 0):
-            command = ["systemctl", "start", "nfcd"]
-            tools.helpers.run.user(args, command, check=False)
-
-        # Sensors
-        if which("waydroid-sensord"):
-            command = ["pidof", "waydroid-sensord"]
-            pid = tools.helpers.run.user(args, command, check=False, output_return=True).strip()
-            if pid:
-                command = ["kill", "-9", pid]
-                tools.helpers.run.user(args, command, check=False)
+        stop_networking(args)
+        stop_sensors(args)
 
         # Umount rootfs
         helpers.images.umount_rootfs(args)
@@ -283,8 +420,7 @@ def freeze(args):
     status = helpers.lxc.status(args)
     if status == "RUNNING":
         helpers.lxc.freeze(args)
-        while helpers.lxc.status(args) == "RUNNING":
-            pass
+        wait_for_status(args, "FROZEN")
     else:
         logging.error("WayDroid container is {}".format(status))
 
@@ -292,5 +428,6 @@ def unfreeze(args):
     status = helpers.lxc.status(args)
     if status == "FROZEN":
         helpers.lxc.unfreeze(args)
-        while helpers.lxc.status(args) == "FROZEN":
-            pass
+        wait_for_status(args, "RUNNING")
+    else:
+        logging.error("WayDroid container is {}".format(status))

--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -8,9 +8,6 @@ import stat
 import sys
 import threading
 import multiprocessing
-import select
-import queue
-import time
 import dbus
 import dbus.service
 import argparse
@@ -19,22 +16,39 @@ from gi.repository import GLib
 def is_initialized(args):
     return os.path.isfile(args.config) and os.path.isdir(tools.config.defaults["rootfs"])
 
+def _int_or_none(value):
+    """Parse an Android version prop as int, or None if absent/garbage."""
+    try:
+        return int(value)
+    except ValueError:
+        # Non-numeric props (e.g. "29.0") must not crash init; treat them
+        # as absent so detection falls back to the next source or MAINLINE.
+        logging.debug("Ignoring non-numeric Android version prop: %r", value)
+        return None
+
 def get_vendor_type(args):
+    """
+    Detect the vendor type from host props (Halium versions, or MAINLINE).
+
+    Uses ro.vndk.version primarily (vndk 20+ maps to Halium N), falling
+    back to ro.vendor.build.version.sdk for Halium 15+ images that no
+    longer expose ro.vndk.version.
+    """
     vndk_str = helpers.props.host_get(args, "ro.vndk.version")
     vendorapi_str = helpers.props.host_get(args, "ro.vendor.build.version.sdk")
     ret = "MAINLINE"
-    if vndk_str != "":
-        vndk = int(vndk_str)
+    vndk = _int_or_none(vndk_str)
+    if vndk is not None:
         if vndk > 19:
             halium_ver = vndk - 19
             if vndk > 31:
-                halium_ver -= 1 # 12L -> Halium 12
+                halium_ver -= 1  # 12L -> Halium 12
             ret = "HALIUM_" + str(halium_ver)
             if vndk == 32:
                 ret += "L"
-    elif vendorapi_str != "":
-        vendorapi = int(vendorapi_str)
-        if vendorapi > 32:
+    else:
+        vendorapi = _int_or_none(vendorapi_str)
+        if vendorapi is not None and vendorapi > 32:
             halium_ver = vendorapi - 20
             ret = "HALIUM_" + str(halium_ver)
 
@@ -187,7 +201,9 @@ class DbusInitializer(dbus.service.Object):
         dbus.service.Object.__init__(self, bus, object_path)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.Initializer", in_signature='a{ss}', out_signature='', sender_keyword="sender", connection_keyword="conn")
+    @dbus.service.method("id.waydro.Initializer", in_signature='a{ss}',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
     def Init(self, params, sender=None, conn=None):
         if self.worker_thread is not None:
             self.worker_thread.kill()
@@ -221,9 +237,14 @@ class DbusInitializer(dbus.service.Object):
         pass
 
 def ensure_polkit_auth(sender, conn, privilege):
-    dbus_info = dbus.Interface(conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False), "org.freedesktop.DBus")
+    dbus_info = dbus.Interface(
+        conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False),
+        "org.freedesktop.DBus")
     pid = dbus_info.GetConnectionUnixProcessID(sender)
-    polkit = dbus.Interface(dbus.SystemBus().get_object("org.freedesktop.PolicyKit1", "/org/freedesktop/PolicyKit1/Authority", False), "org.freedesktop.PolicyKit1.Authority")
+    polkit = dbus.Interface(
+        dbus.SystemBus().get_object("org.freedesktop.PolicyKit1",
+                                    "/org/freedesktop/PolicyKit1/Authority", False),
+        "org.freedesktop.PolicyKit1.Authority")
     try:
         (is_auth, _, _) = polkit.CheckAuthorization(
             ("unix-process", {

--- a/tools/actions/session_manager.py
+++ b/tools/actions/session_manager.py
@@ -11,7 +11,6 @@ import dbus
 import dbus.service
 import dbus.exceptions
 from gi.repository import GLib
-import copy
 
 class DbusSessionManager(dbus.service.Object):
     def __init__(self, looper, bus, object_path, args):
@@ -46,11 +45,16 @@ def start(args, unlocked_cb=None, background=True):
             unlocked_cb()
         return
 
-    session = copy.copy(tools.config.session_defaults)
+    session = tools.config.get_session_defaults()
 
-    # TODO: also support WAYLAND_SOCKET?
     wayland_display = session["wayland_display"]
-    if wayland_display == "None" or not wayland_display:
+    wayland_socket_env = os.getenv("WAYLAND_SOCKET")
+    if wayland_socket_env:
+        # WAYLAND_SOCKET points directly at the compositor socket (a full
+        # path or a socket name relative to XDG_RUNTIME_DIR); it takes
+        # precedence over WAYLAND_DISPLAY, mirroring libwayland clients.
+        wayland_display = session["wayland_display"] = wayland_socket_env
+    elif wayland_display == "None" or not wayland_display:
         logging.warning('WAYLAND_DISPLAY is not set, defaulting to "wayland-0"')
         wayland_display = session["wayland_display"] = "wayland-0"
 

--- a/tools/actions/upgrader.py
+++ b/tools/actions/upgrader.py
@@ -17,10 +17,15 @@ def get_config(args):
 
 def migration(args):
     try:
-        old_ver = tools.helpers.props.file_get(args, args.work + "/waydroid_base.prop", "waydroid.tools_version")
+        old_ver = tools.helpers.props.file_get(
+            args, args.work + "/waydroid_base.prop", "waydroid.tools_version")
         if versiontuple(old_ver) <= versiontuple("1.3.4"):
-            chmod_paths = ["cache_http", "host-permissions", "lxc", "images", "rootfs", "data", "waydroid_base.prop", "waydroid.prop", "waydroid.cfg"]
-            tools.helpers.run.user(args, ["chmod", "-R", "g-w,o-w"] + [os.path.join(args.work, f) for f in chmod_paths], check=False)
+            chmod_paths = ["cache_http", "host-permissions", "lxc", "images",
+                           "rootfs", "data", "waydroid_base.prop", "waydroid.prop",
+                           "waydroid.cfg"]
+            tools.helpers.run.user(
+                args, ["chmod", "-R", "g-w,o-w"] +
+                [os.path.join(args.work, f) for f in chmod_paths], check=False)
             tools.helpers.run.user(args, ["chmod", "g-w,o-w", args.work], check=False)
             os.remove(os.path.join(args.work, "session.cfg"))
         if versiontuple(old_ver) <= versiontuple("1.6.0"):
@@ -28,6 +33,21 @@ def migration(args):
             cfg = tools.config.load(args)
             cfg["waydroid"]["auto_adb"] = "False"
             tools.config.save(args, cfg)
+        if versiontuple(old_ver) <= versiontuple("1.6.3"):
+            # Persist the binder node names that were introduced in 1.6.x so
+            # package upgrades don't rely on the runtime fallback in
+            # drivers.loadBinderNodes on every boot.
+            cfg = tools.config.load(args)
+            waydroid_cfg = cfg["waydroid"]
+            defaults = {"binder": "binder", "vndbinder": "vndbinder",
+                        "hwbinder": "hwbinder"}
+            changed = False
+            for key, value in defaults.items():
+                if key not in waydroid_cfg:
+                    waydroid_cfg[key] = value
+                    changed = True
+            if changed:
+                tools.config.save(args, cfg)
     except Exception as e:
         logging.debug("Error during migration: %s", e)
 
@@ -51,7 +71,9 @@ def upgrade(args):
         if args.images_path not in tools.config.defaults["preinstalled_images_paths"]:
             helpers.images.get(args)
         else:
-            logging.info("Upgrade refused because Waydroid was configured to load pre-installed image from {}.".format(args.images_path))
+            logging.info(
+                "Upgrade refused because Waydroid was configured to load "
+                "pre-installed image from {}.".format(args.images_path))
     helpers.drivers.probeAshmemDriver(args)
     helpers.lxc.setup_host_perms(args)
     helpers.lxc.set_lxc_config(args)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -9,10 +9,12 @@ import pwd
 from tools.config.load import load, load_channels
 from tools.config.save import save
 
+__all__ = ["load", "load_channels", "save"]
+
 #
 # Exported variables (internal configuration)
 #
-version = "1.6.3"
+version = "1.6.4"
 tools_src = os.path.normpath(os.path.realpath(__file__) + "/../../..")
 
 # Keys saved in the config file (mostly what we ask in 'waydroid init')
@@ -25,9 +27,7 @@ config_keys = ["arch",
                "mount_overlays",
                "auto_adb"]
 
-# Config file/commandline default values
-# $WORK gets replaced with the actual value for args.work (which may be
-# overridden on the commandline)
+# Config file default values
 defaults = {
     "arch": "arm64",
     "work": "/var/lib/waydroid",
@@ -54,24 +54,33 @@ defaults["lxc"] = defaults["work"] + "/lxc"
 defaults["host_perms"] = defaults["work"] + "/host-permissions"
 defaults["container_pulse_runtime_path"] = defaults["container_xdg_runtime_dir"] + "/pulse"
 
-session_defaults = {
-    "user_name": pwd.getpwuid(os.getuid()).pw_name,
-    "user_id": str(os.getuid()),
-    "group_id": str(os.getgid()),
-    "host_user": os.path.expanduser("~"),
-    "pid": str(os.getpid()),
-    "xdg_data_home": str(os.environ.get('XDG_DATA_HOME', os.path.expanduser("~") + "/.local/share")),
-    "xdg_runtime_dir": str(os.environ.get('XDG_RUNTIME_DIR')),
-    "wayland_display": str(os.environ.get('WAYLAND_DISPLAY')),
-    "pulse_runtime_path": str(os.environ.get('PULSE_RUNTIME_PATH')),
-    "state": "STOPPED",
-    "lcd_density": "0",
-    "background_start": "true"
-}
-session_defaults["waydroid_user_state"] = session_defaults["xdg_data_home"] + "/waydroid"
-session_defaults["waydroid_data"] = session_defaults["waydroid_user_state"] + "/data"
-if session_defaults["pulse_runtime_path"] == "None":
-    session_defaults["pulse_runtime_path"] = session_defaults["xdg_runtime_dir"] + "/pulse"
+def get_session_defaults():
+    """
+    Build a fresh session-defaults dict from the current environment.
+
+    This must be called at session-start time, not at import time, so the
+    values (WAYLAND_DISPLAY, XDG_RUNTIME_DIR, ...) reflect the compositor
+    environment that is actually running.
+    """
+    session = {
+        "user_name": pwd.getpwuid(os.getuid()).pw_name,
+        "user_id": str(os.getuid()),
+        "group_id": str(os.getgid()),
+        "host_user": os.path.expanduser("~"),
+        "pid": str(os.getpid()),
+        "xdg_data_home": str(os.environ.get('XDG_DATA_HOME', os.path.expanduser("~") + "/.local/share")),
+        "xdg_runtime_dir": str(os.environ.get('XDG_RUNTIME_DIR')),
+        "wayland_display": str(os.environ.get('WAYLAND_DISPLAY')),
+        "pulse_runtime_path": str(os.environ.get('PULSE_RUNTIME_PATH')),
+        "state": "STOPPED",
+        "lcd_density": "0",
+        "background_start": "true"
+    }
+    session["waydroid_user_state"] = session["xdg_data_home"] + "/waydroid"
+    session["waydroid_data"] = session["waydroid_user_state"] + "/data"
+    if session["pulse_runtime_path"] == "None":
+        session["pulse_runtime_path"] = session["xdg_runtime_dir"] + "/pulse"
+    return session
 
 channels_defaults = {
     "config_path": "/usr/share/waydroid-extra/channels.cfg",

--- a/tools/helpers/__init__.py
+++ b/tools/helpers/__init__.py
@@ -13,3 +13,10 @@ import tools.helpers.gpu
 import tools.helpers.protocol
 import tools.helpers.version
 import tools.helpers.logging
+import tools.helpers.run
+import tools.helpers.net
+import tools.helpers.arm_translation
+
+__all__ = ["tools", "arguments", "arch", "props", "lxc", "images",
+           "drivers", "mount", "http", "ipc", "gpu", "protocol",
+           "version", "logging", "run", "net", "arm_translation"]

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -11,11 +11,9 @@ import tools.config
 
 """ This file is about parsing command line arguments passed to waydroid, as
     well as generating the help pages (waydroid -h). All this is done with
-    Python's argparse. The parsed arguments get extended and finally stored in
-    the "args" variable, which is prominently passed to most functions all
-    over the waydroid code base.
-
-    See tools/helpers/args.py for more information about the args variable. """
+    Python's argparse. The parsed arguments get extended in tools/__init__.py
+    (see prep_args) and finally stored in the "args" variable, which is
+    prominently passed to most functions all over the waydroid code base. """
 
 def arguments_init(subparser):
     ret = subparser.add_parser("init", help="set up waydroid specific"
@@ -106,17 +104,34 @@ def arguments_fullUI(subparser):
     return ret
 
 def arguments_firstLaunch(subparser):
-    ret = subparser.add_parser("first-launch", help="start waydroid, prompting to initialize waydroid first if necessary (default)")
+    ret = subparser.add_parser(
+        "first-launch",
+        help="start waydroid, prompting to initialize waydroid first if necessary (default)")
     return ret
 
 def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
     ret.add_argument("-u", "--uid", help="the UID to run as (also sets GID to the same value if -g is not set)")
     ret.add_argument("-g", "--gid", help="the GID to run as")
-    ret.add_argument("-s", "--context", help="transition to the specified SELinux or AppArmor security context. No-op if -L is supplied.")
-    ret.add_argument("-L", "--nolsm", action="store_true", help="tell LXC not to perform security domain transition related to mandatory access control (e.g. SELinux, AppArmor). If this option is supplied, LXC won't apply a container-wide seccomp filter to the executed program. This is a dangerous option that can result in leaking privileges to the container!!!")
-    ret.add_argument("-C", "--allcaps", action="store_true", help="tell LXC not to drop capabilities. This is a dangerous option that can result in leaking privileges to the container!!!")
-    ret.add_argument("-G", "--nocgroup", action="store_true", help="tell LXC not to switch to the container cgroup. This is a dangerous option that can result in leaking privileges to the container!!!")
+    ret.add_argument(
+        "-s", "--context",
+        help="transition to the specified SELinux or AppArmor security context. "
+             "No-op if -L is supplied.")
+    ret.add_argument(
+        "-L", "--nolsm", action="store_true",
+        help="tell LXC not to perform security domain transition related to mandatory "
+             "access control (e.g. SELinux, AppArmor). If this option is supplied, LXC "
+             "won't apply a container-wide seccomp filter to the executed program. "
+             "This is a dangerous option that can result in leaking privileges to the "
+             "container!!!")
+    ret.add_argument(
+        "-C", "--allcaps", action="store_true",
+        help="tell LXC not to drop capabilities. This is a dangerous option that can "
+             "result in leaking privileges to the container!!!")
+    ret.add_argument(
+        "-G", "--nocgroup", action="store_true",
+        help="tell LXC not to switch to the container cgroup. This is a dangerous "
+             "option that can result in leaking privileges to the container!!!")
     ret.add_argument('COMMAND', nargs='*', help="command to run")
     return ret
 
@@ -134,6 +149,24 @@ def arguments_adb(subparser):
 
 def arguments_bugreport(subparser):
     ret = subparser.add_parser("bugreport", help="create a bugreport archive interactively")
+    return ret
+
+def arguments_arm_translation(subparser):
+    ret = subparser.add_parser(
+        "arm-translation",
+        help="manage the ARM64 translation layer (libndk_translation) "
+             "for running ARM apps on x86_64 hosts")
+    sub = ret.add_subparsers(title="subaction", dest="subaction")
+    install = sub.add_parser("install",
+                             help="install the ARM translation layer")
+    install.add_argument("--source",
+                         help="directory with the artifacts (system/... layout)")
+    install.add_argument("--archive",
+                         help="path to a .tar/.tar.gz/.tar.xz/.zip archive")
+    install.add_argument("--url",
+                         help="URL of an archive to download")
+    sub.add_parser("status", help="show the ARM translation state")
+    sub.add_parser("uninstall", help="remove the ARM translation layer")
     return ret
 
 def arguments():
@@ -173,6 +206,7 @@ def arguments():
     arguments_logcat(sub)
     arguments_adb(sub)
     arguments_bugreport(sub)
+    arguments_arm_translation(sub)
 
     if argcomplete:
         argcomplete.autocomplete(parser, always_complete_options="long")

--- a/tools/helpers/arm_translation.py
+++ b/tools/helpers/arm_translation.py
@@ -7,57 +7,133 @@ On x86_64 hosts the Android image is x86_64, but many apps ship ARM-only
 binaries. libndk_translation (Google's open-source ARM translator, used by
 ChromeOS and the Android emulator) runs them through Android's native
 bridge mechanism. The artifacts live under ``work/arm-translation`` and are
-bind-mounted into the container's /system at session start; the
-``ro.dalvik.vm.native.bridge`` property is set by
-``tools/helpers/lxc.py:make_base_props`` when they are installed.
+bind-mounted into the container's /system at session start.
 
-Artifact layout (mirrors the container paths under /system):
+Artifact layout (mirrors the container paths under /system; this is the
+layout of the community prebuilt used by waydroid_script, hosted at
+supremegamers/vendor_google_proprietary_ndk_translation-prebuilt):
 
     arm-translation/system/lib64/libndk_translation.so
-    arm-translation/system/lib64/libndk_translation_proxy.so
-    arm-translation/system/lib64/ndk_translation/libarm.so     (32-bit)
-    arm-translation/system/lib64/ndk_translation/libarm64.so   (64-bit)
-    arm-translation/system/lib/ndk_translation/...             (optional)
+    arm-translation/system/lib64/libndk_translation_proxy_lib*.so
+    arm-translation/system/lib64/libndk_translation_exec_region.so
+    arm-translation/system/lib64/arm64/*.so        (ARM64 system libs)
+    arm-translation/system/lib/libndk_translation.so
+    arm-translation/system/lib/arm/*.so            (ARM32 system libs)
+    arm-translation/system/bin/arm{,64}/            (ARM linker/app_process)
+    arm-translation/system/etc/init/ndk_translation.rc
+    arm-translation/system/etc/binfmt_misc/
+    arm-translation/system/etc/{cpuinfo,ld.config}.arm{,64}.txt
 
-libndk_translation is Apache-2.0. Common sources for prebuilt sets are
-ChromeOS "guybrush" firmware images (what waydroid_script uses) or
-Android-x86 images that ship the translator.
+libndk_translation is Apache-2.0.
 """
 
 import os
+import shutil
 
 import tools.config
 
 # Directory under work/ holding the artifacts (mirrors container /system)
 ARM_TRANSLATION_DIR = tools.config.defaults["work"] + "/arm-translation"
 
+# Default source of prebuilt artifacts (Android 13, i.e. the current
+# official Waydroid image). Hosted on GitHub by the same project that
+# waydroid_script consumes; md5 verified below before installing.
+DEFAULT_ARCHIVE_URL = ("https://github.com/supremegamers/"
+                       "vendor_google_proprietary_ndk_translation-prebuilt/"
+                       "archive/68734c52556d3d7a6db34c603dd9276915c29f2f.zip")
+DEFAULT_ARCHIVE_MD5 = "0b2207c490fcb400aa5c87fcf0d52d38"
+
 # Files that must be present for the layer to be considered installed.
-# libarm64.so is the core; libarm.so (32-bit apps) and the rest are optional.
 REQUIRED = [
     "system/lib64/libndk_translation.so",
-    "system/lib64/libndk_translation_proxy.so",
-    "system/lib64/ndk_translation/libarm64.so",
+    "system/lib64/arm64/libc.so",
+    "system/etc/init/ndk_translation.rc",
 ]
 
-# (relative path under ARM_TRANSLATION_DIR, container path, mount kind)
-# Only paths that exist are mounted; "dir" entries use create=dir so the
-# mount target is created inside the container.
+# Native bridge properties that must be set for the layer to work.
+# ro.dalvik.vm.isa.arm{,64} map the emulated ISA to the host ISA; ART and
+# the ndk_translation.rc binfmt_misc registration depend on them.
+NATIVE_BRIDGE_PROPS = [
+    "ro.dalvik.vm.native.bridge=libndk_translation.so",
+    "ro.product.cpu.abilist=x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist64=x86_64,arm64-v8a",
+    "ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi",
+    "ro.product.cpu.abi=x86_64",
+    "ro.dalvik.vm.isa.arm=x86",
+    "ro.dalvik.vm.isa.arm64=x86_64",
+    "ro.enable.native.bridge.exec=1",
+    "ro.vendor.enable.native.bridge.exec=1",
+    "ro.vendor.enable.native.bridge.exec64=1",
+    "ro.ndk_translation.version=0.2.3",
+]
+
+# (relative path under ARM_TRANSLATION_DIR, container path)
+# Directory entries are bind-mounted with create=dir so the mount target is
+# created inside the container; files use create=file. Everything under the
+# two lib trees is covered by the dir mounts plus the per-file entries here.
 MOUNT_ENTRIES = [
     ("system/lib64/libndk_translation.so",
      "system/lib64/libndk_translation.so", "file"),
-    ("system/lib64/libndk_translation_proxy.so",
-     "system/lib64/libndk_translation_proxy.so", "file"),
-    ("system/lib64/ndk_translation",
-     "system/lib64/ndk_translation", "dir"),
-    ("system/lib/ndk_translation",
-     "system/lib/ndk_translation", "dir"),
+    ("system/lib64/libndk_translation_exec_region.so",
+     "system/lib64/libndk_translation_exec_region.so", "file"),
+    ("system/lib64/arm64", "system/lib64/arm64", "dir"),
+    ("system/lib/libndk_translation.so",
+     "system/lib/libndk_translation.so", "file"),
+    ("system/lib/libndk_translation_exec_region.so",
+     "system/lib/libndk_translation_exec_region.so", "file"),
+    ("system/lib/arm", "system/lib/arm", "dir"),
+    ("system/bin/arm", "system/bin/arm", "dir"),
+    ("system/bin/arm64", "system/bin/arm64", "dir"),
+    ("system/etc/init/ndk_translation.rc",
+     "system/etc/init/ndk_translation.rc", "file"),
+    ("system/etc/binfmt_misc", "system/etc/binfmt_misc", "dir"),
+    ("system/etc/cpuinfo.arm.txt",
+     "system/etc/cpuinfo.arm.txt", "file"),
+    ("system/etc/cpuinfo.arm64.txt",
+     "system/etc/cpuinfo.arm64.txt", "file"),
+    ("system/etc/ld.config.arm.txt",
+     "system/etc/ld.config.arm.txt", "file"),
+    ("system/etc/ld.config.arm64.txt",
+     "system/etc/ld.config.arm64.txt", "file"),
 ]
+
+# Proxy libs in lib/ and lib64/ are synced into the overlay individually.
+# They carry libndk_translation_proxy_lib*.so; globbed at session start.
+PROXY_LIB_DIRS = ["system/lib", "system/lib64"]
 
 
 def is_installed():
     """True when a usable ARM64 translation layer is present."""
     return all(os.path.isfile(ARM_TRANSLATION_DIR + "/" + rel)
                for rel in REQUIRED)
+
+
+def sync_to_overlay():
+    """Copy the installed artifacts into the container's /system overlay.
+
+    The container's /system overlay is mounted read-only, so bind-mounting
+    into it at session start fails silently (the mount targets cannot be
+    created on a ro filesystem). Instead, mirror waydroid_script: copy the
+    artifact tree into the overlay lowerdir (defaults["overlay"]/system),
+    which is host-writable while the container is stopped, before the
+    overlay is mounted at container start.
+
+    Must run as root before mount_rootfs(). No-ops when nothing is
+    installed.
+    """
+    if not is_installed():
+        return
+    overlay_dir = tools.config.defaults["overlay"] + "/system"
+    os.makedirs(overlay_dir, exist_ok=True)
+    source = ARM_TRANSLATION_DIR + "/system"
+    for name in os.listdir(source):
+        src_path = os.path.join(source, name)
+        dst_path = os.path.join(overlay_dir, name)
+        if os.path.isdir(src_path):
+            shutil.rmtree(dst_path, ignore_errors=True)
+            shutil.copytree(src_path, dst_path)
+        else:
+            shutil.copy2(src_path, dst_path)
 
 
 def mount_entries():
@@ -67,4 +143,13 @@ def mount_entries():
         host_path = ARM_TRANSLATION_DIR + "/" + rel
         if os.path.exists(host_path):
             ret.append((host_path, container_path, kind))
+    # The many libndk_translation_proxy_lib*.so files
+    for rel_dir in PROXY_LIB_DIRS:
+        host_dir = ARM_TRANSLATION_DIR + "/" + rel_dir
+        if not os.path.isdir(host_dir):
+            continue
+        for name in sorted(os.listdir(host_dir)):
+            if name.startswith("libndk_translation_proxy_lib"):
+                host_path = host_dir + "/" + name
+                ret.append((host_path, rel_dir + "/" + name, "file"))
     return ret

--- a/tools/helpers/arm_translation.py
+++ b/tools/helpers/arm_translation.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+ARM64 translation layer (libndk_translation) support.
+
+On x86_64 hosts the Android image is x86_64, but many apps ship ARM-only
+binaries. libndk_translation (Google's open-source ARM translator, used by
+ChromeOS and the Android emulator) runs them through Android's native
+bridge mechanism. The artifacts live under ``work/arm-translation`` and are
+bind-mounted into the container's /system at session start; the
+``ro.dalvik.vm.native.bridge`` property is set by
+``tools/helpers/lxc.py:make_base_props`` when they are installed.
+
+Artifact layout (mirrors the container paths under /system):
+
+    arm-translation/system/lib64/libndk_translation.so
+    arm-translation/system/lib64/libndk_translation_proxy.so
+    arm-translation/system/lib64/ndk_translation/libarm.so     (32-bit)
+    arm-translation/system/lib64/ndk_translation/libarm64.so   (64-bit)
+    arm-translation/system/lib/ndk_translation/...             (optional)
+
+libndk_translation is Apache-2.0. Common sources for prebuilt sets are
+ChromeOS "guybrush" firmware images (what waydroid_script uses) or
+Android-x86 images that ship the translator.
+"""
+
+import os
+
+import tools.config
+
+# Directory under work/ holding the artifacts (mirrors container /system)
+ARM_TRANSLATION_DIR = tools.config.defaults["work"] + "/arm-translation"
+
+# Files that must be present for the layer to be considered installed.
+# libarm64.so is the core; libarm.so (32-bit apps) and the rest are optional.
+REQUIRED = [
+    "system/lib64/libndk_translation.so",
+    "system/lib64/libndk_translation_proxy.so",
+    "system/lib64/ndk_translation/libarm64.so",
+]
+
+# (relative path under ARM_TRANSLATION_DIR, container path, mount kind)
+# Only paths that exist are mounted; "dir" entries use create=dir so the
+# mount target is created inside the container.
+MOUNT_ENTRIES = [
+    ("system/lib64/libndk_translation.so",
+     "system/lib64/libndk_translation.so", "file"),
+    ("system/lib64/libndk_translation_proxy.so",
+     "system/lib64/libndk_translation_proxy.so", "file"),
+    ("system/lib64/ndk_translation",
+     "system/lib64/ndk_translation", "dir"),
+    ("system/lib/ndk_translation",
+     "system/lib/ndk_translation", "dir"),
+]
+
+
+def is_installed():
+    """True when a usable ARM64 translation layer is present."""
+    return all(os.path.isfile(ARM_TRANSLATION_DIR + "/" + rel)
+               for rel in REQUIRED)
+
+
+def mount_entries():
+    """(host path, container path, kind) triples for the session LXC config."""
+    ret = []
+    for rel, container_path, kind in MOUNT_ENTRIES:
+        host_path = ARM_TRANSLATION_DIR + "/" + rel
+        if os.path.exists(host_path):
+            ret.append((host_path, container_path, kind))
+    return ret

--- a/tools/helpers/drivers.py
+++ b/tools/helpers/drivers.py
@@ -168,9 +168,10 @@ def setupBinderNodes(args):
 
 def loadBinderNodes(args):
     cfg = tools.config.load(args)
-    args.BINDER_DRIVER = cfg["waydroid"]["binder"]
-    args.VNDBINDER_DRIVER = cfg["waydroid"]["vndbinder"]
-    args.HWBINDER_DRIVER = cfg["waydroid"]["hwbinder"]
-    # These might not be in cfg on package upgrade
+    # The binder node names and the protocol versions might not be in the
+    # config on package upgrade, so fall back to the standard names.
+    args.BINDER_DRIVER = cfg["waydroid"].get("binder", "binder")
+    args.VNDBINDER_DRIVER = cfg["waydroid"].get("vndbinder", "vndbinder")
+    args.HWBINDER_DRIVER = cfg["waydroid"].get("hwbinder", "hwbinder")
     args.BINDER_PROTOCOL = cfg["waydroid"].get("binder_protocol")
     args.SERVICE_MANAGER_PROTOCOL = cfg["waydroid"].get("service_manager_protocol")

--- a/tools/helpers/ipc.py
+++ b/tools/helpers/ipc.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Currently implemented as FIFO
-import os
 import dbus
 
 def DBusContainerService(object_path="/ContainerManager", intf="id.waydro.ContainerManager"):

--- a/tools/helpers/logging.py
+++ b/tools/helpers/logging.py
@@ -3,7 +3,6 @@
 import logging
 from logging.handlers import RotatingFileHandler
 import os
-import sys
 import functools
 from contextlib import suppress
 

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -371,10 +371,18 @@ def make_base_props(args):
         props.append("ro.build.fingerprint=" + prop_fp)
 
     # On x86_64 hosts with the ARM translation layer installed, tell Android
-    # to use the native bridge so ARM-only apps can run. The [properties]
-    # section below can still override this if needed.
+    # to use the native bridge so ARM-only apps can run, and advertise the
+    # emulated ABIs. Advertising arm64-v8a/armeabi-v7a/armeabi in
+    # ro.product.cpu.abilist is what makes both the local PackageManager
+    # accept ARM APKs (INSTALL_FAILED_NO_MATCHING_ABIS) and the Play
+    # delivery check (Aurora's device profile "Platforms") serve them at
+    # all. The [properties] section below can still override any of these.
     if tools.helpers.arm_translation.is_installed():
         props.append("ro.dalvik.vm.native.bridge=libndk_translation.so")
+        props.append("ro.product.cpu.abilist=x86_64,x86,arm64-v8a,armeabi-v7a,armeabi")
+        props.append("ro.product.cpu.abilist64=x86_64,arm64-v8a")
+        props.append("ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi")
+        props.append("ro.product.cpu.abi=x86_64")
 
     # now append/override with values in [properties] section of waydroid.cfg
     cfg = tools.config.load(args)

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -170,7 +170,10 @@ def set_lxc_config(args):
     command = ["cp", "-fpr", seccomp_profile, lxc_path + "/waydroid.seccomp"]
     tools.helpers.run.user(args, command)
     if get_apparmor_status(args):
-        command = ["sed", "-i", "-E", "/lxc.aa_profile|lxc.apparmor.profile/ s/unconfined/{}/g".format(LXC_APPARMOR_PROFILE), lxc_path + "/config"]
+        command = ["sed", "-i", "-E",
+                   "/lxc.aa_profile|lxc.apparmor.profile/ s/unconfined/{}/g".format(
+                       LXC_APPARMOR_PROFILE),
+                   lxc_path + "/config"]
         tools.helpers.run.user(args, command)
 
     nodes = generate_nodes_lxc_config(args)
@@ -200,7 +203,9 @@ def generate_session_lxc_config(args, session):
         raise OSError("Failed to create XDG_RUNTIME_DIR mount point")
 
     wayland_host_socket = os.path.realpath(os.path.join(session["xdg_runtime_dir"], session["wayland_display"]))
-    wayland_container_socket = os.path.realpath(os.path.join(tools.config.defaults["container_xdg_runtime_dir"], tools.config.defaults["container_wayland_display"]))
+    wayland_container_socket = os.path.realpath(os.path.join(
+        tools.config.defaults["container_xdg_runtime_dir"],
+        tools.config.defaults["container_wayland_display"]))
     if not make_entry(wayland_host_socket, wayland_container_socket[1:]):
         raise OSError("Failed to bind Wayland socket")
 
@@ -211,6 +216,14 @@ def generate_session_lxc_config(args, session):
 
     if not make_entry(session["waydroid_data"], "data", options="rbind 0 0"):
         raise OSError("Failed to bind userdata")
+
+    # ARM64 translation layer (x86_64 hosts): bind the installed
+    # libndk_translation artifacts into the container's /system so Android's
+    # native bridge can load them. No-ops when nothing is installed.
+    for host_path, container_path, kind in \
+            tools.helpers.arm_translation.mount_entries():
+        make_entry(host_path, container_path,
+                   options="bind,create={},optional 0 0".format(kind))
 
     lxc_path = tools.config.defaults["lxc"] + "/waydroid"
     config_nodes_tmp_path = args.work + "/config_session"
@@ -357,6 +370,12 @@ def make_base_props(args):
     if prop_fp != "":
         props.append("ro.build.fingerprint=" + prop_fp)
 
+    # On x86_64 hosts with the ARM translation layer installed, tell Android
+    # to use the native bridge so ARM-only apps can run. The [properties]
+    # section below can still override this if needed.
+    if tools.helpers.arm_translation.is_installed():
+        props.append("ro.dalvik.vm.native.bridge=libndk_translation.so")
+
     # now append/override with values in [properties] section of waydroid.cfg
     cfg = tools.config.load(args)
     for k, v in cfg["properties"].items():
@@ -441,7 +460,9 @@ def unfreeze(args):
     tools.helpers.run.user(args, command)
 
 ANDROID_ENV = {
-    "PATH": "/product/bin:/apex/com.android.runtime/bin:/apex/com.android.art/bin:/system_ext/bin:/system/bin:/system/xbin:/odm/bin:/vendor/bin:/vendor/xbin",
+    "PATH": ("/product/bin:/apex/com.android.runtime/bin:/apex/com.android.art/bin:"
+             "/system_ext/bin:/system/bin:/system/xbin:/odm/bin:/vendor/bin:"
+             "/vendor/xbin"),
     "ANDROID_ROOT": "/system",
     "ANDROID_DATA": "/data",
     "ANDROID_STORAGE": "/storage",
@@ -449,7 +470,26 @@ ANDROID_ENV = {
     "ANDROID_I18N_ROOT": "/apex/com.android.i18n",
     "ANDROID_TZDATA_ROOT": "/apex/com.android.tzdata",
     "ANDROID_RUNTIME_ROOT": "/apex/com.android.runtime",
-    "BOOTCLASSPATH": "/apex/com.android.art/javalib/core-oj.jar:/apex/com.android.art/javalib/core-libart.jar:/apex/com.android.art/javalib/core-icu4j.jar:/apex/com.android.art/javalib/okhttp.jar:/apex/com.android.art/javalib/bouncycastle.jar:/apex/com.android.art/javalib/apache-xml.jar:/system/framework/framework.jar:/system/framework/ext.jar:/system/framework/telephony-common.jar:/system/framework/voip-common.jar:/system/framework/ims-common.jar:/system/framework/framework-atb-backward-compatibility.jar:/apex/com.android.conscrypt/javalib/conscrypt.jar:/apex/com.android.media/javalib/updatable-media.jar:/apex/com.android.mediaprovider/javalib/framework-mediaprovider.jar:/apex/com.android.os.statsd/javalib/framework-statsd.jar:/apex/com.android.permission/javalib/framework-permission.jar:/apex/com.android.sdkext/javalib/framework-sdkextensions.jar:/apex/com.android.wifi/javalib/framework-wifi.jar:/apex/com.android.tethering/javalib/framework-tethering.jar"
+    "BOOTCLASSPATH": ("/apex/com.android.art/javalib/core-oj.jar:"
+                      "/apex/com.android.art/javalib/core-libart.jar:"
+                      "/apex/com.android.art/javalib/core-icu4j.jar:"
+                      "/apex/com.android.art/javalib/okhttp.jar:"
+                      "/apex/com.android.art/javalib/bouncycastle.jar:"
+                      "/apex/com.android.art/javalib/apache-xml.jar:"
+                      "/system/framework/framework.jar:"
+                      "/system/framework/ext.jar:"
+                      "/system/framework/telephony-common.jar:"
+                      "/system/framework/voip-common.jar:"
+                      "/system/framework/ims-common.jar:"
+                      "/system/framework/framework-atb-backward-compatibility.jar:"
+                      "/apex/com.android.conscrypt/javalib/conscrypt.jar:"
+                      "/apex/com.android.media/javalib/updatable-media.jar:"
+                      "/apex/com.android.mediaprovider/javalib/framework-mediaprovider.jar:"
+                      "/apex/com.android.os.statsd/javalib/framework-statsd.jar:"
+                      "/apex/com.android.permission/javalib/framework-permission.jar:"
+                      "/apex/com.android.sdkext/javalib/framework-sdkextensions.jar:"
+                      "/apex/com.android.wifi/javalib/framework-wifi.jar:"
+                      "/apex/com.android.tethering/javalib/framework-tethering.jar")
 }
 
 def android_env_attach_options(args):

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -217,13 +217,13 @@ def generate_session_lxc_config(args, session):
     if not make_entry(session["waydroid_data"], "data", options="rbind 0 0"):
         raise OSError("Failed to bind userdata")
 
-    # ARM64 translation layer (x86_64 hosts): bind the installed
-    # libndk_translation artifacts into the container's /system so Android's
-    # native bridge can load them. No-ops when nothing is installed.
-    for host_path, container_path, kind in \
-            tools.helpers.arm_translation.mount_entries():
-        make_entry(host_path, container_path,
-                   options="bind,create={},optional 0 0".format(kind))
+    # ARM64 translation layer (x86_64 hosts): copy the installed
+    # libndk_translation artifacts into the container's /system overlay
+    # lowerdir, which happens before mount_rootfs() mounts the overlay, so
+    # the files land at /system inside the container. Bind-mounting into
+    # /system is not possible: the overlay is mounted read-only and the
+    # mount targets cannot be created. No-ops when nothing is installed.
+    tools.helpers.arm_translation.sync_to_overlay()
 
     lxc_path = tools.config.defaults["lxc"] + "/waydroid"
     config_nodes_tmp_path = args.work + "/config_session"
@@ -376,13 +376,11 @@ def make_base_props(args):
     # ro.product.cpu.abilist is what makes both the local PackageManager
     # accept ARM APKs (INSTALL_FAILED_NO_MATCHING_ABIS) and the Play
     # delivery check (Aurora's device profile "Platforms") serve them at
-    # all. The [properties] section below can still override any of these.
+    # all. The ro.dalvik.vm.isa.* mapping is required by ART and the
+    # ndk_translation binfmt_misc registration. The [properties] section
+    # below can still override any of these.
     if tools.helpers.arm_translation.is_installed():
-        props.append("ro.dalvik.vm.native.bridge=libndk_translation.so")
-        props.append("ro.product.cpu.abilist=x86_64,x86,arm64-v8a,armeabi-v7a,armeabi")
-        props.append("ro.product.cpu.abilist64=x86_64,arm64-v8a")
-        props.append("ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi")
-        props.append("ro.product.cpu.abi=x86_64")
+        props.extend(tools.helpers.arm_translation.NATIVE_BRIDGE_PROPS)
 
     # now append/override with values in [properties] section of waydroid.cfg
     cfg = tools.config.load(args)

--- a/tools/helpers/run_core.py
+++ b/tools/helpers/run_core.py
@@ -143,8 +143,8 @@ def foreground_pipe(args, cmd, working_dir=None, output_to_stdout=False,
     :param output_to_stdout: copy all output to waydroid's stdout
     :param output_return: return the output of the whole program
     :param output_timeout: kill the process when it doesn't print any output
-                           after a certain time (configured with --timeout)
-                           and raise a RuntimeError exception
+                           after args.timeout seconds and raise a
+                           RuntimeError exception
     :param sudo: use sudo to kill the process when it hits the timeout
     :returns: (code, output)
               * code: return code of the program
@@ -177,8 +177,6 @@ def foreground_pipe(args, cmd, working_dir=None, output_to_stdout=False,
             if wait_end - wait_start >= args.timeout:
                 logging.info("Process did not write any output for " +
                              str(args.timeout) + " seconds. Killing it.")
-                logging.info("NOTE: The timeout can be increased with"
-                             " 'waydroid -t'.")
                 kill_command(args, process.pid, sudo)
                 continue
 
@@ -215,8 +213,8 @@ def check_return_code(args, code, log_message):
 
     :param code: exit code to check
     :param log_message: simplified and more readable form of the command, e.g.
-                        "(native) % echo test" instead of the full command with
-                        entering the chroot and more escaping
+                        "(native) % echo test" instead of the full command
+                        with its escaping
     :raises RuntimeError: when the code indicates that the command failed
     """
 
@@ -258,12 +256,11 @@ def core(args, log_message, cmd, working_dir=None, output="log",
     Run a command and create a log entry.
 
     This is a low level function not meant to be used directly. Use one of the
-    following instead: tools.helpers.run.user(), tools.helpers.run.root(),
-                       tools.chroot.user(), tools.chroot.root()
+    following instead: tools.helpers.run.user(), tools.helpers.run.root()
 
     :param log_message: simplified and more readable form of the command, e.g.
-                        "(native) % echo test" instead of the full command with
-                        entering the chroot and more escaping
+                        "(native) % echo test" instead of the full command
+                        with its escaping
     :param cmd: command as list, e.g. ["echo", "string with spaces"]
     :param working_dir: path in host system where the command should run
     :param output: where to write the output (stdout and stderr) of the
@@ -280,8 +277,8 @@ def core(args, log_message, cmd, working_dir=None, output="log",
 
                    When the output is not set to "interactive", "tui",
                    "background" or "pipe", we kill the process if it does not
-                   output anything for 5 minutes (time can be set with
-                   "waydroid --timeout").
+                   output anything for args.timeout seconds (default: 30
+                   minutes, set in tools.prep_args).
 
                    The table below shows all possible values along with
                    their properties. "wait" indicates that we wait for the

--- a/tools/interfaces/INotificationCallback.py
+++ b/tools/interfaces/INotificationCallback.py
@@ -1,7 +1,4 @@
 import gbinder
-import logging
-from tools import helpers
-from gi.repository import GLib
 
 INTERFACE = "lineageos.waydroid.INotifications.INotificationCallback"
 

--- a/tools/interfaces/INotifications.py
+++ b/tools/interfaces/INotifications.py
@@ -84,7 +84,10 @@ def add_service(args, registerListener, notify, closeNotification):
             _, resident = reader.read_bool()
             _, transient = reader.read_bool()
             _, urgency = reader.read_byte()
-            notification_id = notify(replaces_id, app_name, package_name, summary, body, actions, image_data, category, suppress_sound, expire_timeout, resident, transient, urgency)
+            notification_id = notify(replaces_id, app_name, package_name, summary,
+                                     body, actions, image_data, category,
+                                     suppress_sound, expire_timeout, resident,
+                                     transient, urgency)
             local_response.append_int32(0)
             local_response.append_int32(notification_id)
         elif code == TRANSACTION_closeNotification:

--- a/tools/interfaces/IPlatform.py
+++ b/tools/interfaces/IPlatform.py
@@ -280,7 +280,7 @@ class IPlatform:
         request.append_int32(arg1)
         request.append_string16(arg2)
         reply, status = self.client.transact_sync_reply(
-            TRANSACTION_settingsGetString, request)
+            TRANSACTION_settingsGetInt, request)
 
         if status:
             logging.error("Sending reply failed")

--- a/tools/release/package.py
+++ b/tools/release/package.py
@@ -30,17 +30,10 @@ import logging
 import os
 import shutil
 import socket
-import sys
 import tarfile
 import tempfile
 import urllib.request
 import zipfile
-
-# Allow running as a plain script from anywhere in the repo.
-sys.path.insert(0, os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-
-from tools.helpers import arm_translation  # noqa: E402
 
 log = logging.getLogger("waydroid.release")
 
@@ -52,6 +45,15 @@ COMMUNITY_REPO = "WayDroid-ATV/waydroid-builds"
 COMMUNITY_RELEASES_API = ("https://api.github.com/repos/"
                           + COMMUNITY_REPO + "/releases?per_page=10")
 COMMUNITY_ANDROID_MAJOR = {"community-los22": 22, "community-los23": 23}
+
+# Default source of prebuilt ARM64 translation artifacts, mirroring
+# tools/helpers/arm_translation.py. Kept local (rather than importing the
+# module) so this script runs on a bare CI runner without waydroid's
+# runtime dependencies (dbus, PyGObject, gbinder). md5-verified below.
+DEFAULT_ARCHIVE_URL = ("https://github.com/supremegamers/"
+                       "vendor_google_proprietary_ndk_translation-prebuilt/"
+                       "archive/68734c52556d3d7a6db34c603dd9276915c29f2f.zip")
+DEFAULT_ARCHIVE_MD5 = "0b2207c490fcb400aa5c87fcf0d52d38"
 
 DEFAULT_TIMEOUT = 60  # seconds per socket read
 
@@ -456,17 +458,17 @@ def _prepare_arm_translation(work):
     archive = os.path.join(work, "arm-translation.zip")
     log.info("Downloading ARM translation layer")
     socket.setdefaulttimeout(DEFAULT_TIMEOUT)
-    req = urllib.request.Request(arm_translation.DEFAULT_ARCHIVE_URL,
+    req = urllib.request.Request(DEFAULT_ARCHIVE_URL,
                                  headers={"User-Agent":
                                           "waydroid-release-package"})
     with urllib.request.urlopen(req) as response, open(archive, "wb") as out:
         shutil.copyfileobj(response, out, 1 << 20)
     actual_md5 = md5(archive)
-    if actual_md5 != arm_translation.DEFAULT_ARCHIVE_MD5:
+    if actual_md5 != DEFAULT_ARCHIVE_MD5:
         os.remove(archive)
         raise ValueError(
             f"MD5 mismatch for translation archive: expected "
-            f"{arm_translation.DEFAULT_ARCHIVE_MD5}, got {actual_md5}")
+            f"{DEFAULT_ARCHIVE_MD5}, got {actual_md5}")
     extract_dir = os.path.join(work, "arm-extract")
     os.makedirs(extract_dir)
     with zipfile.ZipFile(archive) as handle:

--- a/tools/release/package.py
+++ b/tools/release/package.py
@@ -1,0 +1,509 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Build a self-contained Waydroid release package.
+
+The package bundles the tooling (a ``make install DESTDIR`` tree), the
+latest Android system/vendor images from a selectable channel, and — by
+default — the ARM64 translation layer, together with ``install.sh``,
+``SHA256SUMS``, ``LICENSE`` and ``NOTICE``.
+
+Channels:
+
+- ``official``: the latest validated build from the official Waydroid OTA
+  channel (Android 13 / LineageOS 20), SHA-256 checked against the channel
+  manifest.
+- ``community-los22`` / ``community-los23``: the latest matching build from
+  the community WayDroid-ATV/waydroid-builds GitHub releases (Android 14-16).
+  Upstream publishes no checksums there, so we compute and record them.
+
+Usage (from the repo root, after ``make install DESTDIR=...``):
+
+    python3 tools/release/package.py \\
+        --tooling <destdir tree> --channel official --arch x86_64 \\
+        --system-type VANILLA --out dist
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import shutil
+import socket
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+
+# Allow running as a plain script from anywhere in the repo.
+sys.path.insert(0, os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from tools.helpers import arm_translation  # noqa: E402
+
+log = logging.getLogger("waydroid.release")
+
+OFFICIAL_SYSTEM_OTA = ("https://ota.waydro.id/system/lineage/"
+                       "waydroid_{arch}/{system_type}.json")
+OFFICIAL_VENDOR_OTA = ("https://ota.waydro.id/vendor/"
+                       "waydroid_{arch}/{vendor_type}.json")
+COMMUNITY_REPO = "WayDroid-ATV/waydroid-builds"
+COMMUNITY_RELEASES_API = ("https://api.github.com/repos/"
+                          + COMMUNITY_REPO + "/releases?per_page=10")
+COMMUNITY_ANDROID_MAJOR = {"community-los22": 22, "community-los23": 23}
+
+DEFAULT_TIMEOUT = 60  # seconds per socket read
+
+
+# ---------------------------------------------------------------------------
+# Channel resolution (pure, testable)
+# ---------------------------------------------------------------------------
+
+def parse_official_channel(data, system_type, vendor_type, arch):
+    """Pick the newest build from an official OTA channel JSON response.
+
+    Returns ``{"system": {...}, "vendor": {...}}`` with keys url, filename,
+    sha256 and datetime. Raises ValueError if the channel has no builds.
+    """
+    response = data.get("response", [])
+    if not response:
+        raise ValueError("Official channel has no builds")
+    # The OTA server lists newest first, but sort defensively anyway.
+    system = max(response, key=lambda b: b.get("datetime", 0))
+    system_sha = system.get("id")
+    if not system_sha:
+        raise ValueError("Official system build has no SHA-256 id")
+    return {
+        "system": {
+            "url": system["url"],
+            "filename": system["filename"],
+            "sha256": system_sha,
+            "datetime": system.get("datetime"),
+            "channel": f"official/{arch}/{system_type}",
+        },
+        "vendor": {
+            "url": None,
+            "filename": None,
+            "sha256": None,
+            "datetime": None,
+            "channel": f"official/{arch}/{vendor_type}",
+        },
+    }
+
+
+def _asset_matches(filename, arch, system_type):
+    """Match a community system asset name for arch + system type.
+
+    Modern releases split system and vendor:
+        lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip
+    Older combined releases used:
+        lineage-22.2-20260224-UNOFFICIAL-waydroid_x86_64.zip
+    """
+    base = f"waydroid_{arch}"
+    if f"-{system_type}-{base}-system.zip" in filename:
+        return "system"
+    if f"-UNOFFICIAL-{base}.zip" in filename:
+        return "combined"
+    return None
+
+
+def parse_community_releases(releases, android_major, arch, system_type):
+    """Pick the newest community release matching the requested Android major.
+
+    Returns a dict with system/vendor URL+filename (vendor may equal the
+    combined system zip) and ``sha256=None`` — upstream publishes no
+    checksums, so the caller computes them. Raises ValueError when no
+    matching release exists.
+    """
+    for release in releases:
+        tag = release.get("tag_name", "")
+        assets = [a.get("name", "") for a in release.get("assets", [])]
+        system_asset = None
+        combined_asset = None
+        for name in assets:
+            if not name.startswith(f"lineage-{android_major}."):
+                continue
+            kind = _asset_matches(name, arch, system_type)
+            if kind == "system":
+                system_asset = name
+            elif kind == "combined":
+                combined_asset = name
+        if system_asset or combined_asset:
+            if system_asset:
+                system_name = system_asset
+                vendor_name = next(
+                    (n for n in assets if f"-MAINLINE-waydroid_{arch}-vendor.zip" in n),
+                    None)
+            else:
+                system_name = combined_asset
+                vendor_name = combined_asset
+            if not vendor_name:
+                raise ValueError(
+                    f"Release {tag} has a system asset but no vendor asset")
+            return {
+                "system": {
+                    "url": _release_asset_url(release, system_name),
+                    "filename": system_name,
+                    "sha256": None,
+                    "datetime": release.get("published_at"),
+                    "channel": f"{COMMUNITY_REPO}/{tag}/{arch}/{system_type}",
+                },
+                "vendor": {
+                    "url": _release_asset_url(release, vendor_name),
+                    "filename": vendor_name,
+                    "sha256": None,
+                    "datetime": release.get("published_at"),
+                    "channel": f"{COMMUNITY_REPO}/{tag}/{arch}/{system_type}",
+                },
+            }
+    raise ValueError(
+        f"No community release matches Android {android_major}, "
+        f"arch {arch}, system type {system_type}")
+
+
+def _release_asset_url(release, name):
+    """Browser-download URL for a release asset (follows redirects)."""
+    return (f"https://github.com/{COMMUNITY_REPO}/releases/download/"
+            f"{release['tag_name']}/{name}")
+
+
+def resolve_builds(channel, arch, system_type, vendor_type, fetch_json):
+    """Resolve the system+vendor builds for a channel.
+
+    ``fetch_json(url)`` is injected so tests can stub the network.
+    """
+    if channel == "official":
+        system_url = OFFICIAL_SYSTEM_OTA.format(arch=arch,
+                                                system_type=system_type)
+        vendor_url = OFFICIAL_VENDOR_OTA.format(arch=arch,
+                                                vendor_type=vendor_type)
+        system = parse_official_channel(
+            fetch_json(system_url), system_type, vendor_type, arch)
+        vendor_data = fetch_json(vendor_url)
+        response = vendor_data.get("response", [])
+        if not response:
+            raise ValueError("Official vendor channel has no builds")
+        vendor = max(response, key=lambda b: b.get("datetime", 0))
+        if not vendor.get("id"):
+            raise ValueError("Official vendor build has no SHA-256 id")
+        system["vendor"].update({
+            "url": vendor["url"],
+            "filename": vendor["filename"],
+            "sha256": vendor["id"],
+            "datetime": vendor.get("datetime"),
+        })
+        return system
+    if channel in COMMUNITY_ANDROID_MAJOR:
+        android_major = COMMUNITY_ANDROID_MAJOR[channel]
+        releases = fetch_json(COMMUNITY_RELEASES_API)
+        if not isinstance(releases, list):
+            raise ValueError("Community releases API returned no data")
+        return parse_community_releases(releases, android_major, arch,
+                                        system_type)
+    raise ValueError(f"Unknown channel: {channel}")
+
+
+# ---------------------------------------------------------------------------
+# Downloads & integrity (thin network layer)
+# ---------------------------------------------------------------------------
+
+def sha256(path):
+    """SHA-256 of a file in chunks."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download(url, dest, expected_sha256=None, loglevel=logging.INFO):
+    """Download url to dest, optionally verifying its SHA-256."""
+    log.log(loglevel, "Downloading %s", url)
+    socket.setdefaulttimeout(DEFAULT_TIMEOUT)
+    req = urllib.request.Request(url, headers={"User-Agent":
+                                               "waydroid-release-package"})
+    with urllib.request.urlopen(req) as response, open(dest, "wb") as out:
+        shutil.copyfileobj(response, out, 1 << 20)
+    if expected_sha256:
+        actual = sha256(dest)
+        if actual != expected_sha256:
+            os.remove(dest)
+            raise ValueError(
+                f"SHA-256 mismatch for {os.path.basename(dest)}: "
+                f"expected {expected_sha256}, got {actual}")
+    return dest
+
+
+def md5(path):
+    """MD5 of a file, for verifying the translation-layer archive."""
+    digest = hashlib.md5()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def extract_images(zip_path, dest_dir):
+    """Extract system.img / vendor.img from an image zip into dest_dir."""
+    with zipfile.ZipFile(zip_path) as handle:
+        for member in handle.infolist():
+            if member.filename.endswith(".img"):
+                target = os.path.join(dest_dir, os.path.basename(member.filename))
+                with handle.open(member) as src, open(target, "wb") as out:
+                    shutil.copyfileobj(src, out, 1 << 20)
+                log.info("Extracted %s", target)
+
+
+# ---------------------------------------------------------------------------
+# Package assembly
+# ---------------------------------------------------------------------------
+
+INSTALL_SH = """#!/bin/sh
+# Install a Waydroid release package onto this host.
+# Run as root:  sudo ./install.sh
+set -e
+
+PREFIX="${PREFIX:-/usr}"
+IMAGES_DIR="${IMAGES_DIR:-/usr/share/waydroid-extra/images}"
+ARM_DIR="${ARM_DIR:-/var/lib/waydroid/arm-translation}"
+
+echo "==> Installing Waydroid tooling to $PREFIX"
+cp -a waydroid/. "$PREFIX"/
+
+if [ -d arm-translation ]; then
+    echo "==> Installing ARM translation layer to $ARM_DIR"
+    mkdir -p "$(dirname "$ARM_DIR")"
+    cp -a arm-translation "$ARM_DIR"
+fi
+
+echo "==> Installing images to $IMAGES_DIR"
+mkdir -p "$IMAGES_DIR"
+cp images/system.img images/vendor.img "$IMAGES_DIR"/
+
+echo "==> Done."
+echo
+echo "Next steps:"
+echo "  1. sudo waydroid init -i $IMAGES_DIR"
+echo "  2. waydroid session start"
+echo
+echo "The images are validated by SHA256SUMS in this directory; see"
+echo "docs/LICENSING.md for the licensing of every bundled component."
+"""
+
+NOTICE = """Waydroid release package — third-party notices
+
+This package bundles or references the following third-party components.
+Attribution is provided as required by their licenses.
+
+1. Waydroid itself (this tooling)
+   License: GPL-3.0-or-later
+   Source:  https://github.com/waydroid/waydroid
+   NO WARRANTY: this software is provided "as is", without warranty of any
+   kind, express or implied (GPLv3 sections 15-16). Use at your own risk.
+
+2. Android system and vendor images
+   The images are LineageOS-based Android builds fetched from the official
+   Waydroid OTA channel (https://ota.waydro.id) or from the community
+   WayDroid-ATV/waydroid-builds releases. They are unmodified upstream
+   artifacts and are NOT authored by this project.
+   - Android framework: Apache-2.0
+   - Linux kernel: GPL-2.0
+   - LineageOS sources: https://github.com/LineageOS
+   See the release notes for the exact image builds and their checksums.
+
+3. ARM64 translation layer (libndk_translation)
+   The binaries are from Google's ndk_translation project (Apache-2.0, the
+   translator used by ChromeOS and the Android emulator), obtained from the
+   community prebuilt archive:
+   https://github.com/supremegamers/vendor_google_proprietary_ndk_translation-prebuilt
+   NOTE: that prebuilt archive declares no SPDX license (GitHub reports
+   NOASSERTION). The underlying Google source is Apache-2.0; if you require
+   an unambiguous license grant, build the artifacts from Google's source:
+   https://github.com/google-ndk-translation
+
+4. Trademarks
+   "Waydroid", "Android" and "LineageOS" are trademarks of their respective
+   owners. This package is not endorsed by Google or the LineageOS project.
+"""
+
+
+def write_checksums(manifest_path, files):
+    """Write a SHA256SUMS file for the given absolute paths."""
+    with open(manifest_path, "w") as out:
+        for path in sorted(files):
+            out.write(f"{sha256(path)}  {os.path.basename(path)}\n")
+
+
+def assemble_package(tooling_dir, images_dir, arm_dir, out_path,
+                     channel_label, version, with_arm_translation=True):
+    """Assemble the release tarball from staged files.
+
+    - tooling_dir: a ``make install DESTDIR`` tree (contents land under
+      ``waydroid/`` in the tarball).
+    - images_dir: directory containing system.img and vendor.img.
+    - arm_dir: optional directory containing the translation layer's
+      ``system/`` tree (as produced by ``waydroid arm-translation install``).
+    Returns the tarball path.
+    """
+    temp_dir = tempfile.mkdtemp(prefix="waydroid-pkg-")
+    try:
+        staging = os.path.join(temp_dir, "pkg")
+        os.makedirs(staging)
+        shutil.copytree(tooling_dir, os.path.join(staging, "waydroid"))
+        images = os.path.join(staging, "images")
+        os.makedirs(images)
+        shutil.copy(os.path.join(images_dir, "system.img"),
+                    os.path.join(images, "system.img"))
+        shutil.copy(os.path.join(images_dir, "vendor.img"),
+                    os.path.join(images, "vendor.img"))
+        if with_arm_translation and arm_dir and os.path.isdir(arm_dir):
+            shutil.copytree(arm_dir, os.path.join(staging, "arm-translation"))
+        with open(os.path.join(staging, "install.sh"), "w") as handle:
+            handle.write(INSTALL_SH)
+        os.chmod(os.path.join(staging, "install.sh"), 0o755)
+        with open(os.path.join(staging, "LICENSE"), "w") as handle:
+            handle.write(open(os.path.join(
+                os.path.dirname(os.path.dirname(
+                    os.path.dirname(os.path.abspath(__file__)))),
+                "LICENSE"), encoding="utf-8").read())
+        with open(os.path.join(staging, "NOTICE"), "w") as handle:
+            handle.write(NOTICE)
+        checksum_files = []
+        for root, _dirs, files in os.walk(staging):
+            for name in files:
+                if name != "SHA256SUMS":
+                    checksum_files.append(os.path.join(root, name))
+        write_checksums(os.path.join(staging, "SHA256SUMS"), checksum_files)
+
+        with tarfile.open(out_path, "w:xz") as tar:
+            tar.add(staging, arcname=f"waydroid-{version}-{channel_label}")
+        log.info("Wrote %s", out_path)
+        return out_path
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Build a Waydroid release package")
+    parser.add_argument("--tooling", required=True,
+                        help="path to a 'make install DESTDIR' tree")
+    parser.add_argument("--channel", default="official",
+                        choices=["official", "community-los22",
+                                 "community-los23"])
+    parser.add_argument("--arch", default="x86_64",
+                        choices=["x86_64", "arm64"])
+    parser.add_argument("--system-type", default="VANILLA",
+                        choices=["VANILLA", "GAPPS"])
+    parser.add_argument("--vendor-type", default="MAINLINE")
+    parser.add_argument("--out", default="dist", help="output directory")
+    parser.add_argument("--no-arm-translation", action="store_true",
+                        help="do not bundle the ARM64 translation layer")
+    parser.add_argument("--version", default="1.6.4",
+                        help="waydroid version string for the package name")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO,
+                        format="%(levelname)s: %(message)s")
+    builds = resolve_builds(args.channel, args.arch, args.system_type,
+                            args.vendor_type, fetch_json=_fetch_json)
+
+    work = tempfile.mkdtemp(prefix="waydroid-release-")
+    try:
+        images_dir = os.path.join(work, "images")
+        os.makedirs(images_dir)
+        arm_dir = None
+        if not args.no_arm_translation:
+            arm_dir = _prepare_arm_translation(work)
+        for kind in ("system", "vendor"):
+            build = builds[kind]
+            zip_path = os.path.join(work, build["filename"] or kind + ".zip")
+            download(build["url"], zip_path, build["sha256"])
+            extract_images(zip_path, images_dir)
+            # Community images have no upstream checksum; record ours.
+            if build["sha256"] is None:
+                log.info("%s SHA-256: %s", kind, sha256(zip_path))
+
+        os.makedirs(args.out, exist_ok=True)
+        date = builds["system"]["datetime"] or "latest"
+        channel_label = args.channel.replace("community-", "los")
+        out_path = os.path.join(
+            args.out, f"waydroid-{args.version}-{channel_label}-{args.arch}"
+                      f"-{date}.tar.xz")
+        assemble_package(args.tooling, images_dir, arm_dir, out_path,
+                         channel_label, args.version,
+                         with_arm_translation=not args.no_arm_translation)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def _fetch_json(url):
+    """Fetch and parse a JSON document (injectable for tests)."""
+    socket.setdefaulttimeout(DEFAULT_TIMEOUT)
+    req = urllib.request.Request(url, headers={"User-Agent":
+                                               "waydroid-release-package"})
+    with urllib.request.urlopen(req) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _prepare_arm_translation(work):
+    """Download and stage the ARM64 translation layer, md5-verified."""
+    archive = os.path.join(work, "arm-translation.zip")
+    log.info("Downloading ARM translation layer")
+    socket.setdefaulttimeout(DEFAULT_TIMEOUT)
+    req = urllib.request.Request(arm_translation.DEFAULT_ARCHIVE_URL,
+                                 headers={"User-Agent":
+                                          "waydroid-release-package"})
+    with urllib.request.urlopen(req) as response, open(archive, "wb") as out:
+        shutil.copyfileobj(response, out, 1 << 20)
+    actual_md5 = md5(archive)
+    if actual_md5 != arm_translation.DEFAULT_ARCHIVE_MD5:
+        os.remove(archive)
+        raise ValueError(
+            f"MD5 mismatch for translation archive: expected "
+            f"{arm_translation.DEFAULT_ARCHIVE_MD5}, got {actual_md5}")
+    extract_dir = os.path.join(work, "arm-extract")
+    os.makedirs(extract_dir)
+    with zipfile.ZipFile(archive) as handle:
+        handle.extractall(extract_dir)
+        for info in handle.infolist():
+            mode = (info.external_attr >> 16) & 0o7777
+            if mode and not info.is_dir():
+                os.chmod(os.path.join(extract_dir, info.filename),
+                         mode & 0o7777)
+    root = _find_prebuilts_root(extract_dir)
+    # The runtime expects the tree under arm-translation/system/...
+    # (mirroring container /system paths, see tools/helpers/
+    # arm_translation.py), so install.sh can drop the directory straight
+    # into /var/lib/waydroid.
+    arm_dir = os.path.join(work, "arm-translation")
+    system_dir = os.path.join(arm_dir, "system")
+    os.makedirs(system_dir)
+    for name in os.listdir(root):
+        shutil.copytree(os.path.join(root, name),
+                        os.path.join(system_dir, name))
+    return arm_dir
+
+
+def _find_prebuilts_root(extracted):
+    """Locate the prebuilts/ tree inside the extracted archive (see
+    tools/actions/arm_translation.py for the layout notes)."""
+    candidates = [extracted]
+    for root, dirs, _files in os.walk(extracted):
+        if "lib64" in dirs and "lib" in dirs and "etc" in dirs:
+            candidates.append(root)
+    candidates.sort(key=lambda p: p.count(os.sep), reverse=True)
+    for candidate in candidates:
+        if (os.path.isdir(candidate + "/lib64")
+                and os.path.isdir(candidate + "/etc")):
+            return candidate
+    raise ValueError("Could not find prebuilts/ tree in translation archive")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/release/package.py
+++ b/tools/release/package.py
@@ -330,11 +330,16 @@ Attribution is provided as required by their licenses.
 """
 
 
-def write_checksums(manifest_path, files):
-    """Write a SHA256SUMS file for the given absolute paths."""
+def write_checksums(manifest_path, root, files):
+    """Write a SHA256SUMS file for the given absolute paths.
+
+    Entries are recorded relative to ``root`` (the package staging dir), so
+    ``sha256sum -c SHA256SUMS`` works from the extracted package root.
+    """
     with open(manifest_path, "w") as out:
         for path in sorted(files):
-            out.write(f"{sha256(path)}  {os.path.basename(path)}\n")
+            rel = os.path.relpath(path, root)
+            out.write(f"{sha256(path)}  {rel}\n")
 
 
 def assemble_package(tooling_dir, images_dir, arm_dir, out_path,
@@ -352,7 +357,11 @@ def assemble_package(tooling_dir, images_dir, arm_dir, out_path,
     try:
         staging = os.path.join(temp_dir, "pkg")
         os.makedirs(staging)
-        shutil.copytree(tooling_dir, os.path.join(staging, "waydroid"))
+        # The install tree's usr/bin/waydroid is a symlink to
+        # ../lib/waydroid/waydroid.py; keep it (copytree's default
+        # dereferences, which breaks sys.path[0] resolution at runtime).
+        shutil.copytree(tooling_dir, os.path.join(staging, "waydroid"),
+                        symlinks=True)
         images = os.path.join(staging, "images")
         os.makedirs(images)
         shutil.copy(os.path.join(images_dir, "system.img"),
@@ -376,7 +385,8 @@ def assemble_package(tooling_dir, images_dir, arm_dir, out_path,
             for name in files:
                 if name != "SHA256SUMS":
                     checksum_files.append(os.path.join(root, name))
-        write_checksums(os.path.join(staging, "SHA256SUMS"), checksum_files)
+        write_checksums(os.path.join(staging, "SHA256SUMS"), staging,
+                        checksum_files)
 
         with tarfile.open(out_path, "w:xz") as tar:
             tar.add(staging, arcname=f"waydroid-{version}-{channel_label}")

--- a/tools/services/__init__.py
+++ b/tools/services/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
-from tools.services.user_manager import start, stop
-from tools.services.clipboard_manager import start, stop
-from tools.services.hardware_manager import start, stop
-from tools.services.notification_manager import start, stop
+from tools.services import (clipboard_manager, hardware_manager,
+                            notification_manager, user_manager)
+
+__all__ = ["clipboard_manager", "hardware_manager",
+           "notification_manager", "user_manager"]

--- a/tools/services/clipboard_manager.py
+++ b/tools/services/clipboard_manager.py
@@ -1,8 +1,8 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import threading
 from tools.interfaces import IClipboard
+from tools.services.runner import ServiceRunner
 
 try:
     import pyclip
@@ -11,7 +11,7 @@ except Exception as e:
     logging.debug(str(e))
     canClip = False
 
-stopping = False
+runner = ServiceRunner("Clipboard", "clipboardLoop")
 
 def start(args):
     def sendClipboardData(value):
@@ -27,23 +27,11 @@ def start(args):
             logging.debug(str(e))
         return ""
 
-    def service_thread():
-        while not stopping:
-            IClipboard.add_service(args, sendClipboardData, getClipboardData)
-
-    if canClip:
-        global stopping
-        stopping = False
-        args.clipboard_manager = threading.Thread(target=service_thread)
-        args.clipboard_manager.start()
-    else:
+    if not canClip:
         logging.debug("Skipping clipboard manager service because of missing pyclip package")
+        return
+
+    runner.start(lambda: IClipboard.add_service(args, sendClipboardData, getClipboardData))
 
 def stop(args):
-    global stopping
-    stopping = True
-    try:
-        if args.clipboardLoop:
-            args.clipboardLoop.quit()
-    except AttributeError:
-        logging.debug("Clipboard service is not even started")
+    runner.stop(args)

--- a/tools/services/hardware_manager.py
+++ b/tools/services/hardware_manager.py
@@ -1,23 +1,48 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import threading
 import time
-import os
 import tools.actions.container_manager
 import tools.actions.session_manager
 import tools.config
 from tools import helpers
 from tools.interfaces import IHardware
+from tools.services.runner import ServiceRunner
 
-stopping = False
+runner = ServiceRunner("Hardware", "hardwareLoop")
 
 def start(args):
     def enableNFC(enable):
-        logging.debug("Function enableNFC not implemented")
+        """
+        Intentionally unimplemented.
+
+        Android invokes this over the IHardware binder service whenever NFC
+        is toggled on/off. It stays a stub because this codebase has no data
+        plane between the container's Android NFC stack and the host's NFC
+        hardware: there is no HAL or forwarding service for the container to
+        reach the host adapter, so toggling the host nfcd from here could
+        not make NFC work in Android anyway.
+
+        The former container_manager NFC hacks (stop host nfcd at container
+        start, restart it at stop) were a session-scoped workaround for the
+        host and container daemons contending over the NFC adapter, not
+        toggle-driven control; they were removed together with the TODO that
+        marked them. Driving host nfcd from this callback would restart that
+        contention: starting it while the container's nfcd is active would
+        leave two daemons fighting over one adapter. Real handling belongs
+        in a session-scoped or hardware-adaptation layer that owns the NFC
+        device and restores host nfcd state at session teardown.
+        """
+        logging.warning("enableNFC not implemented: host NFC daemon is left untouched")
 
     def enableBluetooth(enable):
-        logging.debug("Function enableBluetooth not implemented")
+        """
+        Intentionally unimplemented, for the same reason as enableNFC: the
+        container's Bluetooth stack is self-contained in this codebase (no
+        host-side service is wired up for it), so there is nothing to drive
+        from this callback.
+        """
+        logging.warning("enableBluetooth not implemented: container Bluetooth is self-contained")
 
     def suspend():
         cfg = tools.config.load(args)
@@ -36,7 +61,8 @@ def start(args):
         helpers.images.replace(args, system_zip, system_time,
                                vendor_zip, vendor_time)
         args.session["background_start"] = "false"
-        helpers.images.mount_rootfs(args, args.images_path, args.session)
+        cfg = tools.config.load(args)
+        helpers.images.mount_rootfs(args, cfg["waydroid"]["images_path"], args.session)
         helpers.protocol.set_aidl_version(args)
         helpers.lxc.start(args)
 
@@ -58,21 +84,8 @@ def start(args):
         else:
             tools.actions.container_manager.stop(args)
 
-    def service_thread():
-        while not stopping:
-            IHardware.add_service(
-                args, enableNFC, enableBluetooth, suspend, reboot, upgrade, shutdownRequest)
-
-    global stopping
-    stopping = False
-    args.hardware_manager = threading.Thread(target=service_thread)
-    args.hardware_manager.start()
+    runner.start(lambda: IHardware.add_service(
+        args, enableNFC, enableBluetooth, suspend, reboot, upgrade, shutdownRequest))
 
 def stop(args):
-    global stopping
-    stopping = True
-    try:
-        if args.hardwareLoop:
-            args.hardwareLoop.quit()
-    except AttributeError:
-        logging.debug("Hardware service is not even started")
+    runner.stop(args)

--- a/tools/services/notification_manager.py
+++ b/tools/services/notification_manager.py
@@ -1,14 +1,11 @@
 # Copyright 2025 Alessandro Astone
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import os
-import threading
-import tools.config
 from tools.interfaces import INotifications
-from gi.repository import GLib
+from tools.services.runner import ServiceRunner
 import dbus
 
-stopping = False
+runner = ServiceRunner("NotificationManager", "notificationLoop")
 bus_signals = []
 
 def start(args, session):
@@ -20,7 +17,9 @@ def start(args, session):
         listener.addDeathHandler(onListenerDeath)
         listeners.append(listener)
 
-    def notify(replaces_id, app_name, package_name, summary, body, actions, image_data, category, suppress_sound, expire_timeout, resident, transient, urgency):
+    def notify(replaces_id, app_name, package_name, summary, body, actions,
+               image_data, category, suppress_sound, expire_timeout, resident,
+               transient, urgency):
         # By reading the spec, I believe app_icon should be pointing to the desktop entry Icon=
         # but when we set it plasmashell uses it in place of image-data.
         # Ignore app_icon and use desktop-entry to show the app icon.
@@ -66,13 +65,11 @@ def start(args, session):
         for listener in listeners:
             listener.onActionInvoked(int(notification_id), str(action_id), str(token))
 
-    def service_thread():
-        while not stopping:
-            INotifications.add_service(args, registerListener, notify, closeNotification)
-
     try:
-        dbus_proxy = dbus.Interface(dbus.SessionBus().get_object("org.freedesktop.Notifications", "/org/freedesktop/Notifications"),
-                                    "org.freedesktop.Notifications")
+        dbus_proxy = dbus.Interface(
+            dbus.SessionBus().get_object("org.freedesktop.Notifications",
+                                         "/org/freedesktop/Notifications"),
+            "org.freedesktop.Notifications")
     except dbus.DBusException as e:
         logging.info("Skipping notification manager service because we could not connect to the notifications server: %s", str(e))
         return
@@ -82,18 +79,9 @@ def start(args, session):
     bus_signals.append(dbus_proxy.connect_to_signal("ActivationToken", onActivationToken))
     bus_signals.append(dbus_proxy.connect_to_signal("ActionInvoked", onActionInvoked))
 
-    global stopping
-    stopping = False
-    args.notification_manager = threading.Thread(target=service_thread)
-    args.notification_manager.start()
+    runner.start(lambda: INotifications.add_service(args, registerListener, notify, closeNotification))
 
 def stop(args):
-    global stopping
-    stopping = True
     for signal in bus_signals:
         signal.remove()
-    try:
-        if args.notificationLoop:
-            args.notificationLoop.quit()
-    except AttributeError:
-        logging.debug("NotificationManager service is not even started")
+    runner.stop(args)

--- a/tools/services/runner.py
+++ b/tools/services/runner.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+import threading
+
+
+class ServiceRunner:
+    """
+    Run a per-session binder service in a background thread.
+
+    Collapses the lifecycle pattern shared by all per-session services
+    (user_manager, clipboard_manager, hardware_manager, notification_manager):
+    a stop flag, a worker thread that keeps re-registering the service, and a
+    GLib main loop that the binder interface installs on ``args`` (e.g.
+    ``args.hardwareLoop``) and that must be quit on stop.
+    """
+
+    def __init__(self, name, loop_attr):
+        self.name = name
+        self.loop_attr = loop_attr
+        self._stopping = False
+        self._thread = None
+
+    def start(self, run_fn):
+        """Run ``run_fn`` repeatedly in a background thread until stopped."""
+        self._stopping = False
+        self._thread = threading.Thread(target=self._loop, args=(run_fn,))
+        self._thread.start()
+
+    def _loop(self, run_fn):
+        while not self._stopping:
+            run_fn()
+
+    def stop(self, args):
+        """Ask the thread to stop and quit the service's GLib main loop."""
+        self._stopping = True
+        loop = getattr(args, self.loop_attr, None)
+        if loop:
+            loop.quit()
+        else:
+            logging.debug("%s service is not even started", self.name)
+
+    def join(self, timeout=None):
+        """Wait for the worker thread to finish (no-op if never started)."""
+        if self._thread:
+            self._thread.join(timeout)

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -1,16 +1,16 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import threading
 import tools.config
 import tools.helpers.net
 from pathlib import Path
 from contextlib import suppress
 from tools.interfaces import IUserMonitor
 from tools.interfaces import IPlatform
+from tools.services.runner import ServiceRunner
 from gi.repository import GLib
 
-stopping = False
+runner = ServiceRunner("UserMonitor", "userMonitorLoop")
 
 
 def start(args, session, unlocked_cb=None):
@@ -125,7 +125,10 @@ def start(args, session, unlocked_cb=None):
             desktop_file.set_boolean("Desktop Entry", "NoDisplay", True)
 
         desktop_file.set_string("Desktop Action app-settings", "Name", "App Settings")
-        desktop_file.set_string("Desktop Action app-settings", "Exec", f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:{packageName}")
+        desktop_file.set_string(
+            "Desktop Action app-settings", "Exec",
+            f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS "
+            f"package:{packageName}")
         desktop_file.set_string("Desktop Action app-settings", "Icon", str(waydroid_data_icons_dir / "com.android.settings.png"))
 
         desktop_file.save_to_file(str(desktop_file_path))
@@ -161,21 +164,8 @@ def start(args, session, unlocked_cb=None):
                 appInfo = platformService.getAppInfo(packageName)
                 updateDesktopFile(appInfo)
 
-    def service_thread():
-        while not stopping:
-            IUserMonitor.add_service(args, userUnlocked, packageStateChanged)
-
-    global stopping
-    stopping = False
-    args.user_manager = threading.Thread(target=service_thread)
-    args.user_manager.start()
+    runner.start(lambda: IUserMonitor.add_service(args, userUnlocked, packageStateChanged))
 
 
 def stop(args):
-    global stopping
-    stopping = True
-    try:
-        if args.userMonitorLoop:
-            args.userMonitorLoop.quit()
-    except AttributeError:
-        logging.debug("UserMonitor service is not even started")
+    runner.stop(args)

--- a/waydroid.py
+++ b/waydroid.py
@@ -4,7 +4,15 @@
 # PYTHON_ARGCOMPLETE_OK
 import os
 import sys
-import tools
+
+try:
+    import tools
+except ModuleNotFoundError as e:
+    print("Waydroid could not start: the Python module '{}' is not installed.".format(e.name),
+          file=sys.stderr)
+    print("Install the corresponding package (e.g. python3-{}).".format(e.name.split(".")[0]),
+          file=sys.stderr)
+    sys.exit(1)
 
 if __name__ == "__main__":
     os.umask(0o0022)


### PR DESCRIPTION
## Summary

This PR brings the fork's full delta over upstream `e7d73e7` (7 commits,
~64 files, +4900/−400): a ServiceRunner/dispatch refactor with hardened
root/init guards, the 1.6.4 bug-fix batch, a LineageOS 13→16 support
update, a working ARM64 translation layer with end-to-end verification,
and a release-package workflow with a licensing review.

## Highlights

### ARM64 translation layer (libndk_translation)

- **New `waydroid arm-translation` action** (`install`/`status`/`uninstall`),
  root-gated automatically via the dispatch table.
- **One-command install**: `waydroid arm-translation install` with no flags
  fetches a known-good prebuilt (Android 13, md5-verified), auto-detects
  the `prebuilts/` tree, validates, and installs. `--source`/`--archive`/
  `--url` accept user artifacts.
- **Overlay sync instead of bind mounts**: the container's `/system` overlay
  is mounted read-only, so bind-mounting into it fails silently. Artifacts
  are copied into the overlay lowerdir at session start, before
  `mount_rootfs()` mounts it (the waydroid_script approach).
- **Full native-bridge prop set** in `make_base_props`: emulated
  `ro.product.cpu.abilist*` (fixes both Play's delivery gate and local
  `INSTALL_FAILED_NO_MATCHING_ABIS`), plus `ro.dalvik.vm.isa.arm{,64}` and
  `ro.enable.native.bridge.exec` required by ART and the binfmt_misc
  registration. `[properties]` still overrides.
- **Verified live** (2026-08-14, x86_64 host): an ARM-only APK that failed
  with `-113` before now installs; a test app with a real AArch64 `.so`
  rendered its activity with `ndk_translation: Initialized NDK translation
  (aarch64)` in logcat.

### Release packages + GitHub Actions

- **`.github/workflows/build-release.yaml`**: weekly + manual-dispatch
  workflow that builds a self-contained release package (tooling install
  tree + latest Android images + optional ARM64 translation layer) and
  publishes it as a GitHub Release asset. Inputs select channel
  (`official` / `community-los22` / `community-los23`), arch, system type
  (`VANILLA`/`GAPPS`), and whether to bundle the translation layer.
- **`tools/release/package.py`**: channel resolution, SHA-256 validation
  against the official OTA manifest (checksums computed and recorded for
  community images, which publish none), image extraction, and tarball
  assembly with `install.sh`, `SHA256SUMS`, `LICENSE` and `NOTICE`.
- **`docs/LICENSING.md`**: a licensing/liability review of every bundled
  component — project GPL-3.0-or-later, images LineageOS (Apache-2.0
  framework / GPL-2.0 kernel), and the key finding that the `supremegamers`
  translation prebuilt declares **NOASSERTION** (Google's source is
  Apache-2.0 but the packaging has no explicit grant). Mitigated by
  optional bundling and an explicit NOTICE with provenance + no-warranty
  statement.
- Full LineageOS source builds (~300 GB disk, ~5 h) cannot run on
  GitHub-hosted runners; the workflow packages the upstream-published
  images instead, integrity-verified.

### ServiceRunner + dispatch table

- `tools/services/runner.py` with a dispatch table; `ROOT_ACTIONS` and
  `ALLOWED_UNINITIALIZED` are now **derived from the DISPATCH table's guard
  flags**, so a new action cannot silently skip the root/init guards.
- Session stop ordering, hardening, and expanded test coverage.

### 1.6.4 bug-fix batch

- `@BINDIR@` substitution in the systemd/D-Bus activation files so
  `make install PREFIX=/usr/local` works (was hardcoded `/usr/bin/waydroid`).
- schedtune lazy-unmount retry + actionable warning.
- `enableNFC`/`enableBluetooth` no-ops log at WARNING level.
- `waydroid-net.sh` defaults `LXC_USE_NFT` to auto (nftables-only hosts).
- IPv6 NAT variables now read from the environment.
- Binder/vndbinder/hwbinder config migration in `upgrader.migration()`.
- `waydroid log` path selection extracted and unit-tested.
- Version 1.6.4 + changelog entry; E501 enforced at 131 columns.
- Makefile install prunes `__pycache__` from the install tree.

### LineageOS / Android base support

- README/docs updated: tooling supports Android 13–16 (LineageOS 20–23)
  via runtime API detection; official OTA images remain Android 13 with
  community LineageOS 22/23 builds available (upstream #2229 tracks the
  official rebuild).

## Testing

- `make check`: ruff clean, **128 passed / 1 skipped**.
- `make install DESTDIR=...`: clean tree, `__pycache__` pruned, units
  rendered with correct `ExecStart`.
- Release packaging: all three channels resolve correctly against the live
  endpoints; the staged translation layer matches the runtime `system/`
  layout with exec bits preserved.
- Live runtime verification on a real x86_64 host (binder, Wayland,
  container boot, ARM translation end-to-end).

## Notes for maintainers

- The `--url` default (third-party `supremegamers/...` prebuilt) is
  convenience-only; `--source`/`--archive` remain the primary artifact
  inputs and the code path is identical.
- The `ro.product.cpu.abilist` emulated-ABI advertising is opt-in: it only
  happens when the translation layer is actually installed, and
  `[properties]` in `waydroid.cfg` can override every prop.
- The release workflow publishes to the fork's own Releases page by
  default; publishing to upstream would need maintainer approval.
