### PR TITLE
tools: add ServiceRunner and dispatch table with derived root/init guards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ ignore = [
 	"F401", # TODO: Remove this once unused imports are removed.
 	"F811", # TODO: Remove this once redefined variables are refactored.
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pytest configuration.
+
+The waydroid ``tools`` package imports heavy runtime dependencies (dbus,
+PyGObject, gbinder) at module import time. The pure-logic helpers under test
+(arch, protocol, images, mount) don't use any of them, so we stub them out in
+``sys.modules`` to keep the test suite runnable in a minimal environment
+(e.g. CI without those native packages installed).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+HEAVY_DEPS = [
+    "dbus",
+    "dbus.exceptions",
+    "dbus.mainloop.glib",
+    "dbus.service",
+    "gbinder",
+    "gi",
+    "gi.repository",
+    "gi.repository.GLib",
+]
+
+
+class _StubModule(types.ModuleType):
+    """A module that answers any attribute access with a MagicMock."""
+
+    def __getattr__(self, attr):
+        return MagicMock()
+
+
+def _install_stub(name):
+    if name in sys.modules:
+        return
+    module = _StubModule(name)
+    sys.modules[name] = module
+    # Make dotted names importable (e.g. `import dbus.mainloop.glib`).
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = _StubModule(parent)
+
+
+for _name in HEAVY_DEPS:
+    _install_stub(_name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.config.get_session_defaults()."""
+
+import types
+
+import tools.config
+
+
+def _patch_user(monkeypatch, name="u", uid=1000, gid=1000):
+    monkeypatch.setattr(tools.config.pwd, "getpwuid",
+                        lambda real_uid: types.SimpleNamespace(pw_name=name))
+    monkeypatch.setattr(tools.config.os, "getuid", lambda: uid)
+    monkeypatch.setattr(tools.config.os, "getgid", lambda: gid)
+    monkeypatch.setenv("HOME", "/home/" + name)
+
+
+def test_get_session_defaults_env(monkeypatch):
+    _patch_user(monkeypatch)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    monkeypatch.setenv("PULSE_RUNTIME_PATH", "/run/user/1000/pulse")
+    monkeypatch.setenv("XDG_DATA_HOME", "/home/u/.local/share")
+
+    session = tools.config.get_session_defaults()
+
+    assert session["wayland_display"] == "wayland-1"
+    assert session["xdg_runtime_dir"] == "/run/user/1000"
+    assert session["pulse_runtime_path"] == "/run/user/1000/pulse"
+    assert session["user_name"] == "u"
+    assert session["user_id"] == "1000"
+    assert session["group_id"] == "1000"
+    assert session["waydroid_user_state"] == "/home/u/.local/share/waydroid"
+    assert session["waydroid_data"] == "/home/u/.local/share/waydroid/data"
+
+
+def test_get_session_defaults_unset_env(monkeypatch):
+    # os.environ.get() yields the literal string "None" when unset;
+    # session_manager treats that as "not set" (see its WAYLAND_DISPLAY
+    # handling), so pin that behavior here.
+    _patch_user(monkeypatch)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    session = tools.config.get_session_defaults()
+
+    assert session["wayland_display"] == "None"
+    assert session["xdg_runtime_dir"] == "None"
+    assert session["pulse_runtime_path"] == "None/pulse"
+    assert session["waydroid_user_state"] == "/home/u/.local/share/waydroid"
+
+
+def test_get_session_defaults_pulse_falls_back_to_runtime_dir(monkeypatch):
+    _patch_user(monkeypatch)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    session = tools.config.get_session_defaults()
+
+    assert session["pulse_runtime_path"] == "/run/user/1000/pulse"

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import re
+import sys
+
+import pytest
+
+import tools
+from tools import helpers
+
+# argparse renders subparser choices as {a,b,c} in help text
+_CHOICES_RE = re.compile(r"\{([a-z0-9,-]+)\}")
+
+
+def _choices(capsys, monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit):
+        helpers.arguments()
+    out = capsys.readouterr().out
+    match = _CHOICES_RE.search(out)
+    if not match:
+        return []
+    return [choice.strip() for choice in match.group(1).split(",")]
+
+
+def test_dispatch_covers_cli_surface(capsys, monkeypatch):
+    actions_list = _choices(capsys, monkeypatch, ["waydroid", "-h"])
+    assert actions_list, "could not parse action list from help"
+
+    for action in actions_list:
+        table = tools.DISPATCH.get(action)
+        assert table is not None, \
+            f"action {action!r} is missing from tools.DISPATCH"
+
+        subactions = _choices(capsys, monkeypatch, ["waydroid", action, "-h"])
+        if subactions:
+            for subaction in subactions:
+                assert subaction in table, \
+                    f"subaction {action} {subaction!r} is missing from tools.DISPATCH"
+        else:
+            assert None in table, \
+                f"action {action!r} has no subparsers but its table has no None handler"
+
+
+def test_dispatch_handlers_are_callable():
+    for action, table in tools.DISPATCH.items():
+        for subaction, handler in table.items():
+            assert callable(handler), \
+                f"handler for {action} {subaction!r} is not callable"
+
+
+def test_root_actions_have_handlers():
+    for action in tools.ROOT_ACTIONS:
+        assert action in tools.DISPATCH, \
+            f"root action {action!r} is missing from tools.DISPATCH"
+
+
+def test_dispatch_entries_declare_guard_flags():
+    # A new action must go through _entry() so it cannot silently skip the
+    # root or init guards in main().
+    for action, entry in tools.DISPATCH.items():
+        assert hasattr(entry, "need_root"), \
+            f"action {action!r} must declare its root flag via _entry()"
+        assert hasattr(entry, "allowed_uninitialized"), \
+            f"action {action!r} must declare its uninitialized flag via _entry()"
+
+
+def test_root_actions_derived_from_dispatch():
+    expected = frozenset(
+        action for action, entry in tools.DISPATCH.items()
+        if entry.need_root)
+    assert tools.ROOT_ACTIONS == expected
+
+
+def test_allowed_uninitialized_derived_from_dispatch():
+    expected = frozenset(
+        action for action, entry in tools.DISPATCH.items()
+        if entry.allowed_uninitialized)
+    assert tools.ALLOWED_UNINITIALIZED == expected

--- a/tests/test_services_runner.py
+++ b/tests/test_services_runner.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import time
+
+from tools.services.runner import ServiceRunner
+
+
+class _Args:
+    pass
+
+
+class _Loop:
+    def __init__(self):
+        self.quit_called = False
+
+    def quit(self):
+        self.quit_called = True
+
+
+def test_start_runs_until_stopped():
+    calls = []
+
+    def run_fn():
+        calls.append(1)
+        time.sleep(0.01)
+
+    args = _Args()
+    runner = ServiceRunner("Test", "testLoop")
+    runner.start(run_fn)
+    time.sleep(0.05)
+    assert len(calls) >= 2
+
+    runner.stop(args)
+    runner.join()
+    count_at_stop = len(calls)
+    time.sleep(0.03)
+    assert len(calls) == count_at_stop
+
+
+def test_stop_quits_glib_loop():
+    args = _Args()
+    args.testLoop = _Loop()
+    runner = ServiceRunner("Test", "testLoop")
+
+    runner.stop(args)
+
+    assert args.testLoop.quit_called
+
+
+def test_stop_when_never_started_is_quiet(caplog):
+    import logging
+    runner = ServiceRunner("Test", "testLoop")
+
+    with caplog.at_level(logging.DEBUG):
+        runner.stop(_Args())
+
+    assert any("not even started" in record.message for record in caplog.records)
+
+
+def test_session_stop_quits_all_service_loops(monkeypatch):
+    # The session stop path must quit the GLib loop of every per-session
+    # service (user/clipboard/notification) plus the session main loop.
+    import types
+
+    import tools.actions.session_manager as session_manager
+
+    loops = {name: _Loop() for name in
+             ("userMonitorLoop", "clipboardLoop", "notificationLoop")}
+    args = types.SimpleNamespace(**loops)
+    mainloop = _Loop()
+
+    session_manager.do_stop(args, mainloop)
+
+    for loop in loops.values():
+        assert loop.quit_called
+    assert mainloop.quit_called
+
+
+def test_join_returns_after_stop():
+    runner = ServiceRunner("Test", "testLoop")
+    runner.start(lambda: None)
+    runner.stop(_Args())
+    # Should not hang or raise
+    runner.join(timeout=2)

--- a/tests/test_tools_init.py
+++ b/tests/test_tools_init.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools/__init__.py helpers (log path selection)."""
+
+import types
+
+import tools
+import tools.config
+
+
+def make_args(user_log=None, log="/var/lib/waydroid/waydroid.log"):
+    return types.SimpleNamespace(user_log=user_log, log=log)
+
+
+def test_log_path_root_uses_own_log(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 0)
+    args = make_args()
+    assert tools._log_path(args) == args.log
+
+
+def test_log_path_nonroot_prefers_root_log_when_readable(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(tools.os, "access", lambda path, mode: True)
+    args = make_args()
+    root_log = tools.config.defaults["work"] + "/waydroid.log"
+    assert tools._log_path(args) == root_log
+
+
+def test_log_path_nonroot_explicit_log_wins(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(tools.os, "access", lambda path, mode: True)
+    # main() redirects args.log to the explicit -l path before _log runs, so
+    # the root-log preference must not kick in even though it is readable.
+    args = make_args(user_log="/tmp/custom.log", log="/tmp/custom.log")
+    assert tools._log_path(args) == "/tmp/custom.log"
+
+
+def test_log_path_nonroot_root_log_unreadable(monkeypatch):
+    monkeypatch.setattr(tools.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(tools.os, "access", lambda path, mode: False)
+    args = make_args()
+    assert tools._log_path(args) == args.log

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -14,6 +14,10 @@ from . import config
 from . import helpers
 from .helpers import logging as tools_logging
 
+# ROOT_ACTIONS and ALLOWED_UNINITIALIZED are derived from the guard flags
+# declared on each DISPATCH entry below, so a new action declares its guards
+# in the one place it is added.
+
 def prep_args(args):
     args.cache = {}
     args.work = config.defaults["work"]
@@ -22,24 +26,130 @@ def prep_args(args):
     args.sudo_timer = True
     args.timeout = 1800
 
-def main():
-    def actionNeedRoot(action):
-        if os.geteuid() != 0:
-            raise RuntimeError(
-                "Action \"{}\" needs root access".format(action))
+def _action_need_root(action):
+    if os.geteuid() != 0:
+        raise RuntimeError(
+            "Action \"{}\" needs root access".format(action))
 
+def _log_path(args):
+    """
+    Choose the log file that `waydroid log` should follow.
+
+    Non-root users prefer the root container log (where container service
+    errors land) when it is readable, unless an explicit -l/--log was given.
+    """
+    if os.geteuid() != 0 and not args.user_log:
+        root_log = config.defaults["work"] + "/waydroid.log"
+        if os.access(root_log, os.R_OK):
+            return root_log
+    return args.log
+
+def _log(args):
+    """Follow the log file, preferring the root container log as a user."""
+    log_path = _log_path(args)
+    if args.clear_log:
+        helpers.run.user(args, ["truncate", "-s", "0", args.log])
+    try:
+        helpers.run.user(
+            args, ["tail", "-n", args.lines, "-F", log_path], output="tui")
+    except KeyboardInterrupt:
+        pass
+
+def _first_launch(args):
+    if not actions.initializer.is_initialized(args):
+        actions.remote_init_client(args)
+    if actions.initializer.is_initialized(args):
+        actions.app_manager.showFullUI(args)
+
+def _init(args):
+    if args.client:
+        actions.remote_init_client(args)
+    else:
+        _action_need_root("init")
+        actions.init(args)
+
+class _ActionEntry(dict):
+    """A DISPATCH entry: {subaction or None: handler} plus guard flags.
+
+    Subclassing dict keeps lookups (``table.get(subaction)``, ``None in
+    table``) unchanged; the flags declare how the action is gated in main()
+    and are what ROOT_ACTIONS / ALLOWED_UNINITIALIZED are derived from.
+    """
+
+
+def _entry(handlers, *, root=False, uninitialized=False):
+    """Build a DISPATCH entry, marking the action's guard flags."""
+    entry = _ActionEntry(handlers)
+    entry.need_root = root
+    entry.allowed_uninitialized = uninitialized
+    return entry
+
+
+# Action dispatch table: action -> entry mapping {subaction or None: handler}
+# plus guard flags. Adding a new action or subaction requires only a new
+# entry here; ROOT_ACTIONS and ALLOWED_UNINITIALIZED are derived from the
+# flags below.
+DISPATCH = {
+    # "init" runs as a user for the --client variant; root is checked inside
+    # _init instead of via the need_root flag.
+    "init": _entry({None: _init}, uninitialized=True),
+    "upgrade": _entry({None: actions.upgrade}, root=True),
+    "session": _entry({"start": actions.session_manager.start,
+                       "stop": actions.session_manager.stop}),
+    "container": _entry({"start": actions.container_manager.start,
+                         "stop": actions.container_manager.stop,
+                         "restart": actions.container_manager.restart,
+                         "freeze": actions.container_manager.freeze,
+                         "unfreeze": actions.container_manager.unfreeze},
+                        root=True, uninitialized=True),
+    "app": _entry({"install": actions.app_manager.install,
+                   "remove": actions.app_manager.remove,
+                   "launch": actions.app_manager.launch,
+                   "intent": actions.app_manager.intent,
+                   "list": actions.app_manager.list}),
+    "prop": _entry({"get": actions.prop.get,
+                    "set": actions.prop.set}),
+    "shell": _entry({None: helpers.lxc.shell}, root=True),
+    "logcat": _entry({None: helpers.lxc.logcat}, root=True),
+    "show-full-ui": _entry({None: actions.app_manager.showFullUI}),
+    "first-launch": _entry({None: _first_launch}, uninitialized=True),
+    "status": _entry({None: actions.status.print_status}),
+    "adb": _entry({"connect": helpers.net.adb_connect,
+                   "disconnect": helpers.net.adb_disconnect}),
+    "log": _entry({None: _log}, uninitialized=True),
+    "bugreport": _entry({None: actions.bugreport}, uninitialized=True),
+}
+
+# Actions that may run before waydroid is initialized, and actions that
+# always require root. Derived from the DISPATCH flags so the two can't
+# drift from the table. "init" is deliberately absent from ROOT_ACTIONS:
+# its --client variant runs as a user and checks root itself in _init.
+ALLOWED_UNINITIALIZED = frozenset(
+    action for action, entry in DISPATCH.items()
+    if entry.allowed_uninitialized)
+ROOT_ACTIONS = frozenset(
+    action for action, entry in DISPATCH.items() if entry.need_root)
+
+def main():
     # Wrap everything to display nice error messages
     args = None
     try:
         # Parse arguments, set up logging
         args = helpers.arguments()
+        user_log = args.log
         prep_args(args)
 
         if os.geteuid() == 0:
             if not os.path.exists(args.work):
                 os.mkdir(args.work)
-        elif not os.path.exists(args.log):
+        elif not user_log and not os.path.exists(args.log):
+            # Non-root users cannot write to the root work dir; fall back
+            # to a per-user log unless an explicit -l/--log was given.
             args.log = "/tmp/tools.log"
+
+        if user_log:
+            args.log = user_log
+        args.user_log = user_log
 
         tools_logging.init(args)
 
@@ -50,98 +160,22 @@ def main():
             args.action = "first-launch"
 
         if not actions.initializer.is_initialized(args) and \
-                args.action not in ("init", "container", "first-launch", "log", "bugreport"):
+                args.action not in ALLOWED_UNINITIALIZED:
             print('Waydroid is not initialized, run "waydroid init"')
             return 0
 
-        if args.action == "init":
-            if args.client:
-                actions.remote_init_client(args)
-            else:
-                actionNeedRoot(args.action)
-                actions.init(args)
-        elif args.action == "upgrade":
-            actionNeedRoot(args.action)
-            actions.upgrade(args)
-        elif args.action == "session":
-            if args.subaction == "start":
-                actions.session_manager.start(args)
-            elif args.subaction == "stop":
-                actions.session_manager.stop(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "container":
-            actionNeedRoot(args.action)
-            if args.subaction == "start":
-                actions.container_manager.start(args)
-            elif args.subaction == "stop":
-                actions.container_manager.stop(args)
-            elif args.subaction == "restart":
-                actions.container_manager.restart(args)
-            elif args.subaction == "freeze":
-                actions.container_manager.freeze(args)
-            elif args.subaction == "unfreeze":
-                actions.container_manager.unfreeze(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "app":
-            if args.subaction == "install":
-                actions.app_manager.install(args)
-            elif args.subaction == "remove":
-                actions.app_manager.remove(args)
-            elif args.subaction == "launch":
-                actions.app_manager.launch(args)
-            elif args.subaction == "intent":
-                actions.app_manager.intent(args)
-            elif args.subaction == "list":
-                actions.app_manager.list(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "prop":
-            if args.subaction == "get":
-                actions.prop.get(args)
-            elif args.subaction == "set":
-                actions.prop.set(args)
-            else:
-                logging.info(
-                    "Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "shell":
-            actionNeedRoot(args.action)
-            helpers.lxc.shell(args)
-        elif args.action == "logcat":
-            actionNeedRoot(args.action)
-            helpers.lxc.logcat(args)
-        elif args.action == "show-full-ui":
-            actions.app_manager.showFullUI(args)
-        elif args.action == "first-launch":
-            if not actions.initializer.is_initialized(args):
-                actions.remote_init_client(args)
-            if actions.initializer.is_initialized(args):
-                actions.app_manager.showFullUI(args)
-        elif args.action == "status":
-            actions.status.print_status(args)
-        elif args.action == "adb":
-            if args.subaction == "connect":
-                helpers.net.adb_connect(args)
-            elif args.subaction == "disconnect":
-                helpers.net.adb_disconnect(args)
-            else:
-                logging.info("Run waydroid {} -h for usage information.".format(args.action))
-        elif args.action == "log":
-            if args.clear_log:
-                helpers.run.user(args, ["truncate", "-s", "0", args.log])
-            try:
-                helpers.run.user(
-                    args, ["tail", "-n", args.lines, "-F", args.log], output="tui")
-            except KeyboardInterrupt:
-                pass
-        elif args.action == "bugreport":
-            actions.bugreport(args)
-        else:
+        action_handlers = DISPATCH.get(args.action)
+        if action_handlers is None:
             logging.info("Run waydroid -h for usage information.")
+        else:
+            if args.action in ROOT_ACTIONS:
+                _action_need_root(args.action)
+            handler = action_handlers.get(getattr(args, "subaction", None))
+            if handler is None:
+                logging.info(
+                    "Run waydroid {} -h for usage information.".format(args.action))
+            else:
+                handler(args)
 
         #logging.info("Done")
 

--- a/tools/actions/__init__.py
+++ b/tools/actions/__init__.py
@@ -1,10 +1,11 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
+from tools.actions import (app_manager, container_manager, prop,
+                           session_manager, status, upgrader)
+from tools.actions.bugreport import bugreport
 from tools.actions.initializer import init, remote_init_client
 from tools.actions.upgrader import upgrade
-from tools.actions.session_manager import start, stop
-from tools.actions.container_manager import start, stop, freeze, unfreeze
-from tools.actions.app_manager import install, remove, launch, list
-from tools.actions.status import print_status
-from tools.actions.prop import get, set
-from tools.actions.bugreport import bugreport
+
+__all__ = ["app_manager", "container_manager", "prop", "session_manager",
+           "status", "upgrader", "bugreport", "init", "remote_init_client",
+           "upgrade"]

--- a/tools/actions/app_manager.py
+++ b/tools/actions/app_manager.py
@@ -20,7 +20,7 @@ def install(args):
         if session["state"] == "FROZEN":
             cm.Unfreeze()
 
-        tmp_dir = tools.config.session_defaults["waydroid_data"] + "/waydroid_tmp"
+        tmp_dir = tools.config.get_session_defaults()["waydroid_data"] + "/waydroid_tmp"
         if not os.path.exists(tmp_dir):
             os.makedirs(tmp_dir)
 

--- a/tools/actions/session_manager.py
+++ b/tools/actions/session_manager.py
@@ -11,7 +11,6 @@ import dbus
 import dbus.service
 import dbus.exceptions
 from gi.repository import GLib
-import copy
 
 class DbusSessionManager(dbus.service.Object):
     def __init__(self, looper, bus, object_path, args):
@@ -46,11 +45,16 @@ def start(args, unlocked_cb=None, background=True):
             unlocked_cb()
         return
 
-    session = copy.copy(tools.config.session_defaults)
+    session = tools.config.get_session_defaults()
 
-    # TODO: also support WAYLAND_SOCKET?
     wayland_display = session["wayland_display"]
-    if wayland_display == "None" or not wayland_display:
+    wayland_socket_env = os.getenv("WAYLAND_SOCKET")
+    if wayland_socket_env:
+        # WAYLAND_SOCKET points directly at the compositor socket (a full
+        # path or a socket name relative to XDG_RUNTIME_DIR); it takes
+        # precedence over WAYLAND_DISPLAY, mirroring libwayland clients.
+        wayland_display = session["wayland_display"] = wayland_socket_env
+    elif wayland_display == "None" or not wayland_display:
         logging.warning('WAYLAND_DISPLAY is not set, defaulting to "wayland-0"')
         wayland_display = session["wayland_display"] = "wayland-0"
 

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -54,24 +54,33 @@ defaults["lxc"] = defaults["work"] + "/lxc"
 defaults["host_perms"] = defaults["work"] + "/host-permissions"
 defaults["container_pulse_runtime_path"] = defaults["container_xdg_runtime_dir"] + "/pulse"
 
-session_defaults = {
-    "user_name": pwd.getpwuid(os.getuid()).pw_name,
-    "user_id": str(os.getuid()),
-    "group_id": str(os.getgid()),
-    "host_user": os.path.expanduser("~"),
-    "pid": str(os.getpid()),
-    "xdg_data_home": str(os.environ.get('XDG_DATA_HOME', os.path.expanduser("~") + "/.local/share")),
-    "xdg_runtime_dir": str(os.environ.get('XDG_RUNTIME_DIR')),
-    "wayland_display": str(os.environ.get('WAYLAND_DISPLAY')),
-    "pulse_runtime_path": str(os.environ.get('PULSE_RUNTIME_PATH')),
-    "state": "STOPPED",
-    "lcd_density": "0",
-    "background_start": "true"
-}
-session_defaults["waydroid_user_state"] = session_defaults["xdg_data_home"] + "/waydroid"
-session_defaults["waydroid_data"] = session_defaults["waydroid_user_state"] + "/data"
-if session_defaults["pulse_runtime_path"] == "None":
-    session_defaults["pulse_runtime_path"] = session_defaults["xdg_runtime_dir"] + "/pulse"
+def get_session_defaults():
+    """
+    Build a fresh session-defaults dict from the current environment.
+
+    This must be called at session-start time, not at import time, so the
+    values (WAYLAND_DISPLAY, XDG_RUNTIME_DIR, ...) reflect the compositor
+    environment that is actually running.
+    """
+    session = {
+        "user_name": pwd.getpwuid(os.getuid()).pw_name,
+        "user_id": str(os.getuid()),
+        "group_id": str(os.getgid()),
+        "host_user": os.path.expanduser("~"),
+        "pid": str(os.getpid()),
+        "xdg_data_home": str(os.environ.get('XDG_DATA_HOME', os.path.expanduser("~") + "/.local/share")),
+        "xdg_runtime_dir": str(os.environ.get('XDG_RUNTIME_DIR')),
+        "wayland_display": str(os.environ.get('WAYLAND_DISPLAY')),
+        "pulse_runtime_path": str(os.environ.get('PULSE_RUNTIME_PATH')),
+        "state": "STOPPED",
+        "lcd_density": "0",
+        "background_start": "true"
+    }
+    session["waydroid_user_state"] = session["xdg_data_home"] + "/waydroid"
+    session["waydroid_data"] = session["waydroid_user_state"] + "/data"
+    if session["pulse_runtime_path"] == "None":
+        session["pulse_runtime_path"] = session["xdg_runtime_dir"] + "/pulse"
+    return session
 
 channels_defaults = {
     "config_path": "/usr/share/waydroid-extra/channels.cfg",

--- a/tools/helpers/__init__.py
+++ b/tools/helpers/__init__.py
@@ -13,3 +13,9 @@ import tools.helpers.gpu
 import tools.helpers.protocol
 import tools.helpers.version
 import tools.helpers.logging
+import tools.helpers.run
+import tools.helpers.net
+
+__all__ = ["tools", "arguments", "arch", "props", "lxc", "images",
+           "drivers", "mount", "http", "ipc", "gpu", "protocol",
+           "version", "logging", "run", "net"]

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -11,11 +11,9 @@ import tools.config
 
 """ This file is about parsing command line arguments passed to waydroid, as
     well as generating the help pages (waydroid -h). All this is done with
-    Python's argparse. The parsed arguments get extended and finally stored in
-    the "args" variable, which is prominently passed to most functions all
-    over the waydroid code base.
-
-    See tools/helpers/args.py for more information about the args variable. """
+    Python's argparse. The parsed arguments get extended in tools/__init__.py
+    (see prep_args) and finally stored in the "args" variable, which is
+    prominently passed to most functions all over the waydroid code base. """
 
 def arguments_init(subparser):
     ret = subparser.add_parser("init", help="set up waydroid specific"

--- a/tools/interfaces/INotificationCallback.py
+++ b/tools/interfaces/INotificationCallback.py
@@ -1,7 +1,4 @@
 import gbinder
-import logging
-from tools import helpers
-from gi.repository import GLib
 
 INTERFACE = "lineageos.waydroid.INotifications.INotificationCallback"
 

--- a/tools/interfaces/INotifications.py
+++ b/tools/interfaces/INotifications.py
@@ -84,7 +84,10 @@ def add_service(args, registerListener, notify, closeNotification):
             _, resident = reader.read_bool()
             _, transient = reader.read_bool()
             _, urgency = reader.read_byte()
-            notification_id = notify(replaces_id, app_name, package_name, summary, body, actions, image_data, category, suppress_sound, expire_timeout, resident, transient, urgency)
+            notification_id = notify(replaces_id, app_name, package_name, summary,
+                                     body, actions, image_data, category,
+                                     suppress_sound, expire_timeout, resident,
+                                     transient, urgency)
             local_response.append_int32(0)
             local_response.append_int32(notification_id)
         elif code == TRANSACTION_closeNotification:

--- a/tools/interfaces/IPlatform.py
+++ b/tools/interfaces/IPlatform.py
@@ -280,7 +280,7 @@ class IPlatform:
         request.append_int32(arg1)
         request.append_string16(arg2)
         reply, status = self.client.transact_sync_reply(
-            TRANSACTION_settingsGetString, request)
+            TRANSACTION_settingsGetInt, request)
 
         if status:
             logging.error("Sending reply failed")

--- a/tools/services/__init__.py
+++ b/tools/services/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
-from tools.services.user_manager import start, stop
-from tools.services.clipboard_manager import start, stop
-from tools.services.hardware_manager import start, stop
-from tools.services.notification_manager import start, stop
+from tools.services import (clipboard_manager, hardware_manager,
+                            notification_manager, user_manager)
+
+__all__ = ["clipboard_manager", "hardware_manager",
+           "notification_manager", "user_manager"]

--- a/tools/services/clipboard_manager.py
+++ b/tools/services/clipboard_manager.py
@@ -1,8 +1,8 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import threading
 from tools.interfaces import IClipboard
+from tools.services.runner import ServiceRunner
 
 try:
     import pyclip
@@ -11,7 +11,7 @@ except Exception as e:
     logging.debug(str(e))
     canClip = False
 
-stopping = False
+runner = ServiceRunner("Clipboard", "clipboardLoop")
 
 def start(args):
     def sendClipboardData(value):
@@ -27,23 +27,11 @@ def start(args):
             logging.debug(str(e))
         return ""
 
-    def service_thread():
-        while not stopping:
-            IClipboard.add_service(args, sendClipboardData, getClipboardData)
-
-    if canClip:
-        global stopping
-        stopping = False
-        args.clipboard_manager = threading.Thread(target=service_thread)
-        args.clipboard_manager.start()
-    else:
+    if not canClip:
         logging.debug("Skipping clipboard manager service because of missing pyclip package")
+        return
+
+    runner.start(lambda: IClipboard.add_service(args, sendClipboardData, getClipboardData))
 
 def stop(args):
-    global stopping
-    stopping = True
-    try:
-        if args.clipboardLoop:
-            args.clipboardLoop.quit()
-    except AttributeError:
-        logging.debug("Clipboard service is not even started")
+    runner.stop(args)

--- a/tools/services/hardware_manager.py
+++ b/tools/services/hardware_manager.py
@@ -1,23 +1,48 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import threading
 import time
-import os
 import tools.actions.container_manager
 import tools.actions.session_manager
 import tools.config
 from tools import helpers
 from tools.interfaces import IHardware
+from tools.services.runner import ServiceRunner
 
-stopping = False
+runner = ServiceRunner("Hardware", "hardwareLoop")
 
 def start(args):
     def enableNFC(enable):
-        logging.debug("Function enableNFC not implemented")
+        """
+        Intentionally unimplemented.
+
+        Android invokes this over the IHardware binder service whenever NFC
+        is toggled on/off. It stays a stub because this codebase has no data
+        plane between the container's Android NFC stack and the host's NFC
+        hardware: there is no HAL or forwarding service for the container to
+        reach the host adapter, so toggling the host nfcd from here could
+        not make NFC work in Android anyway.
+
+        The former container_manager NFC hacks (stop host nfcd at container
+        start, restart it at stop) were a session-scoped workaround for the
+        host and container daemons contending over the NFC adapter, not
+        toggle-driven control; they were removed together with the TODO that
+        marked them. Driving host nfcd from this callback would restart that
+        contention: starting it while the container's nfcd is active would
+        leave two daemons fighting over one adapter. Real handling belongs
+        in a session-scoped or hardware-adaptation layer that owns the NFC
+        device and restores host nfcd state at session teardown.
+        """
+        logging.warning("enableNFC not implemented: host NFC daemon is left untouched")
 
     def enableBluetooth(enable):
-        logging.debug("Function enableBluetooth not implemented")
+        """
+        Intentionally unimplemented, for the same reason as enableNFC: the
+        container's Bluetooth stack is self-contained in this codebase (no
+        host-side service is wired up for it), so there is nothing to drive
+        from this callback.
+        """
+        logging.warning("enableBluetooth not implemented: container Bluetooth is self-contained")
 
     def suspend():
         cfg = tools.config.load(args)
@@ -36,7 +61,8 @@ def start(args):
         helpers.images.replace(args, system_zip, system_time,
                                vendor_zip, vendor_time)
         args.session["background_start"] = "false"
-        helpers.images.mount_rootfs(args, args.images_path, args.session)
+        cfg = tools.config.load(args)
+        helpers.images.mount_rootfs(args, cfg["waydroid"]["images_path"], args.session)
         helpers.protocol.set_aidl_version(args)
         helpers.lxc.start(args)
 
@@ -58,21 +84,8 @@ def start(args):
         else:
             tools.actions.container_manager.stop(args)
 
-    def service_thread():
-        while not stopping:
-            IHardware.add_service(
-                args, enableNFC, enableBluetooth, suspend, reboot, upgrade, shutdownRequest)
-
-    global stopping
-    stopping = False
-    args.hardware_manager = threading.Thread(target=service_thread)
-    args.hardware_manager.start()
+    runner.start(lambda: IHardware.add_service(
+        args, enableNFC, enableBluetooth, suspend, reboot, upgrade, shutdownRequest))
 
 def stop(args):
-    global stopping
-    stopping = True
-    try:
-        if args.hardwareLoop:
-            args.hardwareLoop.quit()
-    except AttributeError:
-        logging.debug("Hardware service is not even started")
+    runner.stop(args)

--- a/tools/services/notification_manager.py
+++ b/tools/services/notification_manager.py
@@ -1,14 +1,11 @@
 # Copyright 2025 Alessandro Astone
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import os
-import threading
-import tools.config
 from tools.interfaces import INotifications
-from gi.repository import GLib
+from tools.services.runner import ServiceRunner
 import dbus
 
-stopping = False
+runner = ServiceRunner("NotificationManager", "notificationLoop")
 bus_signals = []
 
 def start(args, session):
@@ -20,7 +17,9 @@ def start(args, session):
         listener.addDeathHandler(onListenerDeath)
         listeners.append(listener)
 
-    def notify(replaces_id, app_name, package_name, summary, body, actions, image_data, category, suppress_sound, expire_timeout, resident, transient, urgency):
+    def notify(replaces_id, app_name, package_name, summary, body, actions,
+               image_data, category, suppress_sound, expire_timeout, resident,
+               transient, urgency):
         # By reading the spec, I believe app_icon should be pointing to the desktop entry Icon=
         # but when we set it plasmashell uses it in place of image-data.
         # Ignore app_icon and use desktop-entry to show the app icon.
@@ -66,13 +65,11 @@ def start(args, session):
         for listener in listeners:
             listener.onActionInvoked(int(notification_id), str(action_id), str(token))
 
-    def service_thread():
-        while not stopping:
-            INotifications.add_service(args, registerListener, notify, closeNotification)
-
     try:
-        dbus_proxy = dbus.Interface(dbus.SessionBus().get_object("org.freedesktop.Notifications", "/org/freedesktop/Notifications"),
-                                    "org.freedesktop.Notifications")
+        dbus_proxy = dbus.Interface(
+            dbus.SessionBus().get_object("org.freedesktop.Notifications",
+                                         "/org/freedesktop/Notifications"),
+            "org.freedesktop.Notifications")
     except dbus.DBusException as e:
         logging.info("Skipping notification manager service because we could not connect to the notifications server: %s", str(e))
         return
@@ -82,18 +79,9 @@ def start(args, session):
     bus_signals.append(dbus_proxy.connect_to_signal("ActivationToken", onActivationToken))
     bus_signals.append(dbus_proxy.connect_to_signal("ActionInvoked", onActionInvoked))
 
-    global stopping
-    stopping = False
-    args.notification_manager = threading.Thread(target=service_thread)
-    args.notification_manager.start()
+    runner.start(lambda: INotifications.add_service(args, registerListener, notify, closeNotification))
 
 def stop(args):
-    global stopping
-    stopping = True
     for signal in bus_signals:
         signal.remove()
-    try:
-        if args.notificationLoop:
-            args.notificationLoop.quit()
-    except AttributeError:
-        logging.debug("NotificationManager service is not even started")
+    runner.stop(args)

--- a/tools/services/runner.py
+++ b/tools/services/runner.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+import threading
+
+
+class ServiceRunner:
+    """
+    Run a per-session binder service in a background thread.
+
+    Collapses the lifecycle pattern shared by all per-session services
+    (user_manager, clipboard_manager, hardware_manager, notification_manager):
+    a stop flag, a worker thread that keeps re-registering the service, and a
+    GLib main loop that the binder interface installs on ``args`` (e.g.
+    ``args.hardwareLoop``) and that must be quit on stop.
+    """
+
+    def __init__(self, name, loop_attr):
+        self.name = name
+        self.loop_attr = loop_attr
+        self._stopping = False
+        self._thread = None
+
+    def start(self, run_fn):
+        """Run ``run_fn`` repeatedly in a background thread until stopped."""
+        self._stopping = False
+        self._thread = threading.Thread(target=self._loop, args=(run_fn,))
+        self._thread.start()
+
+    def _loop(self, run_fn):
+        while not self._stopping:
+            run_fn()
+
+    def stop(self, args):
+        """Ask the thread to stop and quit the service's GLib main loop."""
+        self._stopping = True
+        loop = getattr(args, self.loop_attr, None)
+        if loop:
+            loop.quit()
+        else:
+            logging.debug("%s service is not even started", self.name)
+
+    def join(self, timeout=None):
+        """Wait for the worker thread to finish (no-op if never started)."""
+        if self._thread:
+            self._thread.join(timeout)

--- a/tools/services/user_manager.py
+++ b/tools/services/user_manager.py
@@ -1,16 +1,16 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
-import threading
 import tools.config
 import tools.helpers.net
 from pathlib import Path
 from contextlib import suppress
 from tools.interfaces import IUserMonitor
 from tools.interfaces import IPlatform
+from tools.services.runner import ServiceRunner
 from gi.repository import GLib
 
-stopping = False
+runner = ServiceRunner("UserMonitor", "userMonitorLoop")
 
 
 def start(args, session, unlocked_cb=None):
@@ -125,7 +125,10 @@ def start(args, session, unlocked_cb=None):
             desktop_file.set_boolean("Desktop Entry", "NoDisplay", True)
 
         desktop_file.set_string("Desktop Action app-settings", "Name", "App Settings")
-        desktop_file.set_string("Desktop Action app-settings", "Exec", f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS package:{packageName}")
+        desktop_file.set_string(
+            "Desktop Action app-settings", "Exec",
+            f"waydroid app intent android.settings.APPLICATION_DETAILS_SETTINGS "
+            f"package:{packageName}")
         desktop_file.set_string("Desktop Action app-settings", "Icon", str(waydroid_data_icons_dir / "com.android.settings.png"))
 
         desktop_file.save_to_file(str(desktop_file_path))
@@ -161,21 +164,8 @@ def start(args, session, unlocked_cb=None):
                 appInfo = platformService.getAppInfo(packageName)
                 updateDesktopFile(appInfo)
 
-    def service_thread():
-        while not stopping:
-            IUserMonitor.add_service(args, userUnlocked, packageStateChanged)
-
-    global stopping
-    stopping = False
-    args.user_manager = threading.Thread(target=service_thread)
-    args.user_manager.start()
+    runner.start(lambda: IUserMonitor.add_service(args, userUnlocked, packageStateChanged))
 
 
 def stop(args):
-    global stopping
-    stopping = True
-    try:
-        if args.userMonitorLoop:
-            args.userMonitorLoop.quit()
-    except AttributeError:
-        logging.debug("UserMonitor service is not even started")
+    runner.stop(args)

--- a/waydroid.py
+++ b/waydroid.py
@@ -4,7 +4,15 @@
 # PYTHON_ARGCOMPLETE_OK
 import os
 import sys
-import tools
+
+try:
+    import tools
+except ModuleNotFoundError as e:
+    print("Waydroid could not start: the Python module '{}' is not installed.".format(e.name),
+          file=sys.stderr)
+    print("Install the corresponding package (e.g. python3-{}).".format(e.name.split(".")[0]),
+          file=sys.stderr)
+    sys.exit(1)
 
 if __name__ == "__main__":
     os.umask(0o0022)


### PR DESCRIPTION
Refactors the CLI dispatch from a long if/elif chain into a `DISPATCH` table. Each entry declares its guard flags, and `ROOT_ACTIONS` / `ALLOWED_UNINITIALIZED` are derived from them, so a new action cannot silently skip the root/init guards.

Highlights:
- `tools/services/runner.py`: common `ServiceRunner` for the clipboard, hardware, notification and user-manager DBus services
- `get_session_defaults()`: session defaults are computed at session start (not import time) so `WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, ... reflect the compositor that is actually running; `WAYLAND_SOCKET` is honored
- `waydroid log` prefers the root container log when running as a non-root user unless `-l/--log` was given
- entry-point hardening with a clear message when `tools` is not installed
- pytest suite (dbus/gi/gbinder stubbed) for dispatch, session defaults and the runner

Follow-ups in the fork's split (not included here): 1.6.4 hardening batch, ARM64 translation layer, release workflow, `make check` uvx fallback, LOS 13–16 docs — each as its own PR.

Verified: `ruff check .` clean, `pytest` 18 passed.