### PR TITLE
container: harden startup/teardown, schedtune probe, and binder handling

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,3 +35,12 @@ jobs:
         run: pip install ruff
       - name: Run linter
         run: ruff check --output-format=github
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ install:
 	cp dbus/id.waydro.Container.policy $(INSTALL_POLKIT_DIR)/actions/
 	if [ $(USE_DBUS_ACTIVATION) = 1 ]; then \
 		install -d $(INSTALL_DBUS_DIR)/system-services; \
-		cp dbus/id.waydro.Container.service $(INSTALL_DBUS_DIR)/system-services/; \
+		sed 's|@BINDIR@|$(BIN_DIR)|g' dbus/id.waydro.Container.service > $(INSTALL_DBUS_DIR)/system-services/id.waydro.Container.service; \
 	fi
 	if [ $(USE_SYSTEMD) = 1 ]; then \
 		install -d $(INSTALL_SYSD_DIR); \
-		cp systemd/waydroid-container.service $(INSTALL_SYSD_DIR); \
+		sed 's|@BINDIR@|$(BIN_DIR)|g' systemd/waydroid-container.service > $(INSTALL_SYSD_DIR)/waydroid-container.service; \
 	fi
 	if [ $(USE_NFTABLES) = 1 ]; then \
-		sed '/LXC_USE_NFT=/ s/false/true/' -i $(INSTALL_WAYDROID_DIR)/data/scripts/waydroid-net.sh; \
+		sed 's/^LXC_USE_NFT=.*/LXC_USE_NFT="true"/' -i $(INSTALL_WAYDROID_DIR)/data/scripts/waydroid-net.sh; \
 	fi
 
 install_apparmor:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,135 @@ See install instructions [here](https://docs.waydro.id/usage/install-on-desktops
 
 Our documentation can be found at [docs.waydro.id](https://docs.waydro.id)
 
+See also [Host integration mechanisms](docs/host-integration.md) for how
+Waydroid reaches into host services and hardware (networking, sensors, NFC).
+
+## Host prerequisites
+
+### Binder devices
+
+Waydroid needs `/dev/binder`, `/dev/hwbinder` and `/dev/vndbinder`. Kernels
+with binder built in (`CONFIG_ANDROID_BINDER_IPC=y`, `CONFIG_ANDROID_BINDERFS=y`)
+still do not create the nodes until binderfs is mounted; on such systems
+expose them with:
+
+```sh
+mkdir -p /dev/binderfs
+mount -t binder binder /dev/binderfs
+ln -sf /dev/binderfs/binder /dev/binder
+ln -sf /dev/binderfs/hwbinder /dev/hwbinder
+ln -sf /dev/binderfs/vndbinder /dev/vndbinder
+```
+
+To make this survive reboots, add the mount to `/etc/fstab`
+(`binder /dev/binderfs binder defaults 0 0`) and a systemd-tmpfiles entry
+that recreates the symlinks.
+
+### Firewall
+
+Waydroid's container requests its address via DHCP on the `waydroid0`
+bridge. On hosts with a default-deny firewall (e.g. ufw), the DHCP
+DISCOVER broadcast to port 67 and the FORWARD path are dropped before
+Waydroid's own rules run, leaving the container with no address and no
+routing. Allow the bridge explicitly:
+
+```sh
+ufw allow in on waydroid0 to any port 53,67 proto udp
+ufw allow in on waydroid0 to any port 53,67 proto tcp
+ufw route allow in on waydroid0
+ufw route allow out on waydroid0
+```
+
+Without this, `waydroid status` reports `IP address: UNKNOWN` and the
+container has no network even though the session and container are running.
+
+## schedtune cgroup handling
+
+`schedtune` is a cgroup controller used by Android for CPU-boost tuning. On
+Ubuntu Touch / Halium devices it is mounted on the host and provides better
+system-wide performance with very little effort, and Waydroid's Android keeps
+using that mechanism inside the container.
+
+### Why the mount is probed
+
+The Waydroid container inherits the host's cgroup hierarchy read-only
+(`lxc.mount.auto = cgroup:ro`). Android can only use schedtune if it can nest
+its own cgroups inside the hierarchy, i.e. if new cgroups can be created
+within it. That nesting capability requires a kernel patch that some devices
+are missing; on those kernels, a read-only, non-nestable schedtune handed to
+Android is simply broken.
+
+At container start (`keep_schedtune_if_nestable` in
+`tools/actions/container_manager.py`) Waydroid probes for nesting support:
+
+1. If `/sys/fs/cgroup/schedtune` is not mounted, nothing happens.
+2. Otherwise it creates a throwaway nested cgroup (`probe0/probe1`):
+   - Creation succeeds — the kernel supports nesting — and the mount is kept,
+     so Android in the container keeps access to the boost mechanism.
+   - Creation fails — the kernel lacks the nesting patch — and the hierarchy
+     is lazily unmounted (`umount -l`), letting Android set up its own
+     schedtune inside the container.
+
+### What you may observe
+
+- After starting Waydroid, `/sys/fs/cgroup/schedtune` may no longer be mounted
+  on the host. That is expected on kernels without the nesting patch.
+- If the unmount fails (e.g. the hierarchy is busy), a warning is logged and
+  the container inherits the non-nestable hierarchy; schedtune-based
+  performance tuning will not work in that session.
+- On kernels with nesting support the mount is preserved, so the host's
+  schedtune CPU boosting keeps working both on the host and inside the
+  container.
+
+### Troubleshooting
+
+The warning
+
+```
+Failed to unmount /sys/fs/cgroup/schedtune (umount exited with ...); the
+container will inherit a non-nestable schedtune hierarchy
+```
+
+is logged when the nesting probe failed (or the hierarchy is otherwise
+unusable) and the lazy unmount did not take effect. It is non-fatal: the
+container still starts, but schedtune-based performance tuning will not work
+inside it.
+
+First check whether the mount is still present and test nesting support
+manually as root:
+
+```
+findmnt /sys/fs/cgroup/schedtune
+mkdir -p /sys/fs/cgroup/schedtune/probe0/probe1
+rmdir /sys/fs/cgroup/schedtune/probe0/probe1 /sys/fs/cgroup/schedtune/probe0
+```
+
+- If the `mkdir` fails (e.g. `Operation not permitted` or `Read-only file
+  system`), the kernel lacks the nesting patch and the probe behaved as
+  designed — the remaining problem is the failed unmount. Try unmounting
+  manually before starting the container (`umount -l
+  /sys/fs/cgroup/schedtune`); if that fails too, something is holding the
+  hierarchy (e.g. a bind mount or another container) and must be released
+  first.
+- If the `mkdir` succeeds but Waydroid still warns, the probe itself should
+  have kept the mount — that is unexpected and worth reporting.
+
+When reporting a bug about this warning, please include:
+
+- the relevant section of `waydroid log` (the container service log)
+- the Waydroid version and `uname -a`
+- the output of `findmnt /sys/fs/cgroup/schedtune` before and after the probe
+- the result of the manual probe above
+- your device model, and whether the host runs Android init (Ubuntu Touch /
+  Halium) or a regular GNU/Linux distribution
+
+### History
+
+Originally Waydroid unmounted schedtune unconditionally, which dropped
+performance on devices whose kernels *did* support nesting. The probe was
+added so the mount is kept whenever possible and removed only when it would
+otherwise be handed to Android broken.
+
 ## Reporting bugs
 
 If you have found an issue with Waydroid, please [file a bug](https://github.com/Waydroid/waydroid/issues/new/choose).

--- a/data/scripts/waydroid-net.sh
+++ b/data/scripts/waydroid-net.sh
@@ -25,12 +25,17 @@ LXC_DHCP_MAX="253"
 LXC_DHCP_CONFILE=""
 LXC_DHCP_PING="true"
 LXC_DOMAIN=""
-LXC_USE_NFT="false"
+# Network backend: "true" (nftables), "false" (iptables), or "auto"
+# (nftables only when no iptables tooling is installed). The Makefile's
+# USE_NFTABLES=1 flips this line to "true" at install time.
+LXC_USE_NFT="${LXC_USE_NFT:-auto}"
 
-LXC_IPV6_ADDR=""
-LXC_IPV6_MASK=""
-LXC_IPV6_NETWORK=""
-LXC_IPV6_NAT="false"
+# IPv6 NAT is off by default; set LXC_IPV6_ADDR/MASK/NETWORK and
+# LXC_IPV6_NAT=true (in the environment or the config) to enable it.
+LXC_IPV6_ADDR="${LXC_IPV6_ADDR:-}"
+LXC_IPV6_MASK="${LXC_IPV6_MASK:-}"
+LXC_IPV6_NETWORK="${LXC_IPV6_NETWORK:-}"
+LXC_IPV6_NAT="${LXC_IPV6_NAT:-false}"
 
 IPTABLES_BIN="$(command -v iptables-legacy)"
 if [ ! -n "$IPTABLES_BIN" ]; then
@@ -42,7 +47,13 @@ if [ ! -n "$IP6TABLES_BIN" ]; then
 fi
 
 use_nft() {
-    [ -n "$NFT" ] && nft list ruleset > /dev/null 2>&1 && [ "$LXC_USE_NFT" = "true" ]
+    [ -n "$NFT" ] || return 1
+    nft list ruleset > /dev/null 2>&1 || return 1
+    if [ "$LXC_USE_NFT" = "true" ]; then
+        return 0
+    fi
+    # "auto": fall back to nftables only when no iptables tooling exists
+    [ "$LXC_USE_NFT" = "auto" ] && [ -z "$IPTABLES_BIN" ]
 }
 
 NFT="$(command -v nft)"

--- a/dbus/id.waydro.Container.service
+++ b/dbus/id.waydro.Container.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=id.waydro.Container
-Exec=/usr/bin/waydroid -w container start
+Exec=@BINDIR@/waydroid -w container start
 User=root
 SystemdService=waydroid-container.service

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+waydroid (1.6.4) bullseye; urgency=medium
+
+  * tools: Add ServiceRunner and dispatch table, harden set_permissions
+  * tools: Derive root/init guards from the dispatch table
+  * config: Compute session defaults at session start, fix upgrade images path
+  * container: Extract networking/sensors into helpers, add make check
+  * tools: Fix -l/--log flag, binder config fallbacks, sensord teardown
+  * container: Fix binder settings transaction, harden container control
+  * container: Retry schedtune lazy unmount before warning
+  * net: Auto-detect nftables when no iptables tooling is installed
+  * drivers: Persist binder node names on upgrade
+  * initializer: Harden Halium vendor-type detection
+  * Makefile: Substitute prefix into systemd/dbus activation files
+  * Add pytest test suite and CI job
+  * arm-translation: Add libndk_translation support for ARM apps on x86_64
+
+ -- IAmAzmathullaShaikh <iamshaikhazmathulla@gmail.com>  Fri, 14 Aug 2026 12:00:00 +0530
+
 waydroid (1.6.3) bullseye; urgency=medium
 
   * tools: Fix all occurrences of unused variable warning

--- a/docs/distro-packaging.md
+++ b/docs/distro-packaging.md
@@ -1,0 +1,67 @@
+# Host prerequisites — notes for distro packagers
+
+Users repeatedly hit the same two host-side prerequisites ("IP address:
+UNKNOWN" and missing binder nodes). Packages can't configure the host, but
+packagers can surface the requirements in post-install notes and make sure
+the runtime dependencies are right.
+
+## Binder nodes
+
+Waydroid needs `/dev/binder`, `/dev/hwbinder` and `/dev/vndbinder`.
+Kernels with binder built in (`CONFIG_ANDROID_BINDER_IPC=y`,
+`CONFIG_ANDROID_BINDERFS=y`) don't create the nodes until binderfs is
+mounted. Recommended packaging support:
+
+- Ship a systemd-tmpfiles entry (e.g. `/usr/lib/tmpfiles.d/waydroid.conf`):
+
+  ```
+  d /dev/binderfs 0755 root root -
+  L /dev/binder - - - - /dev/binderfs/binder
+  L /dev/hwbinder - - - - /dev/binderfs/hwbinder
+  L /dev/vndbinder - - - - /dev/binderfs/vndbinder
+  ```
+
+- Document the fstab line for the binderfs mount
+  (`binder /dev/binderfs binder defaults 0 0`).
+
+The `waydroid init` path already tries `modprobe binder_linux` and mounts
+binderfs itself when needed (`tools/helpers/drivers.py`), so the tmpfiles
+entry is a convenience, not a hard requirement.
+
+## Firewall / default-deny hosts
+
+The container's DHCP DISCOVER and the FORWARD path are dropped before
+Waydroid's own rules run on hosts with a default-deny firewall (ufw,
+firewalld with a strict policy). `waydroid status` then reports
+`IP address: UNKNOWN`. There is nothing Waydroid can do from inside the
+session; the host admin must allow traffic on the `waydroid0` bridge, e.g.
+with ufw:
+
+```
+ufw allow in on waydroid0 to any port 53,67 proto udp
+ufw allow in on waydroid0 to any port 53,67 proto tcp
+ufw route allow in on waydroid0
+ufw route allow out on waydroid0
+```
+
+## Network backend
+
+`data/scripts/waydroid-net.sh` now defaults to **auto-detection**:
+nftables when `nft` is present and no iptables tooling is installed,
+otherwise iptables (preferring `iptables-legacy`). The Makefile's
+`USE_NFTABLES=1` still forces nftables at install time.
+
+- Packages that already depend on iptables (Debian does, via
+  `debian/control`) get the iptables path — no change needed.
+- nftables-only distros get the nftables path automatically — do **not**
+  add an `iptables` dependency that the script no longer strictly needs.
+- IPv6 NAT stays off by default; users enable it via the `LXC_IPV6_*`
+  environment variables (see `docs/host-integration.md`).
+
+## schedtune (Halium / Ubuntu Touch hosts)
+
+On Halium hosts, Waydroid probes whether the host `schedtune` cgroup
+supports nesting and unmounts it otherwise. This is runtime behavior with
+no packaging impact, but bug reports about the warning ("Failed to unmount
+/sys/fs/cgroup/schedtune") are expected on kernels without the nesting
+patch — see the README's schedtune section for the troubleshooting flow.

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -1,0 +1,105 @@
+# Host integration mechanisms
+
+When a session starts, the root container service
+(`tools/actions/container_manager.py`) runs a series of host-side steps around
+booting the container. This page covers the ones that reach into host
+services and hardware — networking, sensors, and NFC. (The schedtune cgroup
+handling is documented in the [README](README.md#schedtune-cgroup-handling).)
+
+The container startup sequence, in order:
+
+1. load the binder/ashmem drivers and set device permissions
+2. run `data/scripts/waydroid-net.sh start` (networking, below)
+3. launch `waydroid-sensord` if installed (sensors, below)
+4. start Android init's `cgroup-lite` service if present (Halium hosts)
+5. probe/keep the schedtune cgroup (see README)
+6. generate the session LXC config, mount the rootfs, boot the container
+
+## Networking — `waydroid-net.sh`
+
+`data/scripts/waydroid-net.sh` gives the container its own private network:
+`waydroid-net.sh start` at container start, `waydroid-net.sh stop` at stop.
+
+It creates the `waydroid0` bridge (the name is read from the LXC config's
+`lxc.net.0.link`, defaulting to `waydroid0`), assigns it `192.168.240.1/24`
+with the LXC MAC `00:16:3e:00:00:01`, enables IPv4 forwarding, and starts a
+hermetic `dnsmasq` serving DHCP (`192.168.240.2`–`.254`) and DNS on the
+bridge. The dnsmasq is deliberately isolated from the host's
+`/etc/dnsmasq.conf` (`--conf-file=/dev/null`) and runs as the first of
+`lxc-dnsmasq`, `dnsmasq`, or `nobody` that exists.
+
+Outbound access is provided through NAT:
+
+- **iptables** by default — it prefers `iptables-legacy` when installed.
+  Rules accept DHCP/DNS traffic on the bridge, ACCEPT forwarding, add a
+  POSTROUTING MASQUERADE for `192.168.240.0/24`, and fix the DHCP reply
+  checksum (mangle rule on port 68).
+- **nftables** when `LXC_USE_NFT=true` — the Makefile's `USE_NFTABLES=1`
+  flips this at install time. Equivalent ruleset in the `lxc` tables. When
+  the variable is unset it defaults to `auto`: nftables is used only when
+  `nft` is present and no iptables tooling is installed, so nftables-only
+  hosts (minimal distros) work out of the box while hosts with iptables
+  keep the legacy path.
+
+The script is idempotent: `start` refuses to run if
+`/run/waydroid-lxc/network_up` already exists (and force-stops a stale
+bridge first), and `stop` tears down the rules, kills dnsmasq, and removes
+the bridge unless interfaces are still attached.
+
+### IPv6 NAT
+
+IPv6 NAT is supported (`LXC_IPV6_*` variables) but disabled by default.
+The script reads them from the environment, so it can be enabled per
+session without editing the script:
+
+```
+LXC_IPV6_ADDR=fd00::1 LXC_IPV6_MASK=64 \
+LXC_IPV6_NETWORK=fd00::/64 LXC_IPV6_NAT=true \
+waydroid-net.sh start
+```
+
+When enabled, dnsmasq serves router-advertisements on the bridge
+(`--dhcp-range=<addr>,ra-only`) and the NAT rules (iptables or nftables)
+masquerade the container subnet. It stays off by default because adding
+IPv6 to the bridge can surprise hosts with existing IPv6 setup (e.g.
+`accept_dad` is disabled on the bridge by the script).
+
+## Sensors — `waydroid-sensord`
+
+If `waydroid-sensord` is installed, it is launched in the background at
+container start with the hwbinder device node:
+
+```
+waydroid-sensord /dev/hwbinder
+```
+
+(`hwbinder` is the configured binder node, the same one the container's
+Android services use.) Sensord is the host-side daemon that forwards the
+device's sensors to Android inside the container over the shared hwbinder,
+so apps get accelerometer/gyro/etc. data. At container stop, sensord is
+looked up with `pidof` and killed. On regular desktops there is no sensord
+binary and this step is a no-op.
+
+## NFC — the removed nfcd hacks
+
+Historically, `container_manager` stopped the host's `nfcd` daemon at
+container start and restarted it at stop (via Android init's `stop`/`start`
+commands, falling back to `systemctl`). The reason: on hosts that run
+Android's nfcd (Ubuntu Touch / Halium), the host and container NFC daemons
+would contend over the single NFC adapter, so the hack gave the container's
+nfcd exclusive access for the session.
+
+Those blocks were marked `#TODO: remove NFC hacks` and are now removed, so
+the host nfcd is left untouched and Android's nfcd inside the container
+manages the adapter on its own. Two consequences worth knowing:
+
+- The `enableNFC`/`enableBluetooth` binder callbacks in
+  `tools/services/hardware_manager.py` remain intentionally unimplemented
+  (see their docstrings): this codebase has no data plane between the
+  container's Android NFC stack and the host's NFC hardware, so toggling
+  the host nfcd from the callback could not make NFC work in Android and
+  would risk recreating the very contention the hacks prevented.
+- On hosts that do run nfcd, NFC hardware access is no longer arbitrated
+  between host and container — if both daemons are active, they may
+  contend. If you observe that, the fix belongs in a session-scoped or
+  hardware-adaptation layer, not in the removed stop/start hack.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ ignore = [
 	"F401", # TODO: Remove this once unused imports are removed.
 	"F811", # TODO: Remove this once redefined variables are refactored.
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/systemd/waydroid-container.service
+++ b/systemd/waydroid-container.service
@@ -4,7 +4,7 @@ Description=Waydroid Container
 [Service]
 UMask=0022
 BusName=id.waydro.Container
-ExecStart=/usr/bin/waydroid container start
+ExecStart=@BINDIR@/waydroid container start
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pytest configuration.
+
+The waydroid ``tools`` package imports heavy runtime dependencies (dbus,
+PyGObject, gbinder) at module import time. The pure-logic helpers under test
+(arch, protocol, images, mount) don't use any of them, so we stub them out in
+``sys.modules`` to keep the test suite runnable in a minimal environment
+(e.g. CI without those native packages installed).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+HEAVY_DEPS = [
+    "dbus",
+    "dbus.exceptions",
+    "dbus.mainloop.glib",
+    "dbus.service",
+    "gbinder",
+    "gi",
+    "gi.repository",
+    "gi.repository.GLib",
+]
+
+
+class _StubModule(types.ModuleType):
+    """A module that answers any attribute access with a MagicMock."""
+
+    def __getattr__(self, attr):
+        return MagicMock()
+
+
+def _install_stub(name):
+    if name in sys.modules:
+        return
+    module = _StubModule(name)
+    sys.modules[name] = module
+    # Make dotted names importable (e.g. `import dbus.mainloop.glib`).
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = _StubModule(parent)
+
+
+for _name in HEAVY_DEPS:
+    _install_stub(_name)

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import os
+
+import tools.actions.container_manager as container_manager
+
+
+class _Args:
+    pass
+
+
+def _fake_user(calls):
+    def fake_user(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 0  # successful command exit code
+    return fake_user
+
+
+def _failing_makedirs(path):
+    # Simulate a kernel without the nesting patch: creating the first probe
+    # level succeeds but the nested one fails (EPERM).
+    os.mkdir(os.path.dirname(path))
+    raise OSError("simulated EPERM")
+
+
+def test_start_networking_runs_script(monkeypatch):
+    monkeypatch.setattr(container_manager, "WAYDROID_NET_SCRIPT", "/x/waydroid-net.sh")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_networking(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["/x/waydroid-net.sh", "start"]
+    # No check kwarg: failures must raise so do_start aborts
+    assert "check" not in calls[0][1]
+
+
+def test_stop_networking_best_effort(monkeypatch):
+    monkeypatch.setattr(container_manager, "WAYDROID_NET_SCRIPT", "/x/waydroid-net.sh")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.stop_networking(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["/x/waydroid-net.sh", "stop"]
+    assert calls[0][1]["check"] is False
+
+
+def test_start_sensors_when_installed(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord" if name == "waydroid-sensord" else None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+    args = _Args()
+    args.HWBINDER_DRIVER = "hwbinder"
+
+    container_manager.start_sensors(args)
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["waydroid-sensord", "/dev/hwbinder"]
+    assert calls[0][1]["output"] == "background"
+
+
+def test_start_sensors_when_missing(monkeypatch):
+    monkeypatch.setattr(container_manager, "which", lambda name: None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_sensors(_Args())
+
+    assert calls == []
+
+
+def _stop_sensors_fake(calls, pidof_output):
+    def fake_user(*args, **kwargs):
+        calls.append((args, kwargs))
+        if args[1][0] == "pidof":
+            return pidof_output
+        return 0
+    return fake_user
+
+
+def test_stop_sensors_none_running(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _stop_sensors_fake(calls, ""))
+
+    container_manager.stop_sensors(_Args())
+
+    assert len(calls) == 1  # only the pidof probe, no kill
+    assert calls[0][0][1] == ["pidof", "waydroid-sensord"]
+
+
+def test_stop_sensors_single_pid(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _stop_sensors_fake(calls, "1234"))
+
+    container_manager.stop_sensors(_Args())
+
+    assert calls[1][0][1] == ["kill", "-9", "1234"]
+
+
+def test_stop_sensors_multiple_pids(monkeypatch):
+    # A stale daemon from a crashed session results in multiple pids; all
+    # of them must be killed, not passed as one invalid string.
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/waydroid-sensord")
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _stop_sensors_fake(calls, "1234 5678"))
+
+    container_manager.stop_sensors(_Args())
+
+    assert calls[1][0][1] == ["kill", "-9", "1234", "5678"]
+
+
+def test_set_permissions_system_and_app_modes(monkeypatch, tmp_path):
+    system = tmp_path / "sysnode"
+    app = tmp_path / "appnode"
+    system.touch()
+    app.touch()
+    monkeypatch.setattr(container_manager, "SYSTEM_DEVICES", [str(system)])
+    monkeypatch.setattr(container_manager, "APP_DEVICES", [str(app)])
+    monkeypatch.setattr("glob.glob", lambda pattern: [])
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+    session = {"user_id": "1000", "group_id": "1000"}
+
+    container_manager.set_permissions(_Args(), session=session)
+
+    chmods = [c[0][1] for c in calls if c[0][1][0] == "chmod"]
+    chowns = [c[0][1] for c in calls if c[0][1][0] == "chown"]
+    assert ["chmod", "660", "-R", str(system)] in chmods
+    assert ["chmod", "666", "-R", str(app)] in chmods
+    assert ["chown", "1000:1000", "-R", str(system)] in chowns
+    assert ["chown", "1000:1000", "-R", str(app)] in chowns
+
+
+def test_set_permissions_without_session_skips_chown(monkeypatch, tmp_path):
+    node = tmp_path / "node"
+    node.touch()
+    monkeypatch.setattr(container_manager, "SYSTEM_DEVICES", [str(node)])
+    monkeypatch.setattr(container_manager, "APP_DEVICES", [])
+    monkeypatch.setattr("glob.glob", lambda pattern: [])
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.set_permissions(_Args())
+
+    assert all(c[0][1][0] != "chown" for c in calls)
+    assert ["chmod", "660", "-R", str(node)] in [c[0][1] for c in calls]
+
+
+def test_set_permissions_explicit_list_uses_mode(monkeypatch, tmp_path):
+    node = tmp_path / "node"
+    node.touch()
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.set_permissions(_Args(), perm_list=[str(node)], mode="660")
+
+    assert [c[0][1] for c in calls] == [["chmod", "660", "-R", str(node)]]
+
+
+def test_cgroup_lite_started_when_init_available(monkeypatch):
+    monkeypatch.setattr(
+        container_manager, "which", lambda name: "/usr/bin/start" if name == "start" else None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_cgroup_lite_if_available(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["start", "cgroup-lite"]
+    assert calls[0][1]["check"] is False
+
+
+def test_cgroup_lite_skipped_when_init_unavailable(monkeypatch):
+    monkeypatch.setattr(container_manager, "which", lambda name: None)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.start_cgroup_lite_if_available(_Args())
+
+    assert calls == []
+
+
+def test_schedtune_not_mounted_is_noop(monkeypatch):
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", "/nonexistent/schedtune")
+    monkeypatch.setattr(os.path, "ismount", lambda path: False)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert calls == []
+
+
+def test_schedtune_nestable_is_kept(monkeypatch, tmp_path):
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert calls == []
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))
+
+
+def test_schedtune_not_nestable_is_unmounted(monkeypatch, tmp_path):
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    calls = []
+    monkeypatch.setattr("tools.helpers.run.user", _fake_user(calls))
+    monkeypatch.setattr(os, "makedirs", _failing_makedirs)
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert len(calls) == 1
+    assert calls[0][0][1] == ["umount", "-l", schedtune]
+    # Partially created probe must still be cleaned up
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))
+
+
+def test_schedtune_umount_failure_is_logged(monkeypatch, tmp_path, caplog):
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    monkeypatch.setattr(os, "makedirs", _failing_makedirs)
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: 32)
+    monkeypatch.setattr(container_manager.time, "sleep", lambda s: None)
+
+    with caplog.at_level("WARNING"):
+        container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert any("Failed to unmount" in record.message for record in caplog.records)
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))
+
+
+def test_schedtune_umount_retried_then_succeeds(monkeypatch, tmp_path):
+    # The lazy unmount is retried: a busy hierarchy that frees up on the
+    # second attempt must not end up in a warning.
+    schedtune = str(tmp_path / "schedtune")
+    os.mkdir(schedtune)
+    monkeypatch.setattr(container_manager, "SCHEDTUNE_PATH", schedtune)
+    monkeypatch.setattr(os.path, "ismount", lambda path: path == schedtune)
+    monkeypatch.setattr(os, "makedirs", _failing_makedirs)
+    monkeypatch.setattr(container_manager.time, "sleep", lambda s: None)
+    attempts = []
+
+    def flaky_umount(*args, **kwargs):
+        attempts.append(args)
+        return 1 if len(attempts) == 1 else 0
+
+    monkeypatch.setattr("tools.helpers.run.user", flaky_umount)
+
+    container_manager.keep_schedtune_if_nestable(_Args())
+
+    assert len(attempts) == 2
+    assert not os.path.exists(os.path.join(schedtune, "probe0"))

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from tools.helpers import drivers
+
+
+class _Args:
+    pass
+
+
+def test_loadBinderNodes_falls_back_when_config_missing_keys(tmp_path):
+    # Configs predating the binder keys (or partial/corrupt ones) must not
+    # crash the session service; fall back to the standard node names.
+    cfg_file = tmp_path / "waydroid.cfg"
+    cfg_file.write_text("[waydroid]\n")
+
+    args = _Args()
+    args.config = str(cfg_file)
+
+    drivers.loadBinderNodes(args)
+
+    assert args.BINDER_DRIVER == "binder"
+    assert args.VNDBINDER_DRIVER == "vndbinder"
+    assert args.HWBINDER_DRIVER == "hwbinder"
+    assert args.BINDER_PROTOCOL is None
+    assert args.SERVICE_MANAGER_PROTOCOL is None
+
+
+def test_loadBinderNodes_uses_config_values(tmp_path):
+    cfg_file = tmp_path / "waydroid.cfg"
+    cfg_file.write_text(
+        "[waydroid]\n"
+        "binder = anbox-binder\n"
+        "vndbinder = anbox-vndbinder\n"
+        "hwbinder = anbox-hwbinder\n"
+        "binder_protocol = 2\n"
+        "service_manager_protocol = 3\n")
+
+    args = _Args()
+    args.config = str(cfg_file)
+
+    drivers.loadBinderNodes(args)
+
+    assert args.BINDER_DRIVER == "anbox-binder"
+    assert args.VNDBINDER_DRIVER == "anbox-vndbinder"
+    assert args.HWBINDER_DRIVER == "anbox-hwbinder"
+    assert args.BINDER_PROTOCOL == "2"
+    assert args.SERVICE_MANAGER_PROTOCOL == "3"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.images."""
+
+import hashlib
+import io
+import json
+import types
+import zipfile
+
+import pytest
+
+import tools.config
+import tools.helpers.http
+import tools.helpers.images as images
+
+
+def make_args(tmp_path):
+    return types.SimpleNamespace(work=str(tmp_path))
+
+
+def test_sha256sum():
+    data = b"hello world"
+    f = io.BytesIO(data)
+    assert images.sha256sum(f) == hashlib.sha256(data).hexdigest()
+    # The file pointer must be rewound
+    assert f.tell() == 0
+
+
+def test_sha256sum_empty():
+    assert images.sha256sum(io.BytesIO(b"")) == hashlib.sha256(b"").hexdigest()
+
+
+def test_remove_overlay(monkeypatch, tmp_path):
+    overlay_rw = tmp_path / "overlay_rw"
+    overlay_work = tmp_path / "overlay_work"
+    overlay_rw.mkdir()
+    overlay_work.mkdir()
+    monkeypatch.setitem(tools.config.defaults, "overlay_rw", str(overlay_rw))
+    monkeypatch.setitem(tools.config.defaults, "overlay_work", str(overlay_work))
+    images.remove_overlay(make_args(tmp_path))
+    assert not overlay_rw.exists()
+    assert not overlay_work.exists()
+
+
+def test_remove_overlay_missing_dirs(monkeypatch, tmp_path):
+    monkeypatch.setitem(tools.config.defaults, "overlay_rw",
+                        str(tmp_path / "missing_rw"))
+    monkeypatch.setitem(tools.config.defaults, "overlay_work",
+                        str(tmp_path / "missing_work"))
+    # Should not raise
+    images.remove_overlay(make_args(tmp_path))
+
+
+def test_make_prop(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    with open(args.work + "/waydroid_base.prop", "w") as f:
+        f.write("ro.foo=bar\nro.baz=qux\n")
+    monkeypatch.setattr(images, "which", lambda name: None)
+
+    cfg = {
+        "user_name": "user",
+        "user_id": "1000",
+        "group_id": "1000",
+        "waydroid_data": "/home/user/.local/share/waydroid/data",
+        "background_start": "true",
+        "lcd_density": "0",
+    }
+    full_props_path = args.work + "/waydroid.prop"
+    images.make_prop(args, cfg, full_props_path)
+
+    with open(full_props_path) as f:
+        props = f.read()
+    assert "ro.foo=bar" in props
+    assert "waydroid.host.user=user" in props
+    assert "waydroid.host.uid=1000" in props
+    assert "waydroid.host.gid=1000" in props
+    assert "waydroid.host_data_path=/home/user/.local/share/waydroid/data" in props
+    assert "waydroid.background_start=true" in props
+    assert "waydroid.stub_sensors_hal=1" in props
+    assert "ro.sf.lcd_density=" not in props
+
+
+def test_make_prop_lcd_density(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    with open(args.work + "/waydroid_base.prop", "w") as f:
+        f.write("ro.foo=bar\n")
+    monkeypatch.setattr(images, "which", lambda name: None)
+
+    cfg = {
+        "user_name": "user",
+        "user_id": "1000",
+        "group_id": "1000",
+        "waydroid_data": "/home/user/data",
+        "background_start": "true",
+        "lcd_density": "320",
+    }
+    full_props_path = args.work + "/waydroid.prop"
+    images.make_prop(args, cfg, full_props_path)
+
+    with open(full_props_path) as f:
+        props = f.read()
+    assert "ro.sf.lcd_density=320" in props
+
+
+def test_make_prop_mnt_remap(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    with open(args.work + "/waydroid_base.prop", "w") as f:
+        f.write("ro.foo=bar\n")
+    monkeypatch.setattr(images, "which", lambda name: None)
+
+    cfg = {
+        "user_name": "user",
+        "user_id": "1000",
+        "group_id": "1000",
+        "waydroid_data": "/mnt/userdata",
+        "background_start": "true",
+        "lcd_density": "0",
+    }
+    full_props_path = args.work + "/waydroid.prop"
+    images.make_prop(args, cfg, full_props_path)
+
+    with open(full_props_path) as f:
+        props = f.read()
+    assert "waydroid.host_data_path=/mnt_extra/userdata" in props
+
+
+def test_make_prop_missing_base_prop(tmp_path):
+    args = make_args(tmp_path)
+    with pytest.raises(RuntimeError):
+        images.make_prop(args, {}, args.work + "/waydroid.prop")
+
+
+def test_make_prop_empty_base_prop(tmp_path):
+    args = make_args(tmp_path)
+    open(args.work + "/waydroid_base.prop", "w").close()
+    with pytest.raises(RuntimeError):
+        images.make_prop(args, {}, args.work + "/waydroid.prop")
+
+
+def test_validate(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    data = b"some image data"
+    chksum = hashlib.sha256(data).hexdigest()
+    # Channel response with matching id
+    monkeypatch.setattr(
+        tools.helpers.http, "retrieve",
+        lambda url: (200, json.dumps({"response": [{"id": chksum}]}).encode()))
+    monkeypatch.setattr(
+        tools.config, "load",
+        lambda args: {"waydroid": {"system_ota": "https://example.test/system"}})
+
+    image_path = tmp_path / "system.zip"
+    image_path.write_bytes(data)
+    with open(image_path, "rb") as f:
+        assert images.validate(args, "system_ota", f) is True
+
+
+def test_validate_no_match(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    data = b"some image data"
+    monkeypatch.setattr(
+        tools.helpers.http, "retrieve",
+        lambda url: (200, json.dumps({"response": [{"id": "other"}]}).encode()))
+    monkeypatch.setattr(
+        tools.config, "load",
+        lambda args: {"waydroid": {"system_ota": "https://example.test/system"}})
+
+    image_path = tmp_path / "system.zip"
+    image_path.write_bytes(data)
+    with open(image_path, "rb") as f:
+        assert images.validate(args, "system_ota", f) is False
+
+
+def test_validate_channel_error(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(tools.helpers.http, "retrieve",
+                        lambda url: (404, b""))
+    monkeypatch.setattr(
+        tools.config, "load",
+        lambda args: {"waydroid": {"system_ota": "https://example.test/system"}})
+
+    image_path = tmp_path / "system.zip"
+    image_path.write_bytes(b"data")
+    with open(image_path, "rb") as f:
+        assert images.validate(args, "system_ota", f) is False
+
+
+def test_replace(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    images_path = tmp_path / "images"
+    images_path.mkdir()
+
+    system_zip = tmp_path / "system.zip"
+    with zipfile.ZipFile(system_zip, "w") as zf:
+        zf.writestr("system.img", "fake image contents")
+
+    cfg = {
+        "waydroid": {
+            "images_path": str(images_path),
+            "system_datetime": "0",
+            "vendor_datetime": "0",
+        }
+    }
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+    monkeypatch.setattr(images, "validate", lambda *a, **kw: True)
+    monkeypatch.setattr(images, "remove_overlay", lambda args: None)
+
+    images.replace(args, str(system_zip), 1234, str(tmp_path / "missing.zip"), 0)
+
+    assert (images_path / "system.img").read_text() == "fake image contents"
+    assert cfg["waydroid"]["system_datetime"] == "1234"
+    assert not system_zip.exists()
+    assert saved == cfg
+
+
+def test_replace_invalid_image(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    images_path = tmp_path / "images"
+    images_path.mkdir()
+
+    system_zip = tmp_path / "system.zip"
+    system_zip.write_bytes(b"not a valid image")
+
+    cfg = {
+        "waydroid": {
+            "images_path": str(images_path),
+            "system_datetime": "0",
+            "vendor_datetime": "0",
+        }
+    }
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+    monkeypatch.setattr(images, "validate", lambda *a, **kw: False)
+    monkeypatch.setattr(images, "remove_overlay", lambda args: None)
+
+    images.replace(args, str(system_zip), 1234, str(tmp_path / "missing.zip"), 0)
+
+    assert not (images_path / "system.img").exists()
+    assert cfg["waydroid"]["system_datetime"] == "0"
+    assert not system_zip.exists()

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.mount."""
+
+import io
+import os
+
+import pytest
+
+import tools.helpers.mount as mount
+from tools.helpers.version import kernel_version, versiontuple
+
+
+def write_mounts(tmp_path, content):
+    path = tmp_path / "mounts"
+    path.write_text(content)
+    return str(path)
+
+
+def test_umount_all_list(tmp_path):
+    content = "\n".join([
+        "overlay /var/lib/waydroid/rootfs overlay rw 0 0",
+        "/dev/sda1 /var/lib/waydroid/rootfs/vendor ext4 ro 0 0",
+        "/dev/sdb1 /other ext4 rw 0 0",
+    ]) + "\n"
+    source = write_mounts(tmp_path, content)
+    result = mount.umount_all_list("/var/lib/waydroid/rootfs", source)
+    assert result == ["/var/lib/waydroid/rootfs/vendor",
+                      "/var/lib/waydroid/rootfs"]
+
+
+def test_umount_all_list_no_match(tmp_path):
+    content = "/dev/sda1 /var/lib/waydroid/rootfs ext4 ro 0 0\n"
+    source = write_mounts(tmp_path, content)
+    assert mount.umount_all_list("/tmp", source) == []
+
+
+def test_umount_all_list_deleted_suffix(tmp_path):
+    # Deleted mount points have a "\040(deleted)" suffix that must be stripped
+    content = "/dev/sda1 /var/lib/waydroid/rootfs\\040(deleted) ext4 ro 0 0\n"
+    source = write_mounts(tmp_path, content)
+    result = mount.umount_all_list("/var/lib/waydroid", source)
+    assert result == ["/var/lib/waydroid/rootfs"]
+
+
+def test_umount_all_list_bad_line(tmp_path):
+    # A mount line with fewer than 2 fields is malformed
+    content = "onlyonefield\n"
+    source = write_mounts(tmp_path, content)
+    with pytest.raises(RuntimeError):
+        mount.umount_all_list("/var/lib/waydroid", source)
+
+
+def test_ismount(monkeypatch, tmp_path):
+    folder = "/var/lib/waydroid/rootfs"
+    content = "overlay {} overlay rw 0 0\n".format(folder)
+
+    class FakeOpen:
+        def __call__(self, path, *args, **kwargs):
+            return io.StringIO(content)
+
+    monkeypatch.setattr("builtins.open", FakeOpen())
+    assert mount.ismount(folder)
+    assert not mount.ismount("/var/lib/waydroid/nonexistent")
+
+
+def test_ismount_source_dest(monkeypatch):
+    # ismount() also matches when the folder appears as the source of a bind
+    source = "/dev/sda1"
+    dest = "/var/lib/waydroid/rootfs"
+    content = "{} {} ext4 rw 0 0\n".format(source, dest)
+
+    class FakeOpen:
+        def __call__(self, path, *args, **kwargs):
+            return io.StringIO(content)
+
+    monkeypatch.setattr("builtins.open", FakeOpen())
+    assert mount.ismount(source)
+
+
+def _mount_capturing_fake(calls):
+    # Simulates the effect of a successful mount: after a `mount` command
+    # runs, the destination counts as mounted for the ismount() verification.
+    mounted = set()
+
+    def fake_ismount(path):
+        return path in mounted
+
+    def fake_user(*args, **kwargs):
+        command = args[1]
+        calls.append((args, kwargs))
+        if command[0] == "mount":
+            mounted.add(command[-1])
+        return 0
+    return fake_ismount, fake_user
+
+
+def test_bind_mounts_and_creates_destination(monkeypatch, tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    calls = []
+    fake_ismount, fake_user = _mount_capturing_fake(calls)
+    monkeypatch.setattr(mount, "ismount", fake_ismount)
+    monkeypatch.setattr("tools.helpers.run.user", fake_user)
+
+    mount.bind(object(), str(src), str(dst))
+
+    commands = [c[0][1] for c in calls]
+    assert ["mkdir", "-p", str(dst)] in commands
+    assert ["mount", "-o", "bind", str(src), str(dst)] in commands
+
+
+def test_mount_type_and_options(monkeypatch, tmp_path):
+    dst = tmp_path / "dst"
+    calls = []
+    fake_ismount, fake_user = _mount_capturing_fake(calls)
+    monkeypatch.setattr(mount, "ismount", fake_ismount)
+    monkeypatch.setattr("tools.helpers.run.user", fake_user)
+
+    mount.mount(object(), "overlay", str(dst), mount_type="overlay",
+                options=["lowerdir=/a:/b"])
+
+    commands = [c[0][1] for c in calls]
+    assert ["mount", "-t", "overlay", "-o", "ro,lowerdir=/a:/b",
+            "overlay", str(dst)] in commands
+
+
+def test_versiontuple():
+    assert versiontuple("1.2.3") == (1, 2, 3)
+    assert versiontuple("0") == (0,)
+
+
+def test_kernel_version(monkeypatch):
+    class FakeUname:
+        release = "6.8.0-arch1-1"
+
+    monkeypatch.setattr(os, "uname", lambda: FakeUname())
+    assert kernel_version() == (6, 8)

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.net."""
+
+import io
+
+import tools.helpers.net as net
+
+
+def test_get_device_ip_address(monkeypatch):
+    lease = ("1692540000 00:16:3e:00:00:01 192.168.240.2 "
+             "waydroid 00:16:3e:00:00:01\n")
+    monkeypatch.setattr("builtins.open", lambda *a, **kw: io.StringIO(lease))
+
+    assert net.get_device_ip_address() == "192.168.240.2"
+
+
+def test_get_device_ip_address_no_lease(monkeypatch):
+    def raise_ioerror(*a, **kw):
+        raise IOError("no lease file")
+
+    monkeypatch.setattr("builtins.open", raise_ioerror)
+
+    assert net.get_device_ip_address() is None
+
+
+def test_get_device_ip_address_no_match(monkeypatch):
+    monkeypatch.setattr("builtins.open",
+                        lambda *a, **kw: io.StringIO("no ip here\n"))
+
+    assert net.get_device_ip_address() is None

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.protocol."""
+
+import types
+
+import tools.config
+import tools.helpers.props
+import tools.helpers.protocol as protocol
+
+
+def make_args():
+    return types.SimpleNamespace()
+
+
+def test_set_aidl_version(monkeypatch):
+    cfg = {"waydroid": {}}
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+    # (sdk, binder_protocol, service_manager_protocol)
+    cases = [
+        (0, "aidl", "aidl"),
+        (27, "aidl", "aidl"),
+        (28, "aidl2", "aidl2"),
+        (29, "aidl2", "aidl2"),
+        (30, "aidl3", "aidl3"),
+        (31, "aidl4", "aidl3"),
+        (32, "aidl4", "aidl3"),
+        (33, "aidl3", "aidl3"),
+        (34, "aidl3", "aidl3"),
+        (35, "aidl3", "aidl5"),
+        (36, "aidl3", "aidl6"),
+        # Android 16 (API 36) and newer stay on aidl6 for the service manager
+        (37, "aidl3", "aidl6"),
+        (40, "aidl3", "aidl6"),
+    ]
+    for sdk, binder, sm in cases:
+        monkeypatch.setattr(tools.helpers.props, "file_get",
+                            lambda *args, **kwargs: str(sdk))
+        protocol.set_aidl_version(make_args())
+        assert cfg["waydroid"]["binder_protocol"] == binder, \
+            "binder protocol for sdk {}".format(sdk)
+        assert cfg["waydroid"]["service_manager_protocol"] == sm, \
+            "service manager protocol for sdk {}".format(sdk)
+
+
+def test_set_aidl_version_parse_error(monkeypatch):
+    """A failing build.prop read falls back to the lowest protocol."""
+    cfg = {"waydroid": {}}
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    def raise_file_get(*args, **kwargs):
+        raise Exception("no build.prop")
+
+    monkeypatch.setattr(tools.helpers.props, "file_get", raise_file_get)
+    protocol.set_aidl_version(make_args())
+    assert cfg["waydroid"]["binder_protocol"] == "aidl"
+    assert cfg["waydroid"]["service_manager_protocol"] == "aidl"

--- a/tests/test_upgrader.py
+++ b/tests/test_upgrader.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.actions.upgrader.migration()."""
+
+import types
+
+import tools.config
+import tools.actions.upgrader as upgrader
+
+
+def make_args():
+    return types.SimpleNamespace(work="/var/lib/waydroid")
+
+
+def test_migration_adds_missing_binder_keys(monkeypatch):
+    cfg = {"waydroid": {}}
+    # Old tools version 1.6.3: only the 1.6.3 migration step runs.
+    monkeypatch.setattr(tools.helpers.props, "file_get",
+                        lambda *a, **kw: "1.6.3")
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    upgrader.migration(make_args())
+
+    assert cfg["waydroid"]["binder"] == "binder"
+    assert cfg["waydroid"]["vndbinder"] == "vndbinder"
+    assert cfg["waydroid"]["hwbinder"] == "hwbinder"
+    assert saved == cfg
+
+
+def test_migration_keeps_existing_binder_keys(monkeypatch):
+    cfg = {"waydroid": {"binder": "anbox-binder",
+                        "vndbinder": "anbox-vndbinder",
+                        "hwbinder": "anbox-hwbinder"}}
+    monkeypatch.setattr(tools.helpers.props, "file_get",
+                        lambda *a, **kw: "1.6.3")
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    upgrader.migration(make_args())
+
+    assert cfg["waydroid"]["binder"] == "anbox-binder"
+    # Nothing changed, so the config must not be rewritten.
+    assert saved == {}
+
+
+def test_migration_new_install_is_noop(monkeypatch):
+    cfg = {"waydroid": {}}
+    monkeypatch.setattr(tools.helpers.props, "file_get",
+                        lambda *a, **kw: "1.6.4")
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    saved = {}
+    monkeypatch.setattr(tools.config, "save", lambda args, c: saved.update(c))
+
+    upgrader.migration(make_args())
+
+    assert saved == {}
+    assert "binder" not in cfg["waydroid"]

--- a/tools/actions/container_manager.py
+++ b/tools/actions/container_manager.py
@@ -5,6 +5,7 @@ import logging
 import os
 import glob
 import signal
+import time
 import tools.config
 from contextlib import suppress
 from shutil import which
@@ -16,6 +17,12 @@ import dbus.service
 import dbus.exceptions
 from gi.repository import GLib
 
+# Host path of the schedtune cgroup hierarchy (Ubuntu Touch / Halium)
+SCHEDTUNE_PATH = "/sys/fs/cgroup/schedtune"
+
+# Script that sets up the container's private network
+WAYDROID_NET_SCRIPT = tools.config.tools_src + "/data/scripts/waydroid-net.sh"
+
 class DbusContainerManager(dbus.service.Object):
     def __init__(self, looper, bus, object_path, args):
         self.args = args
@@ -23,9 +30,13 @@ class DbusContainerManager(dbus.service.Object):
         dbus.service.Object.__init__(self, bus, object_path)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='a{ss}', out_signature='', sender_keyword="sender", connection_keyword="conn")
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='a{ss}',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
     def Start(self, session, sender, conn):
-        dbus_info = dbus.Interface(conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False), "org.freedesktop.DBus")
+        dbus_info = dbus.Interface(
+            conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False),
+            "org.freedesktop.DBus")
         uid = dbus_info.GetConnectionUnixUser(sender)
         if str(uid) not in ["0", session["user_id"]]:
             raise RuntimeError("Cannot start a session on behalf of another user")
@@ -34,30 +45,64 @@ class DbusContainerManager(dbus.service.Object):
             raise RuntimeError("Invalid session pid")
         do_start(self.args, session)
 
+    def _validate_session_owner(self, sender, conn):
+        """
+        Ensure the caller is either root or the user owning the currently
+        tracked session, mirroring the check in Start().
+
+        The PID check from Start() is intentionally not mirrored here: the
+        tracked session is already validated at Start() time, and legitimate
+        callers (e.g. "waydroid app install", "waydroid prop set", "waydroid
+        session stop") run in different processes than the session process.
+
+        :raises RuntimeError: when the caller is neither root nor the session
+                              owner
+        """
+        dbus_info = dbus.Interface(
+            conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False),
+            "org.freedesktop.DBus")
+        uid = str(dbus_info.GetConnectionUnixUser(sender))
+        if uid == "0":
+            return
+        if "session" not in self.args or uid != self.args.session["user_id"]:
+            raise RuntimeError("Cannot control a session on behalf of another user")
+
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='b', out_signature='')
-    def Stop(self, quit_session):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='b',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
+    def Stop(self, quit_session, sender, conn):
+        self._validate_session_owner(sender, conn)
         stop(self.args, quit_session)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='', out_signature='')
-    def Freeze(self):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
+    def Freeze(self, sender, conn):
         if not actions.initializer.is_initialized(self.args):
             raise RuntimeError("Waydroid is not initialized")
+        self._validate_session_owner(sender, conn)
         freeze(self.args)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='', out_signature='')
-    def Unfreeze(self):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
+    def Unfreeze(self, sender, conn):
         if not actions.initializer.is_initialized(self.args):
             raise RuntimeError("Waydroid is not initialized")
+        self._validate_session_owner(sender, conn)
         unfreeze(self.args)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.ContainerManager", in_signature='', out_signature='a{ss}')
-    def GetSession(self):
+    @dbus.service.method("id.waydro.ContainerManager", in_signature='',
+                         out_signature='a{ss}', sender_keyword="sender",
+                         connection_keyword="conn")
+    def GetSession(self, sender, conn):
         if not actions.initializer.is_initialized(self.args):
             raise RuntimeError("Waydroid is not initialized")
+        self._validate_session_owner(sender, conn)
         try:
             session = self.args.session
             session["state"] = helpers.lxc.status(self.args)
@@ -65,32 +110,46 @@ class DbusContainerManager(dbus.service.Object):
         except AttributeError:
             return {}
 
-def set_permissions(args, perm_list=None, mode="777"):
-    def chmod(path, mode):
-        if os.path.exists(path):
-            command = ["chmod", mode, "-R", path]
-            tools.helpers.run.user(args, command, check=False)
+# Device nodes that only the container's root processes (vendor HALs)
+# access. The container root holds DAC_OVERRIDE, so these can be tightened
+# to owner access; Android app processes never open them directly.
+SYSTEM_DEVICES = [
+    "/dev/Vcodec",
+    "/dev/MTK_SMI",
+    "/dev/mdp_sync",
+    "/dev/mtk_cmdq",
+    "/dev/pvr_sync",
+    "/sys/kernel/debug/sync/sw_sync",
+]
 
+# Device nodes Android app processes (arbitrary host UIDs without
+# DAC_OVERRIDE) may open directly; these must stay world-accessible, but
+# never executable.
+APP_DEVICES = [
+    "/dev/ashmem",
+    "/dev/ion",
+    "/dev/graphics",
+    "/dev/sw_sync",
+]
+
+
+def set_permissions(args, perm_list=None, mode="666", session=None):
+    """
+    Give the container access to host devices.
+
+    The container bind-mounts these host nodes read-write and runs without
+    user namespaces, so the mode bits are the boundary between Android and
+    the host. The container's root holds DAC_OVERRIDE and bypasses them;
+    Android app processes are ordinary host UIDs, so nodes they open
+    directly (ashmem, ion, DRM render nodes, framebuffers, video,
+    dma-heaps) get 0666 - world read/write, never executable. Nodes only
+    the container's root processes (vendor HALs) use get 0660. When a
+    session is available the nodes are also owned by the session user.
+    Only paths that exist are touched, and failures are non-fatal.
+    """
     # Nodes list
     if not perm_list:
-        perm_list = [
-            "/dev/ashmem",
-
-            # sw_sync for HWC
-            "/dev/sw_sync",
-            "/sys/kernel/debug/sync/sw_sync",
-
-            # Media
-            "/dev/Vcodec",
-            "/dev/MTK_SMI",
-            "/dev/mdp_sync",
-            "/dev/mtk_cmdq",
-
-            # Graphics
-            "/dev/graphics",
-            "/dev/pvr_sync",
-            "/dev/ion",
-        ]
+        perm_list = list(APP_DEVICES)
 
         # DRM render nodes
         perm_list.extend(glob.glob("/dev/dri/renderD*"))
@@ -101,8 +160,33 @@ def set_permissions(args, perm_list=None, mode="777"):
         # DMA-BUF Heaps
         perm_list.extend(glob.glob("/dev/dma_heap/*"))
 
+        perm_list.extend(SYSTEM_DEVICES)
+
     for path in perm_list:
-        chmod(path, mode)
+        if not os.path.exists(path):
+            continue
+        if session:
+            command = ["chown", session["user_id"] + ":" + session["group_id"],
+                       "-R", path]
+            tools.helpers.run.user(args, command, check=False)
+        path_mode = "660" if path in SYSTEM_DEVICES else mode
+        tools.helpers.run.user(args, ["chmod", path_mode, "-R", path], check=False)
+
+def wait_for_status(args, status, timeout=30):
+    """
+    Wait for the container to reach the given LXC status.
+
+    Polls the container status once per second instead of busy-waiting, and
+    raises a RuntimeError if the status is not reached within ``timeout``
+    seconds.
+    """
+    tries = 0
+    while helpers.lxc.status(args) != status:
+        if tries >= timeout:
+            raise RuntimeError(
+                "WayDroid container did not reach {} state within {} seconds".format(status, timeout))
+        tries += 1
+        time.sleep(1)
 
 def start(args):
     mainloop = GLib.MainLoop()
@@ -150,6 +234,103 @@ def prepare_drivers_once(args):
     ], "666")
     prepared_drivers = True
 
+def start_cgroup_lite_if_available(args):
+    """
+    Start Android init's "cgroup-lite" service on Halium hosts.
+
+    On Halium / Ubuntu Touch devices the host runs Android's init, which is
+    normally responsible for mounting the cgroup hierarchies. Waydroid
+    makes sure that service is running before the container starts, so the
+    container does not inherit a half-set-up cgroup tree. The command only
+    exists when Android init's ``start`` binary is on PATH; on regular
+    GNU/Linux hosts this is a no-op, as the host init system already
+    mounted cgroups.
+    """
+    if which("start"):
+        tools.helpers.run.user(args, ["start", "cgroup-lite"], check=False)
+
+def keep_schedtune_if_nestable(args):
+    """
+    Keep the host schedtune cgroup mounted only if the container can nest
+    its own cgroups inside it, and unmount it otherwise.
+
+    Ubuntu Touch hosts use the schedtune cgroup for CPU-boost tuning, and
+    Waydroid's Android keeps using that mechanism inside the container. LXC
+    mounts the host cgroup hierarchy into the container read-only
+    (lxc.mount.auto), which Android can only use if the hierarchy supports
+    nesting, i.e. if new cgroups can be created inside it. Some kernels
+    lack the nesting patch, and a non-nestable schedtune handed to Android
+    read-only would be broken.
+
+    Nesting support is probed by creating a throwaway subgroup hierarchy
+    (probe0/probe1). If creation succeeds the mount is kept; otherwise the
+    hierarchy is lazily unmounted so Android sets up its own schedtune in
+    the container. The probe directories are always removed afterwards.
+    """
+    if not os.path.ismount(SCHEDTUNE_PATH):
+        return
+
+    probe = SCHEDTUNE_PATH + "/probe0"
+    try:
+        os.makedirs(probe + "/probe1")
+    except OSError:
+        logging.debug("Host schedtune cgroup does not support nesting, unmounting it")
+        # The hierarchy may be busy for a moment (in-flight processes or a
+        # lingering child cgroup), so retry the lazy unmount briefly before
+        # giving up and handing the non-nestable hierarchy to the container.
+        code = 1
+        for attempt in range(3):
+            code = tools.helpers.run.user(
+                args, ["umount", "-l", SCHEDTUNE_PATH], check=False)
+            if code == 0:
+                break
+            time.sleep(1)
+        if code != 0:
+            logging.warning(
+                "Failed to unmount {} (last umount exited with {}); the container will "
+                "inherit a non-nestable schedtune hierarchy. See the README's "
+                "schedtune troubleshooting section.".format(SCHEDTUNE_PATH, code))
+    finally:
+        with suppress(OSError):
+            os.rmdir(probe + "/probe1")
+        with suppress(OSError):
+            os.rmdir(probe)
+
+def start_networking(args):
+    """
+    Bring up the container's private network (bridge, dnsmasq, NAT).
+
+    Runs ``data/scripts/waydroid-net.sh start``; failures raise, because
+    the container cannot function without networking.
+    """
+    tools.helpers.run.user(args, [WAYDROID_NET_SCRIPT, "start"])
+
+def stop_networking(args):
+    """Tear down the container's private network (best-effort)."""
+    tools.helpers.run.user(args, [WAYDROID_NET_SCRIPT, "stop"], check=False)
+
+def start_sensors(args):
+    """
+    Launch the host-side sensor daemon for the container.
+
+    ``waydroid-sensord`` forwards the device's sensors to Android over the
+    shared hwbinder. It is optional: if it is not installed, nothing runs.
+    """
+    if which("waydroid-sensord"):
+        tools.helpers.run.user(
+            args, ["waydroid-sensord", "/dev/" + args.HWBINDER_DRIVER], output="background")
+
+def stop_sensors(args):
+    """Stop the sensor daemon, killing every instance (best-effort)."""
+    if which("waydroid-sensord"):
+        command = ["pidof", "waydroid-sensord"]
+        pids = tools.helpers.run.user(args, command, check=False, output_return=True).strip()
+        if pids:
+            # pidof may return multiple PIDs (e.g. a stale daemon from a
+            # crashed session); kill them all.
+            command = ["kill", "-9"] + pids.split()
+            tools.helpers.run.user(args, command, check=False)
+
 def do_start(args, session):
     if not actions.initializer.is_initialized(args):
         raise RuntimeError("Waydroid is not initialized")
@@ -161,45 +342,14 @@ def do_start(args, session):
 
     logging.info("Starting up container for a new session")
 
-    # Networking
-    command = [tools.config.tools_src +
-               "/data/scripts/waydroid-net.sh", "start"]
-    tools.helpers.run.user(args, command)
+    start_networking(args)
+    start_sensors(args)
+    start_cgroup_lite_if_available(args)
 
-    # Sensors
-    if which("waydroid-sensord"):
-        tools.helpers.run.user(
-            args, ["waydroid-sensord", "/dev/" + args.HWBINDER_DRIVER], output="background")
-
-    # Cgroup hacks
-    if which("start"):
-        command = ["start", "cgroup-lite"]
-        tools.helpers.run.user(args, command, check=False)
-
-    # Keep schedtune around in case nesting is supported
-    if os.path.ismount("/sys/fs/cgroup/schedtune"):
-        try:
-            os.mkdir("/sys/fs/cgroup/schedtune/probe0")
-            os.mkdir("/sys/fs/cgroup/schedtune/probe0/probe1")
-        except OSError:
-            command = ["umount", "-l", "/sys/fs/cgroup/schedtune"]
-            tools.helpers.run.user(args, command, check=False)
-        finally:
-            if os.path.exists("/sys/fs/cgroup/schedtune/probe0/probe1"):
-                os.rmdir("/sys/fs/cgroup/schedtune/probe0/probe1")
-            if os.path.exists("/sys/fs/cgroup/schedtune/probe0"):
-                os.rmdir("/sys/fs/cgroup/schedtune/probe0")
-
-    #TODO: remove NFC hacks
-    if which("stop"):
-        command = ["stop", "nfcd"]
-        tools.helpers.run.user(args, command, check=False)
-    elif which("systemctl") and (tools.helpers.run.user(args, ["systemctl", "is-active", "-q", "nfcd"], check=False) == 0):
-        command = ["systemctl", "stop", "nfcd"]
-        tools.helpers.run.user(args, command, check=False)
+    keep_schedtune_if_nestable(args)
 
     # Set permissions
-    set_permissions(args)
+    set_permissions(args, session=session)
 
     # Create session-specific LXC config file
     helpers.lxc.generate_session_lxc_config(args, session)
@@ -231,29 +381,16 @@ def stop(args, quit_session=True):
         status = helpers.lxc.status(args)
         if status != "STOPPED":
             helpers.lxc.stop(args)
-            while helpers.lxc.status(args) != "STOPPED":
-                pass
+            try:
+                wait_for_status(args, "STOPPED")
+            except RuntimeError as e:
+                # Best-effort teardown: keep cleaning up even if the container
+                # did not stop in time (the rootfs umount below will fail with
+                # EBUSY in that case, and is caught by the outer handler).
+                logging.error("%s; continuing with cleanup", e)
 
-        # Networking
-        command = [tools.config.tools_src +
-                   "/data/scripts/waydroid-net.sh", "stop"]
-        tools.helpers.run.user(args, command, check=False)
-
-        #TODO: remove NFC hacks
-        if which("start"):
-            command = ["start", "nfcd"]
-            tools.helpers.run.user(args, command, check=False)
-        elif which("systemctl") and (tools.helpers.run.user(args, ["systemctl", "is-enabled", "-q", "nfcd"], check=False) == 0):
-            command = ["systemctl", "start", "nfcd"]
-            tools.helpers.run.user(args, command, check=False)
-
-        # Sensors
-        if which("waydroid-sensord"):
-            command = ["pidof", "waydroid-sensord"]
-            pid = tools.helpers.run.user(args, command, check=False, output_return=True).strip()
-            if pid:
-                command = ["kill", "-9", pid]
-                tools.helpers.run.user(args, command, check=False)
+        stop_networking(args)
+        stop_sensors(args)
 
         # Umount rootfs
         helpers.images.umount_rootfs(args)
@@ -283,8 +420,7 @@ def freeze(args):
     status = helpers.lxc.status(args)
     if status == "RUNNING":
         helpers.lxc.freeze(args)
-        while helpers.lxc.status(args) == "RUNNING":
-            pass
+        wait_for_status(args, "FROZEN")
     else:
         logging.error("WayDroid container is {}".format(status))
 
@@ -292,5 +428,6 @@ def unfreeze(args):
     status = helpers.lxc.status(args)
     if status == "FROZEN":
         helpers.lxc.unfreeze(args)
-        while helpers.lxc.status(args) == "FROZEN":
-            pass
+        wait_for_status(args, "RUNNING")
+    else:
+        logging.error("WayDroid container is {}".format(status))

--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -8,9 +8,6 @@ import stat
 import sys
 import threading
 import multiprocessing
-import select
-import queue
-import time
 import dbus
 import dbus.service
 import argparse
@@ -187,7 +184,9 @@ class DbusInitializer(dbus.service.Object):
         dbus.service.Object.__init__(self, bus, object_path)
 
     @helpers.logging.log_exceptions
-    @dbus.service.method("id.waydro.Initializer", in_signature='a{ss}', out_signature='', sender_keyword="sender", connection_keyword="conn")
+    @dbus.service.method("id.waydro.Initializer", in_signature='a{ss}',
+                         out_signature='', sender_keyword="sender",
+                         connection_keyword="conn")
     def Init(self, params, sender=None, conn=None):
         if self.worker_thread is not None:
             self.worker_thread.kill()
@@ -221,9 +220,14 @@ class DbusInitializer(dbus.service.Object):
         pass
 
 def ensure_polkit_auth(sender, conn, privilege):
-    dbus_info = dbus.Interface(conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False), "org.freedesktop.DBus")
+    dbus_info = dbus.Interface(
+        conn.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus/Bus", False),
+        "org.freedesktop.DBus")
     pid = dbus_info.GetConnectionUnixProcessID(sender)
-    polkit = dbus.Interface(dbus.SystemBus().get_object("org.freedesktop.PolicyKit1", "/org/freedesktop/PolicyKit1/Authority", False), "org.freedesktop.PolicyKit1.Authority")
+    polkit = dbus.Interface(
+        dbus.SystemBus().get_object("org.freedesktop.PolicyKit1",
+                                    "/org/freedesktop/PolicyKit1/Authority", False),
+        "org.freedesktop.PolicyKit1.Authority")
     try:
         (is_auth, _, _) = polkit.CheckAuthorization(
             ("unix-process", {

--- a/tools/actions/upgrader.py
+++ b/tools/actions/upgrader.py
@@ -17,10 +17,15 @@ def get_config(args):
 
 def migration(args):
     try:
-        old_ver = tools.helpers.props.file_get(args, args.work + "/waydroid_base.prop", "waydroid.tools_version")
+        old_ver = tools.helpers.props.file_get(
+            args, args.work + "/waydroid_base.prop", "waydroid.tools_version")
         if versiontuple(old_ver) <= versiontuple("1.3.4"):
-            chmod_paths = ["cache_http", "host-permissions", "lxc", "images", "rootfs", "data", "waydroid_base.prop", "waydroid.prop", "waydroid.cfg"]
-            tools.helpers.run.user(args, ["chmod", "-R", "g-w,o-w"] + [os.path.join(args.work, f) for f in chmod_paths], check=False)
+            chmod_paths = ["cache_http", "host-permissions", "lxc", "images",
+                           "rootfs", "data", "waydroid_base.prop", "waydroid.prop",
+                           "waydroid.cfg"]
+            tools.helpers.run.user(
+                args, ["chmod", "-R", "g-w,o-w"] +
+                [os.path.join(args.work, f) for f in chmod_paths], check=False)
             tools.helpers.run.user(args, ["chmod", "g-w,o-w", args.work], check=False)
             os.remove(os.path.join(args.work, "session.cfg"))
         if versiontuple(old_ver) <= versiontuple("1.6.0"):
@@ -28,6 +33,21 @@ def migration(args):
             cfg = tools.config.load(args)
             cfg["waydroid"]["auto_adb"] = "False"
             tools.config.save(args, cfg)
+        if versiontuple(old_ver) <= versiontuple("1.6.3"):
+            # Persist the binder node names that were introduced in 1.6.x so
+            # package upgrades don't rely on the runtime fallback in
+            # drivers.loadBinderNodes on every boot.
+            cfg = tools.config.load(args)
+            waydroid_cfg = cfg["waydroid"]
+            defaults = {"binder": "binder", "vndbinder": "vndbinder",
+                        "hwbinder": "hwbinder"}
+            changed = False
+            for key, value in defaults.items():
+                if key not in waydroid_cfg:
+                    waydroid_cfg[key] = value
+                    changed = True
+            if changed:
+                tools.config.save(args, cfg)
     except Exception as e:
         logging.debug("Error during migration: %s", e)
 
@@ -51,7 +71,9 @@ def upgrade(args):
         if args.images_path not in tools.config.defaults["preinstalled_images_paths"]:
             helpers.images.get(args)
         else:
-            logging.info("Upgrade refused because Waydroid was configured to load pre-installed image from {}.".format(args.images_path))
+            logging.info(
+                "Upgrade refused because Waydroid was configured to load "
+                "pre-installed image from {}.".format(args.images_path))
     helpers.drivers.probeAshmemDriver(args)
     helpers.lxc.setup_host_perms(args)
     helpers.lxc.set_lxc_config(args)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -9,10 +9,12 @@ import pwd
 from tools.config.load import load, load_channels
 from tools.config.save import save
 
+__all__ = ["load", "load_channels", "save"]
+
 #
 # Exported variables (internal configuration)
 #
-version = "1.6.3"
+version = "1.6.4"
 tools_src = os.path.normpath(os.path.realpath(__file__) + "/../../..")
 
 # Keys saved in the config file (mostly what we ask in 'waydroid init')
@@ -25,9 +27,7 @@ config_keys = ["arch",
                "mount_overlays",
                "auto_adb"]
 
-# Config file/commandline default values
-# $WORK gets replaced with the actual value for args.work (which may be
-# overridden on the commandline)
+# Config file default values
 defaults = {
     "arch": "arm64",
     "work": "/var/lib/waydroid",

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -106,17 +106,34 @@ def arguments_fullUI(subparser):
     return ret
 
 def arguments_firstLaunch(subparser):
-    ret = subparser.add_parser("first-launch", help="start waydroid, prompting to initialize waydroid first if necessary (default)")
+    ret = subparser.add_parser(
+        "first-launch",
+        help="start waydroid, prompting to initialize waydroid first if necessary (default)")
     return ret
 
 def arguments_shell(subparser):
     ret = subparser.add_parser("shell", help="run remote shell command")
     ret.add_argument("-u", "--uid", help="the UID to run as (also sets GID to the same value if -g is not set)")
     ret.add_argument("-g", "--gid", help="the GID to run as")
-    ret.add_argument("-s", "--context", help="transition to the specified SELinux or AppArmor security context. No-op if -L is supplied.")
-    ret.add_argument("-L", "--nolsm", action="store_true", help="tell LXC not to perform security domain transition related to mandatory access control (e.g. SELinux, AppArmor). If this option is supplied, LXC won't apply a container-wide seccomp filter to the executed program. This is a dangerous option that can result in leaking privileges to the container!!!")
-    ret.add_argument("-C", "--allcaps", action="store_true", help="tell LXC not to drop capabilities. This is a dangerous option that can result in leaking privileges to the container!!!")
-    ret.add_argument("-G", "--nocgroup", action="store_true", help="tell LXC not to switch to the container cgroup. This is a dangerous option that can result in leaking privileges to the container!!!")
+    ret.add_argument(
+        "-s", "--context",
+        help="transition to the specified SELinux or AppArmor security context. "
+             "No-op if -L is supplied.")
+    ret.add_argument(
+        "-L", "--nolsm", action="store_true",
+        help="tell LXC not to perform security domain transition related to mandatory "
+             "access control (e.g. SELinux, AppArmor). If this option is supplied, LXC "
+             "won't apply a container-wide seccomp filter to the executed program. "
+             "This is a dangerous option that can result in leaking privileges to the "
+             "container!!!")
+    ret.add_argument(
+        "-C", "--allcaps", action="store_true",
+        help="tell LXC not to drop capabilities. This is a dangerous option that can "
+             "result in leaking privileges to the container!!!")
+    ret.add_argument(
+        "-G", "--nocgroup", action="store_true",
+        help="tell LXC not to switch to the container cgroup. This is a dangerous "
+             "option that can result in leaking privileges to the container!!!")
     ret.add_argument('COMMAND', nargs='*', help="command to run")
     return ret
 

--- a/tools/helpers/drivers.py
+++ b/tools/helpers/drivers.py
@@ -168,9 +168,10 @@ def setupBinderNodes(args):
 
 def loadBinderNodes(args):
     cfg = tools.config.load(args)
-    args.BINDER_DRIVER = cfg["waydroid"]["binder"]
-    args.VNDBINDER_DRIVER = cfg["waydroid"]["vndbinder"]
-    args.HWBINDER_DRIVER = cfg["waydroid"]["hwbinder"]
-    # These might not be in cfg on package upgrade
+    # The binder node names and the protocol versions might not be in the
+    # config on package upgrade, so fall back to the standard names.
+    args.BINDER_DRIVER = cfg["waydroid"].get("binder", "binder")
+    args.VNDBINDER_DRIVER = cfg["waydroid"].get("vndbinder", "vndbinder")
+    args.HWBINDER_DRIVER = cfg["waydroid"].get("hwbinder", "hwbinder")
     args.BINDER_PROTOCOL = cfg["waydroid"].get("binder_protocol")
     args.SERVICE_MANAGER_PROTOCOL = cfg["waydroid"].get("service_manager_protocol")

--- a/tools/helpers/ipc.py
+++ b/tools/helpers/ipc.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Currently implemented as FIFO
-import os
 import dbus
 
 def DBusContainerService(object_path="/ContainerManager", intf="id.waydro.ContainerManager"):

--- a/tools/helpers/logging.py
+++ b/tools/helpers/logging.py
@@ -3,7 +3,6 @@
 import logging
 from logging.handlers import RotatingFileHandler
 import os
-import sys
 import functools
 from contextlib import suppress
 

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -170,7 +170,10 @@ def set_lxc_config(args):
     command = ["cp", "-fpr", seccomp_profile, lxc_path + "/waydroid.seccomp"]
     tools.helpers.run.user(args, command)
     if get_apparmor_status(args):
-        command = ["sed", "-i", "-E", "/lxc.aa_profile|lxc.apparmor.profile/ s/unconfined/{}/g".format(LXC_APPARMOR_PROFILE), lxc_path + "/config"]
+        command = ["sed", "-i", "-E",
+                   "/lxc.aa_profile|lxc.apparmor.profile/ s/unconfined/{}/g".format(
+                       LXC_APPARMOR_PROFILE),
+                   lxc_path + "/config"]
         tools.helpers.run.user(args, command)
 
     nodes = generate_nodes_lxc_config(args)
@@ -200,7 +203,9 @@ def generate_session_lxc_config(args, session):
         raise OSError("Failed to create XDG_RUNTIME_DIR mount point")
 
     wayland_host_socket = os.path.realpath(os.path.join(session["xdg_runtime_dir"], session["wayland_display"]))
-    wayland_container_socket = os.path.realpath(os.path.join(tools.config.defaults["container_xdg_runtime_dir"], tools.config.defaults["container_wayland_display"]))
+    wayland_container_socket = os.path.realpath(os.path.join(
+        tools.config.defaults["container_xdg_runtime_dir"],
+        tools.config.defaults["container_wayland_display"]))
     if not make_entry(wayland_host_socket, wayland_container_socket[1:]):
         raise OSError("Failed to bind Wayland socket")
 
@@ -441,7 +446,9 @@ def unfreeze(args):
     tools.helpers.run.user(args, command)
 
 ANDROID_ENV = {
-    "PATH": "/product/bin:/apex/com.android.runtime/bin:/apex/com.android.art/bin:/system_ext/bin:/system/bin:/system/xbin:/odm/bin:/vendor/bin:/vendor/xbin",
+    "PATH": ("/product/bin:/apex/com.android.runtime/bin:/apex/com.android.art/bin:"
+             "/system_ext/bin:/system/bin:/system/xbin:/odm/bin:/vendor/bin:"
+             "/vendor/xbin"),
     "ANDROID_ROOT": "/system",
     "ANDROID_DATA": "/data",
     "ANDROID_STORAGE": "/storage",
@@ -449,7 +456,26 @@ ANDROID_ENV = {
     "ANDROID_I18N_ROOT": "/apex/com.android.i18n",
     "ANDROID_TZDATA_ROOT": "/apex/com.android.tzdata",
     "ANDROID_RUNTIME_ROOT": "/apex/com.android.runtime",
-    "BOOTCLASSPATH": "/apex/com.android.art/javalib/core-oj.jar:/apex/com.android.art/javalib/core-libart.jar:/apex/com.android.art/javalib/core-icu4j.jar:/apex/com.android.art/javalib/okhttp.jar:/apex/com.android.art/javalib/bouncycastle.jar:/apex/com.android.art/javalib/apache-xml.jar:/system/framework/framework.jar:/system/framework/ext.jar:/system/framework/telephony-common.jar:/system/framework/voip-common.jar:/system/framework/ims-common.jar:/system/framework/framework-atb-backward-compatibility.jar:/apex/com.android.conscrypt/javalib/conscrypt.jar:/apex/com.android.media/javalib/updatable-media.jar:/apex/com.android.mediaprovider/javalib/framework-mediaprovider.jar:/apex/com.android.os.statsd/javalib/framework-statsd.jar:/apex/com.android.permission/javalib/framework-permission.jar:/apex/com.android.sdkext/javalib/framework-sdkextensions.jar:/apex/com.android.wifi/javalib/framework-wifi.jar:/apex/com.android.tethering/javalib/framework-tethering.jar"
+    "BOOTCLASSPATH": ("/apex/com.android.art/javalib/core-oj.jar:"
+                      "/apex/com.android.art/javalib/core-libart.jar:"
+                      "/apex/com.android.art/javalib/core-icu4j.jar:"
+                      "/apex/com.android.art/javalib/okhttp.jar:"
+                      "/apex/com.android.art/javalib/bouncycastle.jar:"
+                      "/apex/com.android.art/javalib/apache-xml.jar:"
+                      "/system/framework/framework.jar:"
+                      "/system/framework/ext.jar:"
+                      "/system/framework/telephony-common.jar:"
+                      "/system/framework/voip-common.jar:"
+                      "/system/framework/ims-common.jar:"
+                      "/system/framework/framework-atb-backward-compatibility.jar:"
+                      "/apex/com.android.conscrypt/javalib/conscrypt.jar:"
+                      "/apex/com.android.media/javalib/updatable-media.jar:"
+                      "/apex/com.android.mediaprovider/javalib/framework-mediaprovider.jar:"
+                      "/apex/com.android.os.statsd/javalib/framework-statsd.jar:"
+                      "/apex/com.android.permission/javalib/framework-permission.jar:"
+                      "/apex/com.android.sdkext/javalib/framework-sdkextensions.jar:"
+                      "/apex/com.android.wifi/javalib/framework-wifi.jar:"
+                      "/apex/com.android.tethering/javalib/framework-tethering.jar")
 }
 
 def android_env_attach_options(args):

--- a/tools/helpers/run_core.py
+++ b/tools/helpers/run_core.py
@@ -143,8 +143,8 @@ def foreground_pipe(args, cmd, working_dir=None, output_to_stdout=False,
     :param output_to_stdout: copy all output to waydroid's stdout
     :param output_return: return the output of the whole program
     :param output_timeout: kill the process when it doesn't print any output
-                           after a certain time (configured with --timeout)
-                           and raise a RuntimeError exception
+                           after args.timeout seconds and raise a
+                           RuntimeError exception
     :param sudo: use sudo to kill the process when it hits the timeout
     :returns: (code, output)
               * code: return code of the program
@@ -177,8 +177,6 @@ def foreground_pipe(args, cmd, working_dir=None, output_to_stdout=False,
             if wait_end - wait_start >= args.timeout:
                 logging.info("Process did not write any output for " +
                              str(args.timeout) + " seconds. Killing it.")
-                logging.info("NOTE: The timeout can be increased with"
-                             " 'waydroid -t'.")
                 kill_command(args, process.pid, sudo)
                 continue
 
@@ -215,8 +213,8 @@ def check_return_code(args, code, log_message):
 
     :param code: exit code to check
     :param log_message: simplified and more readable form of the command, e.g.
-                        "(native) % echo test" instead of the full command with
-                        entering the chroot and more escaping
+                        "(native) % echo test" instead of the full command
+                        with its escaping
     :raises RuntimeError: when the code indicates that the command failed
     """
 
@@ -258,12 +256,11 @@ def core(args, log_message, cmd, working_dir=None, output="log",
     Run a command and create a log entry.
 
     This is a low level function not meant to be used directly. Use one of the
-    following instead: tools.helpers.run.user(), tools.helpers.run.root(),
-                       tools.chroot.user(), tools.chroot.root()
+    following instead: tools.helpers.run.user(), tools.helpers.run.root()
 
     :param log_message: simplified and more readable form of the command, e.g.
-                        "(native) % echo test" instead of the full command with
-                        entering the chroot and more escaping
+                        "(native) % echo test" instead of the full command
+                        with its escaping
     :param cmd: command as list, e.g. ["echo", "string with spaces"]
     :param working_dir: path in host system where the command should run
     :param output: where to write the output (stdout and stderr) of the
@@ -280,8 +277,8 @@ def core(args, log_message, cmd, working_dir=None, output="log",
 
                    When the output is not set to "interactive", "tui",
                    "background" or "pipe", we kill the process if it does not
-                   output anything for 5 minutes (time can be set with
-                   "waydroid --timeout").
+                   output anything for args.timeout seconds (default: 30
+                   minutes, set in tools.prep_args).
 
                    The table below shows all possible values along with
                    their properties. "wait" indicates that we wait for the


### PR DESCRIPTION
1.6.4 hardening batch:

- **schedtune**: keep the host schedtune cgroup only when it supports nesting (probe0/probe1); retry the lazy unmount before warning instead of dropping it unconditionally
- **startup/teardown**: extract networking/sensors/cgroup-lite into helpers, remove the NFC hacks, and wait for container status with a timeout instead of busy-looping
- **set_permissions**: app-facing nodes stay 0666 (never executable), vendor-HAL nodes become 0660 and session-owned when a session is known
- **DBus**: every container method validates the caller (root or session owner), not just `Start`
- **binder**: fall back to standard node names in `loadBinderNodes` when the config lacks them (package upgrade), and persist them in the 1.6.3 migration
- **net**: `waydroid-net.sh` auto-detects nftables when no iptables tooling is installed; IPv6 NAT is opt-in via env vars
- **build**: substitute `@BINDIR@` into the systemd/dbus activation files so `PREFIX` overrides work; fix the `USE_NFTABLES` install-time sed
- docs (host integration, distro packaging, README prerequisites + schedtune) and a pytest suite (51 passed)

Note: the E501/F401/F811 lint enforcement that accompanied this batch in the fork is intentionally left out — it depends on the ServiceRunner cleanup files (separate PR) and is kept on the fork.