### PR TITLE
arm-translation: add libndk_translation support for ARM apps on x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,34 @@ See install instructions [here](https://docs.waydro.id/usage/install-on-desktops
 
 Our documentation can be found at [docs.waydro.id](https://docs.waydro.id)
 
+## Running ARM-only apps on x86_64 hosts
+
+On x86_64 hosts the image is x86_64, but many apps ship ARM-only binaries.
+Waydroid supports Google's [libndk_translation](https://github.com/google-ndk-translation)
+native bridge for those (Apache-2.0, the same translator ChromeOS uses):
+
+```
+waydroid arm-translation install --source /path/to/artifacts
+# or: waydroid arm-translation install --archive libndk.tar.xz
+# or: waydroid arm-translation install --url https://example.org/libndk.tar.xz
+# or: waydroid arm-translation install --default
+waydroid arm-translation status
+```
+
+`--source`/`--archive`/`--url` accept your own artifacts; `--default`
+fetches a third-party prebuilt (Android 13, md5-verified) that
+[waydroid_script](https://github.com/casualsnek/waydroid_script) also
+consumes. The artifacts must mirror the container's `/system` layout (at
+least `system/lib64/libndk_translation.so`, `system/lib64/arm64/libc.so`
+and `system/etc/init/ndk_translation.rc`; see
+`tools/helpers/arm_translation.py` for the full tree). They are synced into
+the container's `/system` overlay at session start, before the overlay is
+mounted, and `make_base_props` advertises the emulated ABIs
+(`arm64-v8a,armeabi-v7a,armeabi`) so both the local PackageManager and
+Google Play's delivery check accept ARM-only apps. After installing, restart
+the container (`waydroid container restart`); remove it with
+`waydroid arm-translation uninstall`.
+
 ## Reporting bugs
 
 If you have found an issue with Waydroid, please [file a bug](https://github.com/Waydroid/waydroid/issues/new/choose).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ ignore = [
 	"F401", # TODO: Remove this once unused imports are removed.
 	"F811", # TODO: Remove this once redefined variables are refactored.
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pytest configuration.
+
+The waydroid ``tools`` package imports heavy runtime dependencies (dbus,
+PyGObject, gbinder) at module import time. The pure-logic helpers under test
+(arch, protocol, images, mount) don't use any of them, so we stub them out in
+``sys.modules`` to keep the test suite runnable in a minimal environment
+(e.g. CI without those native packages installed).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+HEAVY_DEPS = [
+    "dbus",
+    "dbus.exceptions",
+    "dbus.mainloop.glib",
+    "dbus.service",
+    "gbinder",
+    "gi",
+    "gi.repository",
+    "gi.repository.GLib",
+]
+
+
+class _StubModule(types.ModuleType):
+    """A module that answers any attribute access with a MagicMock."""
+
+    def __getattr__(self, attr):
+        return MagicMock()
+
+
+def _install_stub(name):
+    if name in sys.modules:
+        return
+    module = _StubModule(name)
+    sys.modules[name] = module
+    # Make dotted names importable (e.g. `import dbus.mainloop.glib`).
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = _StubModule(parent)
+
+
+for _name in HEAVY_DEPS:
+    _install_stub(_name)

--- a/tests/test_arm_translation.py
+++ b/tests/test_arm_translation.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the ARM64 translation layer (libndk_translation)."""
+
+import types
+
+import pytest
+
+import tools.config
+from tools.helpers import arm_translation
+import tools.actions.arm_translation as action
+
+
+def _install_files(base, required=True):
+    """Create the real prebuilt layout under base (a /system tree)."""
+    (base / "system/lib64/arm64").mkdir(parents=True)
+    (base / "system/lib/arm").mkdir(parents=True)
+    (base / "system/etc/init").mkdir(parents=True)
+    (base / "system/etc/binfmt_misc").mkdir(parents=True)
+    for rel in arm_translation.REQUIRED:
+        (base / rel).touch()
+    (base / "system/lib64/libndk_translation_proxy_libc.so").touch()
+    (base / "system/lib/libndk_translation_proxy_libc.so").touch()
+    if not required:
+        (base / "system/lib64/libndk_translation.so").unlink()
+
+
+def test_not_installed_when_dir_missing(monkeypatch):
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        "/nonexistent/arm-translation")
+    assert not arm_translation.is_installed()
+
+
+def test_installed_when_required_files_present(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+    assert arm_translation.is_installed()
+
+
+def test_mount_entries_only_existing(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    (base / "system/lib64").mkdir(parents=True)
+    (base / "system/lib64/libndk_translation.so").touch()
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+
+    entries = arm_translation.mount_entries()
+
+    assert entries[0] == (str(base / "system/lib64/libndk_translation.so"),
+                          "system/lib64/libndk_translation.so", "file")
+    # Missing dir entries are skipped
+    assert all(e[1] != "system/lib64/arm64" for e in entries)
+    assert all(e[1] != "system/etc/init/ndk_translation.rc" for e in entries)
+
+
+def test_mount_entries_include_proxy_libs(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+
+    entries = arm_translation.mount_entries()
+    container_paths = [e[1] for e in entries]
+
+    assert ("system/lib64/arm64", "dir") in [
+        (e[1], e[2]) for e in entries]
+    assert "system/lib64/libndk_translation_proxy_libc.so" in container_paths
+    assert "system/lib/libndk_translation_proxy_libc.so" in container_paths
+    assert "system/etc/init/ndk_translation.rc" in container_paths
+
+
+def test_sync_to_overlay_copies_artifacts(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    overlay = tmp_path / "overlay"
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+    monkeypatch.setitem(tools.config.defaults, "overlay", str(overlay))
+
+    arm_translation.sync_to_overlay()
+
+    assert (overlay / "system/lib64/libndk_translation.so").exists()
+    assert (overlay / "system/lib64/arm64/libc.so").exists()
+    assert (overlay / "system/etc/init/ndk_translation.rc").exists()
+    assert (overlay / "system/lib64/libndk_translation_proxy_libc.so").exists()
+
+
+def test_sync_to_overlay_noop_when_not_installed(monkeypatch, tmp_path):
+    overlay = tmp_path / "overlay"
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        "/nonexistent/arm-translation")
+    monkeypatch.setitem(tools.config.defaults, "overlay", str(overlay))
+
+    arm_translation.sync_to_overlay()  # must not raise
+
+    assert not (overlay / "system").exists()
+
+
+def _patch_install_env(monkeypatch, tmp_path, cfg=None):
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        str(tmp_path / "arm-translation"))
+    monkeypatch.setattr(action.helpers.arch, "host", lambda: "x86_64")
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    monkeypatch.setattr(action.helpers.lxc, "make_base_props", lambda args: None)
+    if cfg is None:
+        cfg = {"waydroid": {"arch": "x86_64", "images_path": "/x",
+                            "vendor_type": "MAINLINE", "system_ota": "s",
+                            "vendor_ota": "v"}}
+    monkeypatch.setattr(tools.config, "load", lambda args: cfg)
+    return types.SimpleNamespace(source=None, archive=None, url=None,
+                                 default=False)
+
+
+def test_install_from_source_dir(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _install_files(source)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    action.install(args)
+
+    assert arm_translation.is_installed()
+    assert (tmp_path / "arm-translation/system/lib64/arm64/libc.so").exists()
+
+
+def test_install_from_source_nested_prebuilts_dir(monkeypatch, tmp_path):
+    # The community archive nests artifacts under prebuilts/ inside a
+    # repo-name directory; install must find and use that tree.
+    source = tmp_path / "source"
+    nested = source / "vendor_google_proprietary_ndk_translation-prebuilt-x" \
+                    / "prebuilts"
+    _install_files(nested)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    action.install(args)
+
+    assert arm_translation.is_installed()
+
+
+def test_install_rejects_missing_layout(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _install_files(source, required=False)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+    # Nothing must remain installed
+    assert not arm_translation.is_installed()
+
+
+def test_install_rejects_non_system_tree(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "random.txt").touch()
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+
+def test_install_refuses_on_arm64_host(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _install_files(source)
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.source = str(source)
+    monkeypatch.setattr(action.helpers.arch, "host", lambda: "arm64")
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+
+def test_install_default_url_without_source(monkeypatch, tmp_path):
+    """--default with no --source/--archive/--url fetches the prebuilt."""
+    args = _patch_install_env(monkeypatch, tmp_path)
+    args.default = True
+
+    archive = tmp_path / "default.zip"
+    # Build a tiny zip with the prebuilt layout so extraction + validation
+    # succeed without network.
+    import zipfile
+    with zipfile.ZipFile(archive, "w") as zf:
+        for rel in arm_translation.REQUIRED:
+            zf.writestr("repo/prebuilts/" + rel, "x")
+        zf.writestr("repo/prebuilts/system/lib64/libndk_translation_proxy_libc.so", "x")
+        zf.writestr("repo/prebuilts/system/lib/libndk_translation_proxy_libc.so", "x")
+        zf.writestr("repo/README.md", "x")
+
+    monkeypatch.setattr(action.helpers.http, "download",
+                        lambda *a, **k: str(archive))
+    monkeypatch.setattr(action, "_md5",
+                        lambda path: arm_translation.DEFAULT_ARCHIVE_MD5)
+
+    action.install(args)
+
+    assert arm_translation.is_installed()
+
+
+def test_install_without_source_requires_default(monkeypatch, tmp_path):
+    """No artifacts and no --default: refuse (prebuilt fetch is opt-in)."""
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    with pytest.raises(RuntimeError, match="--default"):
+        action.install(args)
+
+
+def test_extract_archive_preserves_zip_exec_bits(monkeypatch, tmp_path):
+    """zipfile drops unix modes; extraction must restore exec bits so
+    binfmt_misc can run the ARM translator binaries."""
+    import stat
+    import zipfile
+    archive = tmp_path / "x.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        info = zipfile.ZipInfo("prebuilts/bin/arm64/linker64")
+        info.external_attr = (0o755 << 16)
+        zf.writestr(info, b"\x7fELF")
+        info2 = zipfile.ZipInfo("prebuilts/etc/ndk_translation.rc")
+        info2.external_attr = (0o644 << 16)
+        zf.writestr(info2, b"on early-init")
+
+    dest = tmp_path / "out"
+    dest.mkdir()
+    action._extract_archive(str(archive), str(dest))
+
+    linker = dest / "prebuilts/bin/arm64/linker64"
+    rc = dest / "prebuilts/etc/ndk_translation.rc"
+    assert linker.stat().st_mode & stat.S_IXUSR
+    assert not rc.stat().st_mode & stat.S_IXUSR
+
+
+def test_install_default_url_checks_integrity(monkeypatch, tmp_path):
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    archive = tmp_path / "default.zip"
+    archive.write_bytes(b"not a real archive")
+
+    monkeypatch.setattr(action.helpers.http, "download",
+                        lambda *a, **k: str(archive))
+    monkeypatch.setattr(action, "_md5",
+                        lambda path: "00000000000000000000000000000000")
+
+    with pytest.raises(RuntimeError):
+        action.install(args)
+
+    assert not arm_translation.is_installed()
+
+
+def test_uninstall_removes_installed_layer(monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    action.uninstall(args)
+
+    assert not arm_translation.is_installed()
+    assert not base.exists()
+
+
+def test_uninstall_when_not_installed_is_quiet(monkeypatch, tmp_path):
+    args = _patch_install_env(monkeypatch, tmp_path)
+
+    action.uninstall(args)  # must not raise
+
+
+def test_status_reports_installed(capsys, monkeypatch, tmp_path):
+    base = tmp_path / "arm-translation"
+    _install_files(base)
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR", str(base))
+
+    action.status(None)
+
+    out = capsys.readouterr().out
+    assert "INSTALLED" in out
+    assert "libndk_translation.so" in out
+
+
+def test_status_reports_not_installed(capsys, monkeypatch):
+    monkeypatch.setattr(arm_translation, "ARM_TRANSLATION_DIR",
+                        "/nonexistent/arm-translation")
+
+    action.status(None)
+
+    out = capsys.readouterr().out
+    assert "NOT INSTALLED" in out

--- a/tests/test_lxc_config.py
+++ b/tests/test_lxc_config.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the LXC config generation in tools.helpers.lxc."""
+
+import types
+
+import pytest
+
+import tools.config
+import tools.helpers.lxc as lxc
+
+
+class _Args:
+    vendor_type = "MAINLINE"
+    BINDER_DRIVER = "binder"
+    VNDBINDER_DRIVER = "vndbinder"
+    HWBINDER_DRIVER = "hwbinder"
+
+
+def _fake_glob(pattern):
+    return {
+        "/dev/fb*": ["/dev/fb0"],
+        "/dev/graphics/fb*": [],
+        "/dev/video*": [],
+        "/dev/dma_heap/*": [],
+    }.get(pattern, [])
+
+
+def _build_nodes(monkeypatch, exists=None):
+    monkeypatch.setattr("glob.glob", _fake_glob)
+    monkeypatch.setattr(tools.helpers.gpu, "getDriNode",
+                        lambda args: ("/dev/dri/renderD128", ""))
+    if exists is None:
+        monkeypatch.setattr("os.path.exists", lambda path: True)
+    else:
+        monkeypatch.setattr("os.path.exists", exists)
+    return lxc.generate_nodes_lxc_config(_Args())
+
+
+def test_nodes_include_core_entries(monkeypatch):
+    text = "\n".join(_build_nodes(monkeypatch))
+
+    assert "lxc.mount.entry = tmpfs dev tmpfs nosuid 0 0" in text
+    assert ("lxc.mount.entry = /dev/dri/renderD128 dev/dri/renderD128 "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/binder dev/binder "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/vndbinder dev/vndbinder "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/hwbinder dev/hwbinder "
+            "none bind,create=file,optional 0 0") in text
+    assert ("lxc.mount.entry = /dev/net/tun dev/tun "
+            "none bind,create=file,optional 0 0") in text
+    assert "lxc.mount.entry = /dev/fb0 dev/fb0" in text
+
+
+def test_nodes_skip_missing_check_nodes(monkeypatch):
+    # Only /dev/zero exists; everything else with check=True is skipped.
+    text = "\n".join(_build_nodes(
+        monkeypatch, exists=lambda path: path == "/dev/zero"))
+
+    # check=False entries are always present (binder, tmpfs)
+    assert "lxc.mount.entry = /dev/binder dev/binder" in text
+    assert "lxc.mount.entry = tmpfs dev tmpfs nosuid 0 0" in text
+    # check=True entries for missing nodes are skipped
+    assert "/dev/ion" not in text
+    assert "/dev/ashmem" not in text
+    assert "/dev/sw_sync" not in text
+    assert "/dev/null" not in text
+
+
+def test_session_config_binds_wayland_and_userdata(monkeypatch, tmp_path):
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    data = tmp_path / "data"
+    data.mkdir()
+    session = {
+        "user_id": "1000",
+        "xdg_runtime_dir": str(xdg),
+        "wayland_display": "wayland-0",
+        "pulse_runtime_path": str(xdg) + "/pulse",
+        "waydroid_data": str(data),
+    }
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(work=str(work))
+    monkeypatch.setitem(tools.config.defaults, "container_xdg_runtime_dir",
+                        "/run/xdg")
+    monkeypatch.setitem(tools.config.defaults, "container_wayland_display",
+                        "wayland-0")
+    monkeypatch.setitem(tools.config.defaults,
+                        "container_pulse_runtime_path", "/run/xdg/pulse")
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    monkeypatch.setattr(tools.helpers.arm_translation, "sync_to_overlay",
+                        lambda: None)
+
+    lxc.generate_session_lxc_config(args, session)
+
+    content = (work / "config_session").read_text()
+    assert "lxc.mount.entry = tmpfs /run/xdg none create=dir 0 0" in content
+    assert ("lxc.mount.entry = {0}/wayland-0 run/xdg/wayland-0 "
+            "none rbind,create=file 0 0".format(xdg)) in content
+    assert ("lxc.mount.entry = {0}/pulse/native run/xdg/pulse/native "
+            "none rbind,create=file 0 0".format(xdg)) in content
+    assert ("lxc.mount.entry = {0} data none rbind 0 0".format(data)) in content
+
+
+def test_session_config_arm_translation_syncs_overlay(monkeypatch, tmp_path):
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    session = {
+        "user_id": "1000",
+        "xdg_runtime_dir": str(xdg),
+        "wayland_display": "wayland-0",
+        "pulse_runtime_path": str(xdg) + "/pulse",
+        "waydroid_data": str(tmp_path / "data"),
+    }
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(work=str(work))
+    monkeypatch.setitem(tools.config.defaults, "container_xdg_runtime_dir",
+                        "/run/xdg")
+    monkeypatch.setitem(tools.config.defaults, "container_wayland_display",
+                        "wayland-0")
+    monkeypatch.setitem(tools.config.defaults,
+                        "container_pulse_runtime_path", "/run/xdg/pulse")
+    monkeypatch.setattr("tools.helpers.run.user", lambda *a, **k: None)
+    sync_called = []
+    monkeypatch.setattr(
+        tools.helpers.arm_translation, "sync_to_overlay",
+        lambda: sync_called.append(True))
+
+    lxc.generate_session_lxc_config(args, session)
+
+    assert sync_called == [True]
+
+
+def test_make_base_props_advertises_arm_abis_when_translation_installed(
+        monkeypatch, tmp_path):
+    """With libndk_translation installed, the base props must advertise the
+    emulated ARM ABIs so the Play delivery check and local PackageManager
+    accept ARM-only APKs."""
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(
+        work=str(work),
+        vendor_type="MAINLINE",
+        images_path="/usr/share/waydroid-extra/images",
+        system_ota="None",
+        vendor_ota="None",
+    )
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr("tools.helpers.props.host_get", lambda *a, **k: "")
+    monkeypatch.setattr("tools.helpers.props.host_list", lambda *a, **k: {})
+    monkeypatch.setattr("tools.helpers.gpu.getDriNode",
+                        lambda args: (None, ""))
+    monkeypatch.setattr("tools.helpers.gpu.getVulkanDriver",
+                        lambda *a, **k: None)
+    monkeypatch.setattr("tools.helpers.arm_translation.is_installed",
+                        lambda: True)
+    monkeypatch.setattr("tools.config.load",
+                        lambda args: {"properties": {}})
+
+    lxc.make_base_props(args)
+
+    props = (work / "waydroid_base.prop").read_text().splitlines()
+    assert "ro.dalvik.vm.native.bridge=libndk_translation.so" in props
+    assert ("ro.product.cpu.abilist=x86_64,x86,arm64-v8a,"
+            "armeabi-v7a,armeabi") in props
+    assert "ro.product.cpu.abilist64=x86_64,arm64-v8a" in props
+    assert "ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi" in props
+    assert "ro.product.cpu.abi=x86_64" in props
+
+
+def test_make_base_props_keeps_x86_abis_without_translation(
+        monkeypatch, tmp_path):
+    """Without the translation layer, the image's x86-only ABI list must be
+    left untouched (no ARM ABIs advertised)."""
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(
+        work=str(work),
+        vendor_type="MAINLINE",
+        images_path="/usr/share/waydroid-extra/images",
+        system_ota="None",
+        vendor_ota="None",
+    )
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr("tools.helpers.props.host_get", lambda *a, **k: "")
+    monkeypatch.setattr("tools.helpers.props.host_list", lambda *a, **k: {})
+    monkeypatch.setattr("tools.helpers.gpu.getDriNode",
+                        lambda args: (None, ""))
+    monkeypatch.setattr("tools.helpers.gpu.getVulkanDriver",
+                        lambda *a, **k: None)
+    monkeypatch.setattr("tools.helpers.arm_translation.is_installed",
+                        lambda: False)
+    monkeypatch.setattr("tools.config.load",
+                        lambda args: {"properties": {}})
+
+    lxc.make_base_props(args)
+
+    props = (work / "waydroid_base.prop").read_text().splitlines()
+    assert "ro.dalvik.vm.native.bridge=libndk_translation.so" not in props
+    assert not any(p.startswith("ro.product.cpu.abilist") for p in props)
+
+
+def test_session_config_rejects_newline_in_mount_path(monkeypatch, tmp_path):
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    session = {
+        "user_id": "1000",
+        "xdg_runtime_dir": str(xdg),
+        "wayland_display": "bad\npath",
+        "pulse_runtime_path": str(xdg) + "/pulse",
+        "waydroid_data": str(tmp_path / "data"),
+    }
+    work = tmp_path / "work"
+    work.mkdir()
+    args = types.SimpleNamespace(work=str(work))
+    monkeypatch.setitem(tools.config.defaults, "container_xdg_runtime_dir",
+                        "/run/xdg")
+    monkeypatch.setitem(tools.config.defaults, "container_wayland_display",
+                        "wayland-0")
+    monkeypatch.setitem(tools.config.defaults,
+                        "container_pulse_runtime_path", "/run/xdg/pulse")
+
+    with pytest.raises(OSError):
+        lxc.generate_session_lxc_config(args, session)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -140,6 +140,17 @@ def main():
                 pass
         elif args.action == "bugreport":
             actions.bugreport(args)
+        elif args.action == "arm-translation":
+            actionNeedRoot(args.action)
+            if args.subaction == "install":
+                actions.arm_translation.install(args)
+            elif args.subaction == "status":
+                actions.arm_translation.status(args)
+            elif args.subaction == "uninstall":
+                actions.arm_translation.uninstall(args)
+            else:
+                logging.info(
+                    "Run waydroid {} -h for usage information.".format(args.action))
         else:
             logging.info("Run waydroid -h for usage information.")
 

--- a/tools/actions/__init__.py
+++ b/tools/actions/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Erfan Abdi
 # SPDX-License-Identifier: GPL-3.0-or-later
+from tools.actions import arm_translation
 from tools.actions.initializer import init, remote_init_client
 from tools.actions.upgrader import upgrade
 from tools.actions.session_manager import start, stop

--- a/tools/actions/arm_translation.py
+++ b/tools/actions/arm_translation.py
@@ -1,0 +1,214 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+import hashlib
+import logging
+import os
+import shutil
+import tarfile
+import zipfile
+
+import tools.config
+from tools import helpers
+from tools.helpers import arm_translation
+
+
+def get_config(args):
+    """Load the config-derived args needed to regenerate the base props."""
+    cfg = tools.config.load(args)
+    args.arch = cfg["waydroid"]["arch"]
+    args.images_path = cfg["waydroid"]["images_path"]
+    args.vendor_type = cfg["waydroid"]["vendor_type"]
+    args.system_ota = cfg["waydroid"]["system_ota"]
+    args.vendor_ota = cfg["waydroid"]["vendor_ota"]
+    args.session = None
+
+
+def _extract_archive(archive_path, dest):
+    """Extract a .tar/.tar.gz/.tar.xz or .zip archive into dest."""
+    if tarfile.is_tarfile(archive_path):
+        with tarfile.open(archive_path) as handle:
+            try:
+                handle.extractall(dest, filter="data")
+            except TypeError:
+                # Python < 3.12 has no filter parameter
+                handle.extractall(dest)
+    elif zipfile.is_zipfile(archive_path):
+        with zipfile.ZipFile(archive_path) as handle:
+            handle.extractall(dest)
+            # zipfile does not restore the unix permission bits that
+            # tarfile keeps; the prebuilt's bin/ executables must stay
+            # executable for binfmt_misc to run them.
+            for info in handle.infolist():
+                mode = (info.external_attr >> 16) & 0o7777
+                if mode and not info.is_dir():
+                    os.chmod(os.path.join(dest, info.filename),
+                             mode & 0o7777)
+    else:
+        raise RuntimeError("Unsupported archive format: " + archive_path)
+
+
+def _md5(path):
+    """md5 of a file, for verifying downloaded archives."""
+    digest = hashlib.md5()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_prebuilts_root(extracted):
+    """Locate the directory holding the artifacts inside an extracted tree.
+
+    The community prebuilt archive (supremegamers/vendor_google_...)
+    nests the files under ``prebuilts/`` inside a repo-name directory; plain
+    user-made archives may put them directly at the top. Returns the path
+    whose children look like a /system tree (lib/lib64/etc/bin).
+    """
+    candidates = [extracted]
+    for root, dirs, files in os.walk(extracted):
+        if "lib64" in dirs and "lib" in dirs and "etc" in dirs:
+            candidates.append(root)
+    # Deepest match first: a prebuilts/ dir wins over the archive root.
+    candidates.sort(key=lambda p: p.count(os.sep), reverse=True)
+    for candidate in candidates:
+        if (os.path.isdir(candidate + "/lib64")
+                and os.path.isdir(candidate + "/etc")):
+            return candidate
+    return None
+
+
+def _copy_to_system_tree(root, dest):
+    """Copy a /system artifact tree into dest/system/.
+
+    The helper stores artifacts as ``work/arm-translation/system/...``
+    (mirroring the container /system paths); ``root`` is a directory whose
+    children are the top-level /system entries (lib/lib64/etc/bin).
+    """
+    system_dir = dest + "/system"
+    os.makedirs(system_dir, exist_ok=True)
+    for name in os.listdir(root):
+        source_path = os.path.join(root, name)
+        target_path = os.path.join(system_dir, name)
+        if os.path.isdir(source_path):
+            shutil.copytree(source_path, target_path, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source_path, target_path)
+
+
+def _regenerate_base_props(args):
+    """Rewrite waydroid_base.prop so the native-bridge property updates."""
+    get_config(args)
+    helpers.lxc.make_base_props(args)
+
+
+def install(args):
+    if helpers.arch.host() not in ("x86", "x86_64"):
+        raise RuntimeError(
+            "ARM translation is only needed on x86/x86_64 hosts, this host "
+            "is " + helpers.arch.host())
+
+    dest = arm_translation.ARM_TRANSLATION_DIR
+    if os.path.isdir(dest) and os.listdir(dest):
+        logging.warning("An ARM translation layer is already installed, "
+                        "replacing it")
+
+    # The action always runs as root (ROOT_ACTIONS), so plain rmtree works.
+    shutil.rmtree(dest, ignore_errors=True)
+
+    extracted = None
+    if args.source:
+        source = os.path.abspath(args.source)
+        if not os.path.isdir(source):
+            raise RuntimeError("Source is not a directory: " + args.source)
+        root = _find_prebuilts_root(source)
+        if root is None:
+            raise RuntimeError(
+                "Source does not look like a /system artifact tree (no "
+                "lib64/ and etc/ directories): " + args.source)
+        _copy_to_system_tree(root, dest)
+    elif args.archive or args.url:
+        archive = args.archive
+        if args.url:
+            archive = helpers.http.download(
+                args, args.url, "arm_translation")
+            if archive is None:
+                raise RuntimeError(
+                    "Failed to download the ARM translation archive")
+        if (args.url and args.url == arm_translation.DEFAULT_ARCHIVE_URL
+                and _md5(archive) != arm_translation.DEFAULT_ARCHIVE_MD5):
+            raise RuntimeError("Downloaded archive failed the integrity "
+                               "check; refusing to install")
+        extracted = dest + ".extract"
+        shutil.rmtree(extracted, ignore_errors=True)
+        os.makedirs(extracted)
+        _extract_archive(archive, extracted)
+        root = _find_prebuilts_root(extracted)
+        if root is None:
+            shutil.rmtree(extracted, ignore_errors=True)
+            raise RuntimeError(
+                "The archive does not contain a /system artifact tree "
+                "(no lib64/ and etc/ directories)")
+        _copy_to_system_tree(root, dest)
+        shutil.rmtree(extracted, ignore_errors=True)
+    elif not args.default:
+        # Nothing was given and --default was not requested: the prebuilt
+        # URL is a third-party artifact, so fetching it is opt-in.
+        raise RuntimeError(
+            "No artifacts given: pass --source, --archive or --url, or "
+            "--default to fetch the standard libndk_translation prebuilt")
+    else:
+        # --default: fetch the known-good prebuilt (md5-verified).
+        logging.info("Downloading the standard libndk_translation prebuilt "
+                     "(Android 13)...")
+        archive = helpers.http.download(
+            args, arm_translation.DEFAULT_ARCHIVE_URL, "arm_translation")
+        if archive is None:
+            raise RuntimeError(
+                "Failed to download the ARM translation archive")
+        if _md5(archive) != arm_translation.DEFAULT_ARCHIVE_MD5:
+            raise RuntimeError("Downloaded archive failed the integrity "
+                               "check; refusing to install")
+        extracted = dest + ".extract"
+        shutil.rmtree(extracted, ignore_errors=True)
+        os.makedirs(extracted)
+        _extract_archive(archive, extracted)
+        root = _find_prebuilts_root(extracted)
+        if root is None:
+            shutil.rmtree(extracted, ignore_errors=True)
+            raise RuntimeError(
+                "The default archive does not contain a /system artifact "
+                "tree (no lib64/ and etc/ directories)")
+        _copy_to_system_tree(root, dest)
+        shutil.rmtree(extracted, ignore_errors=True)
+
+    if not arm_translation.is_installed():
+        shutil.rmtree(dest, ignore_errors=True)
+        raise RuntimeError(
+            "The provided files are missing the expected layout; expected "
+            "at least system/lib64/libndk_translation.so, "
+            "system/lib64/arm64/libc.so and "
+            "system/etc/init/ndk_translation.rc. Nothing was installed.")
+
+    _regenerate_base_props(args)
+    logging.info("ARM translation layer installed; restart the container "
+                 "(waydroid container restart) for it to take effect")
+
+
+def uninstall(args):
+    dest = arm_translation.ARM_TRANSLATION_DIR
+    if not os.path.isdir(dest):
+        logging.info("ARM translation layer is not installed")
+        return
+    # The action always runs as root (ROOT_ACTIONS), so plain rmtree works.
+    shutil.rmtree(dest, ignore_errors=True)
+    _regenerate_base_props(args)
+    logging.info("ARM translation layer removed")
+
+
+def status(args):
+    if arm_translation.is_installed():
+        print("ARM translation:\tINSTALLED (libndk_translation)")
+        for host, container_path, kind in arm_translation.mount_entries():
+            print("  -> " + container_path)
+    else:
+        print("ARM translation:\tNOT INSTALLED")

--- a/tools/helpers/__init__.py
+++ b/tools/helpers/__init__.py
@@ -13,3 +13,4 @@ import tools.helpers.gpu
 import tools.helpers.protocol
 import tools.helpers.version
 import tools.helpers.logging
+import tools.helpers.arm_translation

--- a/tools/helpers/arguments.py
+++ b/tools/helpers/arguments.py
@@ -136,6 +136,27 @@ def arguments_bugreport(subparser):
     ret = subparser.add_parser("bugreport", help="create a bugreport archive interactively")
     return ret
 
+def arguments_arm_translation(subparser):
+    ret = subparser.add_parser(
+        "arm-translation",
+        help="manage the ARM64 translation layer (libndk_translation) "
+             "for running ARM apps on x86_64 hosts")
+    sub = ret.add_subparsers(title="subaction", dest="subaction")
+    install = sub.add_parser("install",
+                             help="install the ARM translation layer")
+    install.add_argument("--source",
+                         help="directory with the artifacts (system/... layout)")
+    install.add_argument("--archive",
+                         help="path to a .tar/.tar.gz/.tar.xz/.zip archive")
+    install.add_argument("--url",
+                         help="URL of an archive to download")
+    install.add_argument("--default", action="store_true",
+                         help="fetch the standard libndk_translation prebuilt "
+                              "(third-party archive, md5-verified)")
+    sub.add_parser("status", help="show the ARM translation state")
+    sub.add_parser("uninstall", help="remove the ARM translation layer")
+    return ret
+
 def arguments():
     parser = argparse.ArgumentParser(prog="waydroid")
 
@@ -173,6 +194,7 @@ def arguments():
     arguments_logcat(sub)
     arguments_adb(sub)
     arguments_bugreport(sub)
+    arguments_arm_translation(sub)
 
     if argcomplete:
         argcomplete.autocomplete(parser, always_complete_options="long")

--- a/tools/helpers/arm_translation.py
+++ b/tools/helpers/arm_translation.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+ARM64 translation layer (libndk_translation) support.
+
+On x86_64 hosts the Android image is x86_64, but many apps ship ARM-only
+binaries. libndk_translation (Google's open-source ARM translator, used by
+ChromeOS and the Android emulator) runs them through Android's native
+bridge mechanism. The artifacts live under ``work/arm-translation`` and are
+bind-mounted into the container's /system at session start.
+
+Artifact layout (mirrors the container paths under /system; this is the
+layout of the community prebuilt used by waydroid_script, hosted at
+supremegamers/vendor_google_proprietary_ndk_translation-prebuilt):
+
+    arm-translation/system/lib64/libndk_translation.so
+    arm-translation/system/lib64/libndk_translation_proxy_lib*.so
+    arm-translation/system/lib64/libndk_translation_exec_region.so
+    arm-translation/system/lib64/arm64/*.so        (ARM64 system libs)
+    arm-translation/system/lib/libndk_translation.so
+    arm-translation/system/lib/arm/*.so            (ARM32 system libs)
+    arm-translation/system/bin/arm{,64}/            (ARM linker/app_process)
+    arm-translation/system/etc/init/ndk_translation.rc
+    arm-translation/system/etc/binfmt_misc/
+    arm-translation/system/etc/{cpuinfo,ld.config}.arm{,64}.txt
+
+libndk_translation is Apache-2.0.
+"""
+
+import os
+import shutil
+
+import tools.config
+
+# Directory under work/ holding the artifacts (mirrors container /system)
+ARM_TRANSLATION_DIR = tools.config.defaults["work"] + "/arm-translation"
+
+# Default source of prebuilt artifacts (Android 13, i.e. the current
+# official Waydroid image). Hosted on GitHub by the same project that
+# waydroid_script consumes; md5 verified below before installing.
+DEFAULT_ARCHIVE_URL = ("https://github.com/supremegamers/"
+                       "vendor_google_proprietary_ndk_translation-prebuilt/"
+                       "archive/68734c52556d3d7a6db34c603dd9276915c29f2f.zip")
+DEFAULT_ARCHIVE_MD5 = "0b2207c490fcb400aa5c87fcf0d52d38"
+
+# Files that must be present for the layer to be considered installed.
+REQUIRED = [
+    "system/lib64/libndk_translation.so",
+    "system/lib64/arm64/libc.so",
+    "system/etc/init/ndk_translation.rc",
+]
+
+# Native bridge properties that must be set for the layer to work.
+# ro.dalvik.vm.isa.arm{,64} map the emulated ISA to the host ISA; ART and
+# the ndk_translation.rc binfmt_misc registration depend on them.
+NATIVE_BRIDGE_PROPS = [
+    "ro.dalvik.vm.native.bridge=libndk_translation.so",
+    "ro.product.cpu.abilist=x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist64=x86_64,arm64-v8a",
+    "ro.product.cpu.abilist32=x86,armeabi-v7a,armeabi",
+    "ro.product.cpu.abi=x86_64",
+    "ro.dalvik.vm.isa.arm=x86",
+    "ro.dalvik.vm.isa.arm64=x86_64",
+    "ro.enable.native.bridge.exec=1",
+    "ro.vendor.enable.native.bridge.exec=1",
+    "ro.vendor.enable.native.bridge.exec64=1",
+    "ro.ndk_translation.version=0.2.3",
+]
+
+# (relative path under ARM_TRANSLATION_DIR, container path)
+# Directory entries are bind-mounted with create=dir so the mount target is
+# created inside the container; files use create=file. Everything under the
+# two lib trees is covered by the dir mounts plus the per-file entries here.
+MOUNT_ENTRIES = [
+    ("system/lib64/libndk_translation.so",
+     "system/lib64/libndk_translation.so", "file"),
+    ("system/lib64/libndk_translation_exec_region.so",
+     "system/lib64/libndk_translation_exec_region.so", "file"),
+    ("system/lib64/arm64", "system/lib64/arm64", "dir"),
+    ("system/lib/libndk_translation.so",
+     "system/lib/libndk_translation.so", "file"),
+    ("system/lib/libndk_translation_exec_region.so",
+     "system/lib/libndk_translation_exec_region.so", "file"),
+    ("system/lib/arm", "system/lib/arm", "dir"),
+    ("system/bin/arm", "system/bin/arm", "dir"),
+    ("system/bin/arm64", "system/bin/arm64", "dir"),
+    ("system/etc/init/ndk_translation.rc",
+     "system/etc/init/ndk_translation.rc", "file"),
+    ("system/etc/binfmt_misc", "system/etc/binfmt_misc", "dir"),
+    ("system/etc/cpuinfo.arm.txt",
+     "system/etc/cpuinfo.arm.txt", "file"),
+    ("system/etc/cpuinfo.arm64.txt",
+     "system/etc/cpuinfo.arm64.txt", "file"),
+    ("system/etc/ld.config.arm.txt",
+     "system/etc/ld.config.arm.txt", "file"),
+    ("system/etc/ld.config.arm64.txt",
+     "system/etc/ld.config.arm64.txt", "file"),
+]
+
+# Proxy libs in lib/ and lib64/ are synced into the overlay individually.
+# They carry libndk_translation_proxy_lib*.so; globbed at session start.
+PROXY_LIB_DIRS = ["system/lib", "system/lib64"]
+
+
+def is_installed():
+    """True when a usable ARM64 translation layer is present."""
+    return all(os.path.isfile(ARM_TRANSLATION_DIR + "/" + rel)
+               for rel in REQUIRED)
+
+
+def sync_to_overlay():
+    """Copy the installed artifacts into the container's /system overlay.
+
+    The container's /system overlay is mounted read-only, so bind-mounting
+    into it at session start fails silently (the mount targets cannot be
+    created on a ro filesystem). Instead, mirror waydroid_script: copy the
+    artifact tree into the overlay lowerdir (defaults["overlay"]/system),
+    which is host-writable while the container is stopped, before the
+    overlay is mounted at container start.
+
+    Must run as root before mount_rootfs(). No-ops when nothing is
+    installed.
+    """
+    if not is_installed():
+        return
+    overlay_dir = tools.config.defaults["overlay"] + "/system"
+    os.makedirs(overlay_dir, exist_ok=True)
+    source = ARM_TRANSLATION_DIR + "/system"
+    for name in os.listdir(source):
+        src_path = os.path.join(source, name)
+        dst_path = os.path.join(overlay_dir, name)
+        if os.path.isdir(src_path):
+            shutil.rmtree(dst_path, ignore_errors=True)
+            shutil.copytree(src_path, dst_path)
+        else:
+            shutil.copy2(src_path, dst_path)
+
+
+def mount_entries():
+    """(host path, container path, kind) triples for the session LXC config."""
+    ret = []
+    for rel, container_path, kind in MOUNT_ENTRIES:
+        host_path = ARM_TRANSLATION_DIR + "/" + rel
+        if os.path.exists(host_path):
+            ret.append((host_path, container_path, kind))
+    # The many libndk_translation_proxy_lib*.so files
+    for rel_dir in PROXY_LIB_DIRS:
+        host_dir = ARM_TRANSLATION_DIR + "/" + rel_dir
+        if not os.path.isdir(host_dir):
+            continue
+        for name in sorted(os.listdir(host_dir)):
+            if name.startswith("libndk_translation_proxy_lib"):
+                host_path = host_dir + "/" + name
+                ret.append((host_path, rel_dir + "/" + name, "file"))
+    return ret

--- a/tools/helpers/lxc.py
+++ b/tools/helpers/lxc.py
@@ -212,6 +212,14 @@ def generate_session_lxc_config(args, session):
     if not make_entry(session["waydroid_data"], "data", options="rbind 0 0"):
         raise OSError("Failed to bind userdata")
 
+    # ARM64 translation layer (x86_64 hosts): copy the installed
+    # libndk_translation artifacts into the container's /system overlay
+    # lowerdir, which happens before mount_rootfs() mounts the overlay, so
+    # the files land at /system inside the container. Bind-mounting into
+    # /system is not possible: the overlay is mounted read-only and the
+    # mount targets cannot be created. No-ops when nothing is installed.
+    tools.helpers.arm_translation.sync_to_overlay()
+
     lxc_path = tools.config.defaults["lxc"] + "/waydroid"
     config_nodes_tmp_path = args.work + "/config_session"
     with open(config_nodes_tmp_path, "w") as f:
@@ -356,6 +364,18 @@ def make_base_props(args):
     prop_fp = tools.helpers.props.host_get(args, "ro.vendor.build.fingerprint")
     if prop_fp != "":
         props.append("ro.build.fingerprint=" + prop_fp)
+
+    # On x86_64 hosts with the ARM translation layer installed, tell Android
+    # to use the native bridge so ARM-only apps can run, and advertise the
+    # emulated ABIs. Advertising arm64-v8a/armeabi-v7a/armeabi in
+    # ro.product.cpu.abilist is what makes both the local PackageManager
+    # accept ARM APKs (INSTALL_FAILED_NO_MATCHING_ABIS) and the Play
+    # delivery check (Aurora's device profile "Platforms") serve them at
+    # all. The ro.dalvik.vm.isa.* mapping is required by ART and the
+    # ndk_translation binfmt_misc registration. The [properties] section
+    # below can still override any of these.
+    if tools.helpers.arm_translation.is_installed():
+        props.extend(tools.helpers.arm_translation.NATIVE_BRIDGE_PROPS)
 
     # now append/override with values in [properties] section of waydroid.cfg
     cfg = tools.config.load(args)


### PR DESCRIPTION
Adds a `waydroid arm-translation` action so ARM-only apps run on x86_64 hosts via Google's libndk_translation native bridge (the same translator ChromeOS uses, Apache-2.0).

- **install** from a local tree (`--source`), an archive (`--archive`), a URL (`--url`), or the standard prebuilt (`--default`, md5-verified)
- artifacts are synced into the container's `/system` overlay at session start (before the overlay is mounted) and `make_base_props` advertises the emulated ABIs (`arm64-v8a,armeabi-v7a,armeabi`) + `ro.dalvik.vm.isa.*` mapping, so both the local PackageManager and Play's delivery check accept ARM APKs
- `status` / `uninstall` subcommands

The third-party prebuilt fetch is **opt-in** via `--default` so the mechanism can be reviewed independently of endorsing a specific binary. A pytest suite (26 passed) covers extraction, layout validation, overlay sync and prop advertisement.