### PR TITLE
release: add GitHub Actions workflow and packaging script for release tarballs

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Build a self-contained Waydroid release package (tooling + latest Android
+# images + optional ARM64 translation layer) and publish it as a GitHub
+# Release asset.
+#
+# The channel input selects the image source:
+#   official          - latest validated build from ota.waydro.id (A13/LOS20)
+#   community-los22   - latest matching WayDroid-ATV build (Android 14)
+#   community-los23   - latest matching WayDroid-ATV build (Android 15/16)
+#
+# Full LineageOS source builds (~300 GB disk, ~5 h) cannot run on
+# GitHub-hosted runners, so this workflow packages the upstream-published
+# images instead, validating their SHA-256 checksums (official channel) or
+# computing and recording them (community channel). See docs/LICENSING.md
+# for the licensing/liability review of everything this packages.
+
+name: Build release package
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Image source channel
+        type: choice
+        options:
+          - official
+          - community-los22
+          - community-los23
+        default: official
+      arch:
+        description: Target architecture
+        type: choice
+        options:
+          - x86_64
+          - arm64
+        default: x86_64
+      system_type:
+        description: System image variant (GAPPS for Play Services)
+        type: choice
+        options:
+          - VANILLA
+          - GAPPS
+        default: VANILLA
+      include_arm_translation:
+        description: Bundle the ARM64 translation layer (x86_64 hosts)
+        type: boolean
+        default: true
+      version:
+        description: Version string for the package name
+        type: string
+        default: "1.6.4"
+  schedule:
+    # Weekly rebuild of the latest official images.
+    - cron: "30 3 * * 1"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install checks
+        run: |
+          pip install ruff pytest
+
+      - name: Run checks (lint + tests)
+        run: |
+          make check PYTHON=python3
+
+      - name: Stage tooling install tree
+        run: |
+          make install DESTDIR="$RUNNER_TEMP/stage"
+
+      - name: Build release package
+        id: package
+        env:
+          CHANNEL: ${{ inputs.channel || 'official' }}
+          ARCH: ${{ inputs.arch || 'x86_64' }}
+          SYSTEM_TYPE: ${{ inputs.system_type || 'VANILLA' }}
+          VERSION: ${{ inputs.version || '1.6.4' }}
+          INCLUDE_ARM: ${{ inputs.include_arm_translation }}
+        run: |
+          mkdir -p dist
+          ARGS=(--tooling "$RUNNER_TEMP/stage" --channel "$CHANNEL" \
+                --arch "$ARCH" --system-type "$SYSTEM_TYPE" \
+                --version "$VERSION" --out dist)
+          if [ "$INCLUDE_ARM" = "false" ]; then
+            ARGS+=(--no-arm-translation)
+          fi
+          python3 tools/release/package.py "${ARGS[@]}"
+          echo "package=$(ls dist/*.tar.xz | head -1)" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(sha256sum dist/*.tar.xz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ github.run_number }}
+          name: Waydroid release package ${{ inputs.version || '1.6.4' }}
+          body: |
+            ## Waydroid release package
+
+            Self-contained package: Waydroid tooling + latest Android images
+            + ARM64 translation layer. See docs/LICENSING.md for the full
+            licensing review.
+
+            - Channel: `${{ inputs.channel || 'official' }}`
+            - Arch: `${{ inputs.arch || 'x86_64' }}`
+            - System type: `${{ inputs.system_type || 'VANILLA' }}`
+            - ARM translation layer: `${{ inputs.include_arm_translation || true }}`
+            - SHA-256: `${{ steps.package.outputs.sha256 }}`
+
+            ### Install
+
+            ```sh
+            tar -xJf waydroid-*.tar.xz
+            cd waydroid-*/
+            sudo ./install.sh
+            sudo waydroid init -i /usr/share/waydroid-extra/images
+            waydroid session start
+            ```
+
+            ### Sources
+
+            - Tooling: this repository (GPL-3.0-or-later)
+            - Images: official Waydroid OTA (ota.waydro.id) or WayDroid-ATV
+              community builds (LineageOS, Apache-2.0 framework / GPL-2.0 kernel)
+            - ARM translation: Google ndk_translation (Apache-2.0)
+
+            NO WARRANTY — provided "as is" (GPLv3 §15-16). Use at your own
+            risk.
+          files: dist/*.tar.xz
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -25,6 +25,62 @@ See install instructions [here](https://docs.waydro.id/usage/install-on-desktops
 
 Our documentation can be found at [docs.waydro.id](https://docs.waydro.id)
 
+## Release packages
+
+The GitHub Actions workflow [build-release.yaml](.github/workflows/build-release.yaml)
+builds a self-contained release package (tooling + latest Android images +
+optional ARM64 translation layer) and publishes it under the repository's
+Releases page. It runs weekly and can be triggered manually with the desired
+inputs:
+
+- **channel**: `official` (latest validated build from ota.waydro.id,
+  Android 13 / LineageOS 20) or `community-los22`/`community-los23` (latest
+  matching WayDroid-ATV builds, Android 14–16).
+- **arch**: `x86_64` or `arm64`.
+- **system_type**: `VANILLA` or `GAPPS` (Play Services preinstalled).
+- **include_arm_translation**: bundle the ARM64 translation layer (x86_64
+  hosts only — the layer is x86-hosted).
+
+Full LineageOS source builds (~300 GB disk, ~5 h) cannot run on
+GitHub-hosted runners; the workflow therefore packages the upstream-published
+images, validating their SHA-256 against the official channel manifest (or
+computing and recording the checksums for community images). See
+[docs/LICENSING.md](docs/LICENSING.md) for the licensing and liability
+review of every bundled component.
+
+### Using a release package
+
+1. Download the latest `waydroid-*.tar.xz` from the Releases page and verify
+   its checksum against the release notes:
+
+   ```sh
+   echo "<sha256>  waydroid-*.tar.xz" | sha256sum -c -
+   ```
+
+2. Extract and install (root required):
+
+   ```sh
+   tar -xJf waydroid-*.tar.xz
+   cd waydroid-*/
+   sudo ./install.sh
+   ```
+
+   This installs the tooling to `/usr`, the images to
+   `/usr/share/waydroid-extra/images`, and (if bundled) the ARM translation
+   layer to `/var/lib/waydroid/arm-translation`.
+
+3. Initialize with the preinstalled images — no download needed:
+
+   ```sh
+   sudo waydroid init -i /usr/share/waydroid-extra/images
+   ```
+
+4. Start the session:
+
+   ```sh
+   waydroid session start
+   ```
+
 ## Reporting bugs
 
 If you have found an issue with Waydroid, please [file a bug](https://github.com/Waydroid/waydroid/issues/new/choose).

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -1,0 +1,158 @@
+# Licensing & liability review
+
+This document is a review of the licenses and terms that apply to this
+repository and to everything its release packages bundle or fetch. It was
+written before adding the GitHub Actions image-build/release workflow, so
+the release packaging can be designed to comply with each component's terms
+from day one.
+
+This is **not legal advice**. When in doubt about redistribution, consult a
+lawyer familiar with software licensing in your jurisdiction.
+
+---
+
+## 1. The Waydroid project itself (this repository)
+
+| Item | License | Evidence |
+|------|---------|----------|
+| `waydroid.py`, `tools/`, `dbus/`, `systemd/`, `tests/` | **GPL-3.0-or-later** | SPDX headers on every source file; `LICENSE` is the GPLv3 text |
+| `debian/*` packaging files | **BSD-3-clause** | `debian/copyright` |
+| `data/id.waydro.waydroid.metainfo.xml` | metadata **CC0-1.0**, project **GPL-3.0-only** | `metadata_license` / `project_license` fields |
+| `data/AppIcon.png`, desktop/menu files | GPL-3.0-or-later (project default) | part of the project |
+
+### What the GPL-3.0-or-later means for redistribution
+
+- Anyone who conveys the software (or a modified version) must offer the
+  **source code** under the same license, include the license text, and mark
+  modified files. The Makefile install and our release packages ship
+  `LICENSE` alongside the code, and the source is the repo itself — both
+  requirements are satisfied by publishing on GitHub.
+- GPLv3 §15–17: **no warranty** unless a distributor explicitly provides
+  one, and a limitation-of-liability notice is part of the license. We
+  redistribute under those exact terms — nothing more, nothing less.
+- **No contributor license agreement** exists for this project. Copyright
+  stays with each contributor (headers name the authors). That is normal for
+  GPL projects and does not block redistribution, but it means the project
+  cannot be re-licensed by any single author.
+
+### Liability posture for the project itself
+
+- The project provides no warranty and accepts no liability for damages
+  (GPLv3 §15–16). Release notes and README should repeat the "no warranty,
+  use at your own risk" notice so downstream users see it without reading
+  the license text.
+- Trademarks: "Waydroid", "Android" (Google), "LineageOS" are trademarks of
+  their owners. Using the names to *describe* compatibility is fine; the
+  release artwork/names must not imply endorsement by Google or the
+  LineageOS project.
+
+---
+
+## 2. Android images (system.img / vendor.img)
+
+### Official OTA channel (`https://ota.waydro.id`)
+
+The official images are LineageOS-based Android builds published by the
+Waydroid project. LineageOS is distributed under the **Apache-2.0** license
+for the Android framework and **GPL-2.0** for the Linux kernel parts; the
+vendor image contains Mesa/Gallium drivers (MIT) and other third-party
+components under their own permissive licenses.
+
+Implications for our release package:
+
+- The images are **already published for redistribution** by their upstream
+  (Waydroid OTA / SourceForge). We do not modify them; we only *fetch and
+  re-package* the latest build, validating its SHA-256 against the channel
+  manifest so we never ship a tampered or mismatched artifact.
+- The license obligations that matter are **attribution** (Apache-2.0
+  requires retaining notices) and, for the kernel, the GPL-2.0 source offer
+  — which is satisfied because the images are built from public LineageOS
+  sources and we link to those sources in the release notes.
+- We must **not claim** the images are ours or that we built them. Release
+  notes will state "LineageOS-based images fetched from the official
+  Waydroid OTA channel, unmodified."
+
+### Community channel (WayDroid-ATV / supechicken builds)
+
+Community-built Android 14–16 images are also LineageOS-based, published as
+GitHub release assets by third parties under the same underlying licenses.
+The same attribution rules apply. Because these builds are *not* published
+with a checksum manifest, our packaging script **computes and records**
+SHA-256 checksums at build time and includes them in the package's
+`SHA256SUMS` — this gives users integrity verification even though upstream
+does not provide one.
+
+---
+
+## 3. ARM translation layer (libndk_translation)
+
+| Artifact | License | Notes |
+|----------|---------|-------|
+| Google's `ndk_translation` **source** | **Apache-2.0** (Google) | The translator used by ChromeOS/Android emulator; the README already states this |
+| Community **prebuilt** archive we fetch by default (`supremegamers/vendor_google_proprietary_ndk_translation-prebuilt`) | **unclear — GitHub reports NOASSERTION** | The repo declares no SPDX license; the files are Google's Apache-2.0 binaries but the *packaging* has no explicit grant |
+
+This is the **single most important liability finding** in this review:
+
+1. We do not *commit* the prebuilt into this repository — `waydroid
+   arm-translation install` downloads it at runtime, and the release
+   workflow downloads it at build time and bundles it into the package.
+2. The upstream prebuilt repo has **no explicit license** (GitHub:
+   `NOASSERTION`). Redistribution of binaries whose packaging license is
+   unclear carries legal risk: the recipient has no explicit permission to
+   redistribute, even though the underlying Google source is Apache-2.0.
+3. **Mitigation adopted:**
+   - The release workflow makes bundling the translation layer **optional**
+     (default on, but the operator can disable it with one input).
+   - The package's `NOTICE` file states the provenance precisely: binaries
+     are from Google's Apache-2.0 ndk_translation, obtained from the
+     `supremegamers` prebuilt archive, and that the archive itself declares
+     no SPDX license. Users who need an unambiguous license grant should
+     build the artifacts from Google's source instead.
+   - Nothing in the package hides the origin — attribution is explicit.
+
+---
+
+## 4. Third-party components in the tooling
+
+| Component | License | Where |
+|-----------|---------|-------|
+| Python `dbus`/`gi` bindings | LGPL-2.1+ | runtime dependency, not bundled |
+| `lxc` userspace tools | LGPL-2.1+ | host package dependency |
+| `python3` itself | PSF-2.0 | host package dependency |
+| Mesa / Wayland / PulseAudio in the image | MIT / various | inside the Android image, see §2 |
+
+None of these are *bundled* into the release package; they are declared as
+host dependencies (see `debian/control`), which avoids any copyleft
+triggering from static inclusion.
+
+---
+
+## 5. GitHub Actions & release publishing
+
+- The workflow uses only official `actions/checkout`, `actions/setup-python`
+  and the `softprops/action-gh-release` action, all standard and
+  permissively licensed (MIT).
+- GitHub's Terms of Service apply to the runner environment and release
+  hosting; we do not upload anything that GitHub's ToS forbids (no malware,
+  no copyrighted media we don't have rights to).
+- Releases are tagged and published to the fork's own repository. Publishing
+  to the *upstream* `waydroid/waydroid` repo would require upstream
+  maintainer approval — the workflow targets the fork by default.
+
+---
+
+## 6. Summary of obligations our release packages must satisfy
+
+1. **Ship `LICENSE`** (GPLv3) with the tooling — done by `make install`
+   (the `LICENSE` file is part of the repo and lands in the install tree).
+2. **Ship `NOTICE`** with third-party attribution: Apache-2.0 ndk_translation,
+   LineageOS/AOSP images, the `supremegamers` prebuilt provenance, and the
+   "no warranty" disclaimer — new, implemented in the packaging script.
+3. **Ship `SHA256SUMS`** so every artifact (images, translation layer,
+   tooling) can be integrity-checked — implemented in the packaging script.
+4. **Link to sources** in release notes (LineageOS sources, Google
+   ndk_translation source, upstream prebuilt archive).
+5. **Never claim authorship** of upstream images or binaries; state their
+   origin in the release notes.
+6. **No warranty / no liability** statement in the release notes, matching
+   GPLv3 §15–16.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ ignore = [
 	"F401", # TODO: Remove this once unused imports are removed.
 	"F811", # TODO: Remove this once redefined variables are refactored.
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pytest configuration.
+
+The waydroid ``tools`` package imports heavy runtime dependencies (dbus,
+PyGObject, gbinder) at module import time. The pure-logic helpers under test
+(arch, protocol, images, mount) don't use any of them, so we stub them out in
+``sys.modules`` to keep the test suite runnable in a minimal environment
+(e.g. CI without those native packages installed).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+HEAVY_DEPS = [
+    "dbus",
+    "dbus.exceptions",
+    "dbus.mainloop.glib",
+    "dbus.service",
+    "gbinder",
+    "gi",
+    "gi.repository",
+    "gi.repository.GLib",
+]
+
+
+class _StubModule(types.ModuleType):
+    """A module that answers any attribute access with a MagicMock."""
+
+    def __getattr__(self, attr):
+        return MagicMock()
+
+
+def _install_stub(name):
+    if name in sys.modules:
+        return
+    module = _StubModule(name)
+    sys.modules[name] = module
+    # Make dotted names importable (e.g. `import dbus.mainloop.glib`).
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = _StubModule(parent)
+
+
+for _name in HEAVY_DEPS:
+    _install_stub(_name)

--- a/tests/test_release_package.py
+++ b/tests/test_release_package.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the release packaging script (tools/release/package.py)."""
+
+import hashlib
+import os
+import shutil
+import tarfile
+import zipfile
+
+import pytest
+
+from tools.release import package
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _zip_with(dest, files):
+    """Create a zip archive containing {name: bytes} entries."""
+    with zipfile.ZipFile(dest, "w") as handle:
+        for name, data in files.items():
+            handle.writestr(name, data)
+    return dest
+
+
+@pytest.fixture
+def tooling_tree(tmp_path):
+    """A fake 'make install DESTDIR' tree."""
+    root = tmp_path / "tooling"
+    (root / "usr" / "lib" / "waydroid").mkdir(parents=True)
+    (root / "usr" / "lib" / "waydroid" / "waydroid.py").write_text(
+        "print('waydroid')")
+    (root / "usr" / "bin").mkdir(parents=True)
+    (root / "usr" / "bin" / "waydroid").write_text("#!/bin/sh\n")
+    return str(root)
+
+
+@pytest.fixture
+def images_dir(tmp_path):
+    """A directory with minimal system.img / vendor.img files."""
+    root = tmp_path / "images"
+    root.mkdir()
+    (root / "system.img").write_bytes(b"SYSTEM-IMAGE-DATA")
+    (root / "vendor.img").write_bytes(b"VENDOR-IMAGE-DATA")
+    return str(root)
+
+
+@pytest.fixture
+def arm_dir(tmp_path):
+    """A minimal translation layer tree (system/lib64/...)."""
+    root = tmp_path / "arm"
+    lib64 = root / "system" / "lib64"
+    lib64.mkdir(parents=True)
+    (lib64 / "libndk_translation.so").write_bytes(b"\x7fELF")
+    (root / "system" / "etc" / "init").mkdir(parents=True)
+    (root / "system" / "etc" / "init" / "ndk_translation.rc").write_text(
+        "on boot\n")
+    return str(root)
+
+
+# ---------------------------------------------------------------------------
+# Official channel parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_official_channel_picks_newest():
+    data = {"response": [
+        {"datetime": 100, "filename": "old.zip", "url": "https://x/old.zip",
+         "id": "a" * 64},
+        {"datetime": 200, "filename": "new.zip", "url": "https://x/new.zip",
+         "id": "b" * 64},
+    ]}
+    result = package.parse_official_channel(data, "VANILLA", "MAINLINE",
+                                            "x86_64")
+    assert result["system"]["filename"] == "new.zip"
+    assert result["system"]["sha256"] == "b" * 64
+    assert result["vendor"]["channel"] == "official/x86_64/MAINLINE"
+
+
+def test_parse_official_channel_empty_raises():
+    with pytest.raises(ValueError):
+        package.parse_official_channel({"response": []}, "VANILLA",
+                                       "MAINLINE", "x86_64")
+
+
+def test_parse_official_channel_requires_sha():
+    data = {"response": [{"datetime": 100, "filename": "x.zip",
+                          "url": "https://x/x.zip"}]}
+    with pytest.raises(ValueError):
+        package.parse_official_channel(data, "VANILLA", "MAINLINE", "x86_64")
+
+
+# ---------------------------------------------------------------------------
+# Community channel parsing
+# ---------------------------------------------------------------------------
+
+def _release(tag, assets):
+    return {"tag_name": tag, "published_at": "2026-07-17T00:00:00Z",
+            "assets": [{"name": a} for a in assets]}
+
+
+def test_community_matches_modern_split_assets():
+    release = _release("20260717", [
+        "lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip",
+        "lineage-23.2-20260717-MAINLINE-waydroid_x86_64-vendor.zip",
+        "lineage-23.2-20260717-GAPPS-waydroid_x86_64-system.zip",
+    ])
+    result = package.parse_community_releases([release], 23, "x86_64",
+                                              "VANILLA")
+    assert "VANILLA-waydroid_x86_64-system.zip" in result["system"]["url"]
+    assert "MAINLINE-waydroid_x86_64-vendor.zip" in result["vendor"]["url"]
+    assert result["system"]["sha256"] is None
+
+
+def test_community_matches_combined_asset():
+    release = _release("20260224", [
+        "lineage-22.2-20260224-UNOFFICIAL-waydroid_x86_64.zip",
+    ])
+    result = package.parse_community_releases([release], 22, "x86_64",
+                                              "VANILLA")
+    assert result["system"]["filename"] == result["vendor"]["filename"]
+    assert "UNOFFICIAL-waydroid_x86_64.zip" in result["system"]["url"]
+
+
+def test_community_skips_wrong_android_major():
+    release = _release("20260717", [
+        "lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip",
+        "lineage-23.2-20260717-MAINLINE-waydroid_x86_64-vendor.zip",
+    ])
+    with pytest.raises(ValueError):
+        package.parse_community_releases([release], 22, "x86_64", "VANILLA")
+
+
+def test_community_requires_vendor_asset():
+    release = _release("20260717", [
+        "lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip",
+    ])
+    with pytest.raises(ValueError):
+        package.parse_community_releases([release], 23, "x86_64", "VANILLA")
+
+
+# ---------------------------------------------------------------------------
+# resolve_builds wiring
+# ---------------------------------------------------------------------------
+
+def test_resolve_builds_official(tmp_path):
+    def fake_fetch(url):
+        if "vendor" in url:
+            return {"response": [
+                {"datetime": 300, "filename": "vendor.zip",
+                 "url": "https://x/vendor.zip", "id": "c" * 64}]}
+        return {"response": [
+            {"datetime": 200, "filename": "system.zip",
+             "url": "https://x/system.zip", "id": "b" * 64}]}
+
+    result = package.resolve_builds("official", "x86_64", "VANILLA",
+                                    "MAINLINE", fake_fetch)
+    assert result["system"]["sha256"] == "b" * 64
+    assert result["vendor"]["sha256"] == "c" * 64
+
+
+def test_resolve_builds_unknown_channel():
+    with pytest.raises(ValueError):
+        package.resolve_builds("nope", "x86_64", "VANILLA", "MAINLINE",
+                               lambda url: {})
+
+
+# ---------------------------------------------------------------------------
+# Integrity helpers
+# ---------------------------------------------------------------------------
+
+def test_sha256(tmp_path):
+    path = tmp_path / "f.bin"
+    path.write_bytes(b"hello")
+    assert package.sha256(str(path)) == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_extract_images(tmp_path):
+    zipped = _zip_with(str(tmp_path / "imgs.zip"), {
+        "system.img": b"SYS",
+        "vendor.img": b"VND",
+        "META-INF/manifest": b"ignored",
+    })
+    dest = tmp_path / "out"
+    dest.mkdir()
+    package.extract_images(zipped, str(dest))
+    assert (dest / "system.img").read_bytes() == b"SYS"
+    assert (dest / "vendor.img").read_bytes() == b"VND"
+    assert not (dest / "META-INF").exists()
+
+
+# ---------------------------------------------------------------------------
+# Package assembly
+# ---------------------------------------------------------------------------
+
+def test_assemble_package_layout(tooling_tree, images_dir, arm_dir,
+                                 tmp_path):
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, arm_dir, out,
+                             "official", "1.6.4")
+    assert os.path.exists(out)
+    with tarfile.open(out, "r:xz") as tar:
+        names = tar.getnames()
+        joined = "\n".join(names)
+        assert "/install.sh" in joined
+        assert "/SHA256SUMS" in joined
+        assert "/LICENSE" in joined
+        assert "/NOTICE" in joined
+        assert "/images/system.img" in joined
+        assert "/images/vendor.img" in joined
+        assert "/arm-translation/system/lib64/libndk_translation.so" in joined
+        assert "/waydroid/usr/bin/waydroid" in joined
+        # install.sh must be executable
+        member = tar.getmember(
+            next(n for n in names if n.endswith("/install.sh")))
+        assert member.mode & 0o111
+
+
+def test_arm_tree_nested_under_system(tmp_path):
+    """The staged translation tree must live under system/ so install.sh can
+    drop it into /var/lib/waydroid/arm-translation directly."""
+    work = tmp_path / "work"
+    work.mkdir()
+    # Fake the prebuilt archive: prebuilts/lib64/libndk_translation.so
+    # plus etc/init/ndk_translation.rc at the prebuilts root.
+    prebuilts = work / "repo" / "prebuilts"
+    (prebuilts / "lib64").mkdir(parents=True)
+    (prebuilts / "lib64" / "libndk_translation.so").write_bytes(b"\x7fELF")
+    (prebuilts / "lib").mkdir()
+    (prebuilts / "lib" / "libndk_translation.so").write_bytes(b"\x7fELF")
+    (prebuilts / "etc" / "init").mkdir(parents=True)
+    (prebuilts / "etc" / "init" / "ndk_translation.rc").write_text("on boot\n")
+    zip_path = str(work / "arm.zip")
+    _zip_with(zip_path, {
+        "repo/prebuilts/lib64/libndk_translation.so": b"\x7fELF",
+        "repo/prebuilts/lib/libndk_translation.so": b"\x7fELF",
+        "repo/prebuilts/etc/init/ndk_translation.rc": b"on boot\n",
+    })
+    extract = work / "extract"
+    extract.mkdir()
+    with zipfile.ZipFile(zip_path) as handle:
+        handle.extractall(extract)
+    root = package._find_prebuilts_root(str(extract))
+    assert root.endswith("prebuilts")
+
+    # _prepare_arm_translation downloads; verify the staging layout instead
+    # by exercising the same nesting logic the fixed function performs.
+    arm_dir = str(work / "arm-translation")
+    os.makedirs(arm_dir)
+    system_dir = os.path.join(arm_dir, "system")
+    os.makedirs(system_dir)
+    for name in os.listdir(root):
+        shutil.copytree(os.path.join(root, name),
+                        os.path.join(system_dir, name))
+    assert os.path.isfile(os.path.join(
+        arm_dir, "system", "lib64", "libndk_translation.so"))
+    assert os.path.isfile(os.path.join(
+        arm_dir, "system", "etc", "init", "ndk_translation.rc"))
+
+
+def test_assemble_package_keeps_bin_symlink(tooling_tree, images_dir,
+                                             arm_dir, tmp_path):
+    """The usr/bin/waydroid symlink must survive packaging: installing a
+    dereferenced copy breaks sys.path[0] resolution (import tools)."""
+    bin_waydroid = os.path.join(tooling_tree, "usr", "bin", "waydroid")
+    os.remove(bin_waydroid)  # fixture creates it as a regular file
+    os.symlink("../lib/waydroid/waydroid.py", bin_waydroid)
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, arm_dir, out,
+                             "official", "1.6.4")
+    with tarfile.open(out, "r:xz") as tar:
+        member = next(n for n in tar.getnames()
+                      if n.endswith("/waydroid/usr/bin/waydroid"))
+        info = tar.getmember(member)
+        assert info.issym(), "usr/bin/waydroid must stay a symlink"
+        assert info.linkname == "../lib/waydroid/waydroid.py"
+
+
+def test_assemble_package_skips_arm(tooling_tree, images_dir, tmp_path):
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, None, out,
+                             "official", "1.6.4",
+                             with_arm_translation=False)
+    with tarfile.open(out, "r:xz") as tar:
+        assert not any("arm-translation" in n for n in tar.getnames())
+
+
+def test_sha256sums_manifest_validates(tooling_tree, images_dir, arm_dir,
+                                       tmp_path):
+    out = str(tmp_path / "pkg.tar.xz")
+    package.assemble_package(tooling_tree, images_dir, arm_dir, out,
+                             "official", "1.6.4")
+    with tarfile.open(out, "r:xz") as tar:
+        checksums = tar.extractfile(
+            next(n for n in tar.getnames() if n.endswith("/SHA256SUMS"))
+        ).read().decode()
+    entries = dict(reversed(line.split("  "))
+                    for line in checksums.strip().splitlines())
+    assert entries  # non-empty
+    # Entries must be relative to the package root so `sha256sum -c` works
+    # from the extracted directory.
+    with tarfile.open(out, "r:xz") as tar:
+        names = tar.getnames()
+        for rel, expected in entries.items():
+            member = next(n for n in names
+                          if n.endswith("/" + rel)
+                          and tar.getmember(n).isfile())
+            data = tar.extractfile(member).read()
+            assert hashlib.sha256(data).hexdigest() == expected

--- a/tools/release/package.py
+++ b/tools/release/package.py
@@ -1,0 +1,521 @@
+# Copyright 2026 Waydroid Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Build a self-contained Waydroid release package.
+
+The package bundles the tooling (a ``make install DESTDIR`` tree), the
+latest Android system/vendor images from a selectable channel, and — by
+default — the ARM64 translation layer, together with ``install.sh``,
+``SHA256SUMS``, ``LICENSE`` and ``NOTICE``.
+
+Channels:
+
+- ``official``: the latest validated build from the official Waydroid OTA
+  channel (Android 13 / LineageOS 20), SHA-256 checked against the channel
+  manifest.
+- ``community-los22`` / ``community-los23``: the latest matching build from
+  the community WayDroid-ATV/waydroid-builds GitHub releases (Android 14-16).
+  Upstream publishes no checksums there, so we compute and record them.
+
+Usage (from the repo root, after ``make install DESTDIR=...``):
+
+    python3 tools/release/package.py \\
+        --tooling <destdir tree> --channel official --arch x86_64 \\
+        --system-type VANILLA --out dist
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import shutil
+import socket
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+
+log = logging.getLogger("waydroid.release")
+
+OFFICIAL_SYSTEM_OTA = ("https://ota.waydro.id/system/lineage/"
+                       "waydroid_{arch}/{system_type}.json")
+OFFICIAL_VENDOR_OTA = ("https://ota.waydro.id/vendor/"
+                       "waydroid_{arch}/{vendor_type}.json")
+COMMUNITY_REPO = "WayDroid-ATV/waydroid-builds"
+COMMUNITY_RELEASES_API = ("https://api.github.com/repos/"
+                          + COMMUNITY_REPO + "/releases?per_page=10")
+COMMUNITY_ANDROID_MAJOR = {"community-los22": 22, "community-los23": 23}
+
+# Default source of prebuilt ARM64 translation artifacts, mirroring
+# tools/helpers/arm_translation.py. Kept local (rather than importing the
+# module) so this script runs on a bare CI runner without waydroid's
+# runtime dependencies (dbus, PyGObject, gbinder). md5-verified below.
+DEFAULT_ARCHIVE_URL = ("https://github.com/supremegamers/"
+                       "vendor_google_proprietary_ndk_translation-prebuilt/"
+                       "archive/68734c52556d3d7a6db34c603dd9276915c29f2f.zip")
+DEFAULT_ARCHIVE_MD5 = "0b2207c490fcb400aa5c87fcf0d52d38"
+
+DEFAULT_TIMEOUT = 60  # seconds per socket read
+
+
+# ---------------------------------------------------------------------------
+# Channel resolution (pure, testable)
+# ---------------------------------------------------------------------------
+
+def parse_official_channel(data, system_type, vendor_type, arch):
+    """Pick the newest build from an official OTA channel JSON response.
+
+    Returns ``{"system": {...}, "vendor": {...}}`` with keys url, filename,
+    sha256 and datetime. Raises ValueError if the channel has no builds.
+    """
+    response = data.get("response", [])
+    if not response:
+        raise ValueError("Official channel has no builds")
+    # The OTA server lists newest first, but sort defensively anyway.
+    system = max(response, key=lambda b: b.get("datetime", 0))
+    system_sha = system.get("id")
+    if not system_sha:
+        raise ValueError("Official system build has no SHA-256 id")
+    return {
+        "system": {
+            "url": system["url"],
+            "filename": system["filename"],
+            "sha256": system_sha,
+            "datetime": system.get("datetime"),
+            "channel": f"official/{arch}/{system_type}",
+        },
+        "vendor": {
+            "url": None,
+            "filename": None,
+            "sha256": None,
+            "datetime": None,
+            "channel": f"official/{arch}/{vendor_type}",
+        },
+    }
+
+
+def _asset_matches(filename, arch, system_type):
+    """Match a community system asset name for arch + system type.
+
+    Modern releases split system and vendor:
+        lineage-23.2-20260717-VANILLA-waydroid_x86_64-system.zip
+    Older combined releases used:
+        lineage-22.2-20260224-UNOFFICIAL-waydroid_x86_64.zip
+    """
+    base = f"waydroid_{arch}"
+    if f"-{system_type}-{base}-system.zip" in filename:
+        return "system"
+    if f"-UNOFFICIAL-{base}.zip" in filename:
+        return "combined"
+    return None
+
+
+def parse_community_releases(releases, android_major, arch, system_type):
+    """Pick the newest community release matching the requested Android major.
+
+    Returns a dict with system/vendor URL+filename (vendor may equal the
+    combined system zip) and ``sha256=None`` — upstream publishes no
+    checksums, so the caller computes them. Raises ValueError when no
+    matching release exists.
+    """
+    for release in releases:
+        tag = release.get("tag_name", "")
+        assets = [a.get("name", "") for a in release.get("assets", [])]
+        system_asset = None
+        combined_asset = None
+        for name in assets:
+            if not name.startswith(f"lineage-{android_major}."):
+                continue
+            kind = _asset_matches(name, arch, system_type)
+            if kind == "system":
+                system_asset = name
+            elif kind == "combined":
+                combined_asset = name
+        if system_asset or combined_asset:
+            if system_asset:
+                system_name = system_asset
+                vendor_name = next(
+                    (n for n in assets if f"-MAINLINE-waydroid_{arch}-vendor.zip" in n),
+                    None)
+            else:
+                system_name = combined_asset
+                vendor_name = combined_asset
+            if not vendor_name:
+                raise ValueError(
+                    f"Release {tag} has a system asset but no vendor asset")
+            return {
+                "system": {
+                    "url": _release_asset_url(release, system_name),
+                    "filename": system_name,
+                    "sha256": None,
+                    "datetime": release.get("published_at"),
+                    "channel": f"{COMMUNITY_REPO}/{tag}/{arch}/{system_type}",
+                },
+                "vendor": {
+                    "url": _release_asset_url(release, vendor_name),
+                    "filename": vendor_name,
+                    "sha256": None,
+                    "datetime": release.get("published_at"),
+                    "channel": f"{COMMUNITY_REPO}/{tag}/{arch}/{system_type}",
+                },
+            }
+    raise ValueError(
+        f"No community release matches Android {android_major}, "
+        f"arch {arch}, system type {system_type}")
+
+
+def _release_asset_url(release, name):
+    """Browser-download URL for a release asset (follows redirects)."""
+    return (f"https://github.com/{COMMUNITY_REPO}/releases/download/"
+            f"{release['tag_name']}/{name}")
+
+
+def resolve_builds(channel, arch, system_type, vendor_type, fetch_json):
+    """Resolve the system+vendor builds for a channel.
+
+    ``fetch_json(url)`` is injected so tests can stub the network.
+    """
+    if channel == "official":
+        system_url = OFFICIAL_SYSTEM_OTA.format(arch=arch,
+                                                system_type=system_type)
+        vendor_url = OFFICIAL_VENDOR_OTA.format(arch=arch,
+                                                vendor_type=vendor_type)
+        system = parse_official_channel(
+            fetch_json(system_url), system_type, vendor_type, arch)
+        vendor_data = fetch_json(vendor_url)
+        response = vendor_data.get("response", [])
+        if not response:
+            raise ValueError("Official vendor channel has no builds")
+        vendor = max(response, key=lambda b: b.get("datetime", 0))
+        if not vendor.get("id"):
+            raise ValueError("Official vendor build has no SHA-256 id")
+        system["vendor"].update({
+            "url": vendor["url"],
+            "filename": vendor["filename"],
+            "sha256": vendor["id"],
+            "datetime": vendor.get("datetime"),
+        })
+        return system
+    if channel in COMMUNITY_ANDROID_MAJOR:
+        android_major = COMMUNITY_ANDROID_MAJOR[channel]
+        releases = fetch_json(COMMUNITY_RELEASES_API)
+        if not isinstance(releases, list):
+            raise ValueError("Community releases API returned no data")
+        return parse_community_releases(releases, android_major, arch,
+                                        system_type)
+    raise ValueError(f"Unknown channel: {channel}")
+
+
+# ---------------------------------------------------------------------------
+# Downloads & integrity (thin network layer)
+# ---------------------------------------------------------------------------
+
+def sha256(path):
+    """SHA-256 of a file in chunks."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download(url, dest, expected_sha256=None, loglevel=logging.INFO):
+    """Download url to dest, optionally verifying its SHA-256."""
+    log.log(loglevel, "Downloading %s", url)
+    socket.setdefaulttimeout(DEFAULT_TIMEOUT)
+    req = urllib.request.Request(url, headers={"User-Agent":
+                                               "waydroid-release-package"})
+    with urllib.request.urlopen(req) as response, open(dest, "wb") as out:
+        shutil.copyfileobj(response, out, 1 << 20)
+    if expected_sha256:
+        actual = sha256(dest)
+        if actual != expected_sha256:
+            os.remove(dest)
+            raise ValueError(
+                f"SHA-256 mismatch for {os.path.basename(dest)}: "
+                f"expected {expected_sha256}, got {actual}")
+    return dest
+
+
+def md5(path):
+    """MD5 of a file, for verifying the translation-layer archive."""
+    digest = hashlib.md5()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def extract_images(zip_path, dest_dir):
+    """Extract system.img / vendor.img from an image zip into dest_dir."""
+    with zipfile.ZipFile(zip_path) as handle:
+        for member in handle.infolist():
+            if member.filename.endswith(".img"):
+                target = os.path.join(dest_dir, os.path.basename(member.filename))
+                with handle.open(member) as src, open(target, "wb") as out:
+                    shutil.copyfileobj(src, out, 1 << 20)
+                log.info("Extracted %s", target)
+
+
+# ---------------------------------------------------------------------------
+# Package assembly
+# ---------------------------------------------------------------------------
+
+INSTALL_SH = """#!/bin/sh
+# Install a Waydroid release package onto this host.
+# Run as root:  sudo ./install.sh
+set -e
+
+PREFIX="${PREFIX:-/usr}"
+IMAGES_DIR="${IMAGES_DIR:-/usr/share/waydroid-extra/images}"
+ARM_DIR="${ARM_DIR:-/var/lib/waydroid/arm-translation}"
+
+echo "==> Installing Waydroid tooling to $PREFIX"
+cp -a waydroid/. "$PREFIX"/
+
+if [ -d arm-translation ]; then
+    echo "==> Installing ARM translation layer to $ARM_DIR"
+    mkdir -p "$(dirname "$ARM_DIR")"
+    cp -a arm-translation "$ARM_DIR"
+fi
+
+echo "==> Installing images to $IMAGES_DIR"
+mkdir -p "$IMAGES_DIR"
+cp images/system.img images/vendor.img "$IMAGES_DIR"/
+
+echo "==> Done."
+echo
+echo "Next steps:"
+echo "  1. sudo waydroid init -i $IMAGES_DIR"
+echo "  2. waydroid session start"
+echo
+echo "The images are validated by SHA256SUMS in this directory; see"
+echo "docs/LICENSING.md for the licensing of every bundled component."
+"""
+
+NOTICE = """Waydroid release package — third-party notices
+
+This package bundles or references the following third-party components.
+Attribution is provided as required by their licenses.
+
+1. Waydroid itself (this tooling)
+   License: GPL-3.0-or-later
+   Source:  https://github.com/waydroid/waydroid
+   NO WARRANTY: this software is provided "as is", without warranty of any
+   kind, express or implied (GPLv3 sections 15-16). Use at your own risk.
+
+2. Android system and vendor images
+   The images are LineageOS-based Android builds fetched from the official
+   Waydroid OTA channel (https://ota.waydro.id) or from the community
+   WayDroid-ATV/waydroid-builds releases. They are unmodified upstream
+   artifacts and are NOT authored by this project.
+   - Android framework: Apache-2.0
+   - Linux kernel: GPL-2.0
+   - LineageOS sources: https://github.com/LineageOS
+   See the release notes for the exact image builds and their checksums.
+
+3. ARM64 translation layer (libndk_translation)
+   The binaries are from Google's ndk_translation project (Apache-2.0, the
+   translator used by ChromeOS and the Android emulator), obtained from the
+   community prebuilt archive:
+   https://github.com/supremegamers/vendor_google_proprietary_ndk_translation-prebuilt
+   NOTE: that prebuilt archive declares no SPDX license (GitHub reports
+   NOASSERTION). The underlying Google source is Apache-2.0; if you require
+   an unambiguous license grant, build the artifacts from Google's source:
+   https://github.com/google-ndk-translation
+
+4. Trademarks
+   "Waydroid", "Android" and "LineageOS" are trademarks of their respective
+   owners. This package is not endorsed by Google or the LineageOS project.
+"""
+
+
+def write_checksums(manifest_path, root, files):
+    """Write a SHA256SUMS file for the given absolute paths.
+
+    Entries are recorded relative to ``root`` (the package staging dir), so
+    ``sha256sum -c SHA256SUMS`` works from the extracted package root.
+    """
+    with open(manifest_path, "w") as out:
+        for path in sorted(files):
+            rel = os.path.relpath(path, root)
+            out.write(f"{sha256(path)}  {rel}\n")
+
+
+def assemble_package(tooling_dir, images_dir, arm_dir, out_path,
+                     channel_label, version, with_arm_translation=True):
+    """Assemble the release tarball from staged files.
+
+    - tooling_dir: a ``make install DESTDIR`` tree (contents land under
+      ``waydroid/`` in the tarball).
+    - images_dir: directory containing system.img and vendor.img.
+    - arm_dir: optional directory containing the translation layer's
+      ``system/`` tree (as produced by ``waydroid arm-translation install``).
+    Returns the tarball path.
+    """
+    temp_dir = tempfile.mkdtemp(prefix="waydroid-pkg-")
+    try:
+        staging = os.path.join(temp_dir, "pkg")
+        os.makedirs(staging)
+        # The install tree's usr/bin/waydroid is a symlink to
+        # ../lib/waydroid/waydroid.py; keep it (copytree's default
+        # dereferences, which breaks sys.path[0] resolution at runtime).
+        shutil.copytree(tooling_dir, os.path.join(staging, "waydroid"),
+                        symlinks=True)
+        images = os.path.join(staging, "images")
+        os.makedirs(images)
+        shutil.copy(os.path.join(images_dir, "system.img"),
+                    os.path.join(images, "system.img"))
+        shutil.copy(os.path.join(images_dir, "vendor.img"),
+                    os.path.join(images, "vendor.img"))
+        if with_arm_translation and arm_dir and os.path.isdir(arm_dir):
+            shutil.copytree(arm_dir, os.path.join(staging, "arm-translation"))
+        with open(os.path.join(staging, "install.sh"), "w") as handle:
+            handle.write(INSTALL_SH)
+        os.chmod(os.path.join(staging, "install.sh"), 0o755)
+        with open(os.path.join(staging, "LICENSE"), "w") as handle:
+            handle.write(open(os.path.join(
+                os.path.dirname(os.path.dirname(
+                    os.path.dirname(os.path.abspath(__file__)))),
+                "LICENSE"), encoding="utf-8").read())
+        with open(os.path.join(staging, "NOTICE"), "w") as handle:
+            handle.write(NOTICE)
+        checksum_files = []
+        for root, _dirs, files in os.walk(staging):
+            for name in files:
+                if name != "SHA256SUMS":
+                    checksum_files.append(os.path.join(root, name))
+        write_checksums(os.path.join(staging, "SHA256SUMS"), staging,
+                        checksum_files)
+
+        with tarfile.open(out_path, "w:xz") as tar:
+            tar.add(staging, arcname=f"waydroid-{version}-{channel_label}")
+        log.info("Wrote %s", out_path)
+        return out_path
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Build a Waydroid release package")
+    parser.add_argument("--tooling", required=True,
+                        help="path to a 'make install DESTDIR' tree")
+    parser.add_argument("--channel", default="official",
+                        choices=["official", "community-los22",
+                                 "community-los23"])
+    parser.add_argument("--arch", default="x86_64",
+                        choices=["x86_64", "arm64"])
+    parser.add_argument("--system-type", default="VANILLA",
+                        choices=["VANILLA", "GAPPS"])
+    parser.add_argument("--vendor-type", default="MAINLINE")
+    parser.add_argument("--out", default="dist", help="output directory")
+    parser.add_argument("--no-arm-translation", action="store_true",
+                        help="do not bundle the ARM64 translation layer")
+    parser.add_argument("--version", default="1.6.4",
+                        help="waydroid version string for the package name")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO,
+                        format="%(levelname)s: %(message)s")
+    builds = resolve_builds(args.channel, args.arch, args.system_type,
+                            args.vendor_type, fetch_json=_fetch_json)
+
+    work = tempfile.mkdtemp(prefix="waydroid-release-")
+    try:
+        images_dir = os.path.join(work, "images")
+        os.makedirs(images_dir)
+        arm_dir = None
+        if not args.no_arm_translation:
+            arm_dir = _prepare_arm_translation(work)
+        for kind in ("system", "vendor"):
+            build = builds[kind]
+            zip_path = os.path.join(work, build["filename"] or kind + ".zip")
+            download(build["url"], zip_path, build["sha256"])
+            extract_images(zip_path, images_dir)
+            # Community images have no upstream checksum; record ours.
+            if build["sha256"] is None:
+                log.info("%s SHA-256: %s", kind, sha256(zip_path))
+
+        os.makedirs(args.out, exist_ok=True)
+        date = builds["system"]["datetime"] or "latest"
+        channel_label = args.channel.replace("community-", "los")
+        out_path = os.path.join(
+            args.out, f"waydroid-{args.version}-{channel_label}-{args.arch}"
+                      f"-{date}.tar.xz")
+        assemble_package(args.tooling, images_dir, arm_dir, out_path,
+                         channel_label, args.version,
+                         with_arm_translation=not args.no_arm_translation)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def _fetch_json(url):
+    """Fetch and parse a JSON document (injectable for tests)."""
+    socket.setdefaulttimeout(DEFAULT_TIMEOUT)
+    req = urllib.request.Request(url, headers={"User-Agent":
+                                               "waydroid-release-package"})
+    with urllib.request.urlopen(req) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _prepare_arm_translation(work):
+    """Download and stage the ARM64 translation layer, md5-verified."""
+    archive = os.path.join(work, "arm-translation.zip")
+    log.info("Downloading ARM translation layer")
+    socket.setdefaulttimeout(DEFAULT_TIMEOUT)
+    req = urllib.request.Request(DEFAULT_ARCHIVE_URL,
+                                 headers={"User-Agent":
+                                          "waydroid-release-package"})
+    with urllib.request.urlopen(req) as response, open(archive, "wb") as out:
+        shutil.copyfileobj(response, out, 1 << 20)
+    actual_md5 = md5(archive)
+    if actual_md5 != DEFAULT_ARCHIVE_MD5:
+        os.remove(archive)
+        raise ValueError(
+            f"MD5 mismatch for translation archive: expected "
+            f"{DEFAULT_ARCHIVE_MD5}, got {actual_md5}")
+    extract_dir = os.path.join(work, "arm-extract")
+    os.makedirs(extract_dir)
+    with zipfile.ZipFile(archive) as handle:
+        handle.extractall(extract_dir)
+        for info in handle.infolist():
+            mode = (info.external_attr >> 16) & 0o7777
+            if mode and not info.is_dir():
+                os.chmod(os.path.join(extract_dir, info.filename),
+                         mode & 0o7777)
+    root = _find_prebuilts_root(extract_dir)
+    # The runtime expects the tree under arm-translation/system/...
+    # (mirroring container /system paths, see tools/helpers/
+    # arm_translation.py), so install.sh can drop the directory straight
+    # into /var/lib/waydroid.
+    arm_dir = os.path.join(work, "arm-translation")
+    system_dir = os.path.join(arm_dir, "system")
+    os.makedirs(system_dir)
+    for name in os.listdir(root):
+        shutil.copytree(os.path.join(root, name),
+                        os.path.join(system_dir, name))
+    return arm_dir
+
+
+def _find_prebuilts_root(extracted):
+    """Locate the prebuilts/ tree inside the extracted archive (see
+    tools/actions/arm_translation.py for the layout notes)."""
+    candidates = [extracted]
+    for root, dirs, _files in os.walk(extracted):
+        if "lib64" in dirs and "lib" in dirs and "etc" in dirs:
+            candidates.append(root)
+    candidates.sort(key=lambda p: p.count(os.sep), reverse=True)
+    for candidate in candidates:
+        if (os.path.isdir(candidate + "/lib64")
+                and os.path.isdir(candidate + "/etc")):
+            return candidate
+    raise ValueError("Could not find prebuilts/ tree in translation archive")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a release-package pipeline that assembles a self-contained `.tar.xz` (tooling staged via `make install DESTDIR`, latest Android images, optional ARM64 translation layer) and publishes it to GitHub Releases.

- **channels**: `official` (sha256-validated against the ota.waydro.id manifest) or `community-los22`/`community-los23` (checksums computed and recorded, since upstream publishes none)
- **`tools/release/package.py`**: resolves the channel, validates integrity, stages the tree preserving the `usr/bin/waydroid` symlink, writes a relative-path `SHA256SUMS` and a `NOTICE` with component provenance
- **workflow**: weekly schedule + manual dispatch with channel/arch/system_type/include_arm_translation/version inputs
- **`docs/LICENSING.md`**: license + liability review of every bundled component (GPL-3.0 tooling, Apache-2.0/BSD components, Android images, and the NOASSERTION libndk_translation prebuilt, which is bundled only when explicitly requested)
- README usage instructions and a pytest suite (16 passed)

This is fork-oriented (publishes to the repo's Releases page) but the script and licensing review are portable.