### PR TITLE
initializer: support Android 13-16 / LineageOS 20-23 vendor detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,22 @@ any GNU/Linux-based platform.
 The Android system inside the container has direct access to any needed hardware.
 
 The Android runtime environment ships with a minimal customized Android system
-image based on [LineageOS](https://lineageos.org/). The image is currently based
-on Android 13.
+image based on [LineageOS](https://lineageos.org/). The tooling supports
+Android 13 through Android 16 (API 36, LineageOS 20–23): the service-manager
+protocol and HAL detection follow the image's API level at runtime
+(`tools/helpers/protocol.py`, `tools/helpers/lxc.py`).
+
+The official images on the Waydroid OTA channel are still built on Android 13;
+newer LineageOS 22/23 (Android 15/16) images are available as community builds
+(e.g. [waydroid-builds](https://github.com/supechicken/waydroid-builds)) and
+can be installed with a custom channel:
+
+```
+waydroid init -c <system channel> -v <vendor channel> -r lineage
+```
+
+Upstream tracks the official image rebuild in
+[waydroid/waydroid#2229](https://github.com/waydroid/waydroid/issues/2229).
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ ignore = [
 	"F401", # TODO: Remove this once unused imports are removed.
 	"F811", # TODO: Remove this once redefined variables are refactored.
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pytest configuration.
+
+The waydroid ``tools`` package imports heavy runtime dependencies (dbus,
+PyGObject, gbinder) at module import time. The pure-logic helpers under test
+(arch, protocol, images, mount) don't use any of them, so we stub them out in
+``sys.modules`` to keep the test suite runnable in a minimal environment
+(e.g. CI without those native packages installed).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+HEAVY_DEPS = [
+    "dbus",
+    "dbus.exceptions",
+    "dbus.mainloop.glib",
+    "dbus.service",
+    "gbinder",
+    "gi",
+    "gi.repository",
+    "gi.repository.GLib",
+]
+
+
+class _StubModule(types.ModuleType):
+    """A module that answers any attribute access with a MagicMock."""
+
+    def __getattr__(self, attr):
+        return MagicMock()
+
+
+def _install_stub(name):
+    if name in sys.modules:
+        return
+    module = _StubModule(name)
+    sys.modules[name] = module
+    # Make dotted names importable (e.g. `import dbus.mainloop.glib`).
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            sys.modules[parent] = _StubModule(parent)
+
+
+for _name in HEAVY_DEPS:
+    _install_stub(_name)

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.helpers.arch."""
+
+import io
+import types
+
+import pytest
+
+import tools.helpers.arch as arch
+
+
+class FakeOpen:
+    """Context manager that fakes reading a file's content."""
+
+    def __init__(self, content):
+        self.content = content
+
+    def __call__(self, path, *args, **kwargs):
+        return io.StringIO(self.content)
+
+
+def patch_cpuinfo(monkeypatch, content):
+    monkeypatch.setattr("builtins.open", FakeOpen(content))
+
+
+def test_host_x86_64(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "x86_64")
+    patch_cpuinfo(monkeypatch, "ssse3 sse4_2")
+    assert arch.host() == "x86_64"
+
+
+def test_host_x86_64_falls_back_to_x86_without_sse4_2(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "x86_64")
+    patch_cpuinfo(monkeypatch, "ssse3")
+    assert arch.host() == "x86"
+
+
+def test_host_x86_64_requires_ssse3(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "x86_64")
+    patch_cpuinfo(monkeypatch, "no sse2, no sse3 here")
+    with pytest.raises(ValueError):
+        arch.host()
+
+
+def test_host_i686(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "i686")
+    patch_cpuinfo(monkeypatch, "ssse3")
+    assert arch.host() == "x86"
+
+
+def test_host_armv7l(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "armv7l")
+    assert arch.host() == "arm"
+
+
+def test_host_armv8l(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "armv8l")
+    assert arch.host() == "arm"
+
+
+def test_host_aarch64(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(arch.platform, "architecture", lambda: ("64bit", "ELF"))
+    monkeypatch.setattr(arch, "is_32bit_capable", lambda: True)
+    assert arch.host() == "arm64"
+
+
+def test_host_aarch64_32bit_userspace(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(arch.platform, "architecture", lambda: ("32bit", "ELF"))
+    assert arch.host() == "arm"
+
+
+def test_host_aarch64_without_aarch32(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(arch.platform, "architecture", lambda: ("64bit", "ELF"))
+    monkeypatch.setattr(arch, "is_32bit_capable", lambda: False)
+    assert arch.host() == "arm64_only"
+
+
+def test_host_unsupported(monkeypatch):
+    monkeypatch.setattr(arch.platform, "machine", lambda: "riscv64")
+    with pytest.raises(ValueError):
+        arch.host()
+
+
+def test_is_32bit_capable_true(monkeypatch):
+    calls = []
+
+    def fake_personality(arg):
+        calls.append(arg)
+        return 0  # previous persona (success)
+
+    class FakeLib:
+        personality = staticmethod(fake_personality)
+
+    class FakeCDLL:
+        def __init__(self, *args, **kwargs):
+            self.personality = FakeLib.personality
+
+    fake_ctypes = types.SimpleNamespace(CDLL=FakeCDLL, c_int=int, c_ulong=int)
+    monkeypatch.setattr(arch, "ctypes", fake_ctypes)
+    assert arch.is_32bit_capable() is True
+    # PER_LINUX32 probe, then restore of the previous persona
+    assert calls == [0x0008, 0]
+
+
+def test_is_32bit_capable_false(monkeypatch):
+    def fake_personality(arg):
+        return -1  # personality() failed
+
+    class FakeLib:
+        personality = staticmethod(fake_personality)
+
+    class FakeCDLL:
+        def __init__(self, *args, **kwargs):
+            self.personality = FakeLib.personality
+
+    fake_ctypes = types.SimpleNamespace(CDLL=FakeCDLL, c_int=int, c_ulong=int)
+    monkeypatch.setattr(arch, "ctypes", fake_ctypes)
+    assert arch.is_32bit_capable() is False

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for tools.actions.initializer.get_vendor_type."""
+
+import tools.actions.initializer as initializer
+
+
+def _props(values=None):
+    values = values or {}
+
+    def host_get(args, key):
+        return values.get(key, "")
+    return host_get
+
+
+def test_vendor_type_mainline_when_no_props(monkeypatch):
+    monkeypatch.setattr(initializer.helpers.props, "host_get", _props())
+    assert initializer.get_vendor_type(object()) == "MAINLINE"
+
+
+def test_vendor_type_from_vndk(monkeypatch):
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "30"}))
+    assert initializer.get_vendor_type(object()) == "HALIUM_11"
+
+
+def test_vendor_type_vndk_12l(monkeypatch):
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "32"}))
+    assert initializer.get_vendor_type(object()) == "HALIUM_12L"
+
+
+def test_vendor_type_from_vendor_api(monkeypatch):
+    # Halium 15+ images may not expose ro.vndk.version; fall back to the
+    # vendor API level.
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vendor.build.version.sdk": "35"}))
+    assert initializer.get_vendor_type(object()) == "HALIUM_15"
+
+
+def test_vendor_type_ignores_garbage_props(monkeypatch):
+    # Non-numeric props (e.g. "29.0") must not crash init.
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "29.0",
+                "ro.vendor.build.version.sdk": "garbage"}))
+    assert initializer.get_vendor_type(object()) == "MAINLINE"
+
+
+def test_vendor_type_low_vndk_stays_mainline(monkeypatch):
+    monkeypatch.setattr(
+        initializer.helpers.props, "host_get",
+        _props({"ro.vndk.version": "19"}))
+    assert initializer.get_vendor_type(object()) == "MAINLINE"

--- a/tools/actions/initializer.py
+++ b/tools/actions/initializer.py
@@ -19,22 +19,39 @@ from gi.repository import GLib
 def is_initialized(args):
     return os.path.isfile(args.config) and os.path.isdir(tools.config.defaults["rootfs"])
 
+def _int_or_none(value):
+    """Parse an Android version prop as int, or None if absent/garbage."""
+    try:
+        return int(value)
+    except ValueError:
+        # Non-numeric props (e.g. "29.0") must not crash init; treat them
+        # as absent so detection falls back to the next source or MAINLINE.
+        logging.debug("Ignoring non-numeric Android version prop: %r", value)
+        return None
+
 def get_vendor_type(args):
+    """
+    Detect the vendor type from host props (Halium versions, or MAINLINE).
+
+    Uses ro.vndk.version primarily (vndk 20+ maps to Halium N), falling
+    back to ro.vendor.build.version.sdk for Halium 15+ images that no
+    longer expose ro.vndk.version.
+    """
     vndk_str = helpers.props.host_get(args, "ro.vndk.version")
     vendorapi_str = helpers.props.host_get(args, "ro.vendor.build.version.sdk")
     ret = "MAINLINE"
-    if vndk_str != "":
-        vndk = int(vndk_str)
+    vndk = _int_or_none(vndk_str)
+    if vndk is not None:
         if vndk > 19:
             halium_ver = vndk - 19
             if vndk > 31:
-                halium_ver -= 1 # 12L -> Halium 12
+                halium_ver -= 1  # 12L -> Halium 12
             ret = "HALIUM_" + str(halium_ver)
             if vndk == 32:
                 ret += "L"
-    elif vendorapi_str != "":
-        vendorapi = int(vendorapi_str)
-        if vendorapi > 32:
+    else:
+        vendorapi = _int_or_none(vendorapi_str)
+        if vendorapi is not None and vendorapi > 32:
             halium_ver = vendorapi - 20
             ret = "HALIUM_" + str(halium_ver)
 


### PR DESCRIPTION
- **vendor detection**: fall back to `ro.vendor.build.version.sdk` for Halium 15+ images that no longer expose `ro.vndk.version`; treat non-numeric props as absent instead of crashing init
- **docs**: state the supported Android 13–16 / LineageOS 20–23 range and how to install community Android 15/16 images via a custom channel
- tests for vendor-type detection and arch support (18 passed)